### PR TITLE
Add PlatformIO support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache/
 .claude/
+.pio/
 build/
 managed_components/

--- a/README.md
+++ b/README.md
@@ -40,12 +40,7 @@ Core ESP-IDF components used (`main/CMakeLists.txt`):
 - ESP32-S3 (tested on N16R8)
 - PCM5102A I2S DAC board (or compatible)
 
-## Get started
-1) Install ESP-IDF v5.x and set up the environment:
-   - `source /path/to/esp-idf/export.sh`
-2) Initialize submodules:
-   - `git submodule update --init --recursive`
-3) Wiring overview:
+## Wiring overview:
 
 ```
 AirPlay source (iOS/macOS)
@@ -84,17 +79,35 @@ I2S signal meaning:
 - DOUT is serial audio data from ESP32 to the DAC.
 MCLK is unused in this design.
 
-4) Configure the project:
+## Get started
+
+### ESP-IDF Option
+1) Install ESP-IDF v5.x and set up the environment:
+   - `source /path/to/esp-idf/export.sh`
+2) Initialize submodules:
+   - `git submodule update --init --recursive`
+3) Configure the project:
    - `idf.py set-target esp32s3`
    - `idf.py menuconfig`
      - `AirPlay 2 Receiver Configuration`:
        - `WiFi SSID`
        - `WiFi Password`
        - `AirPlay Device Name`
-5) Build, flash, and monitor:
+4) Build, flash, and monitor:
    - `idf.py build`
    - `idf.py -p /dev/ttyUSB0 flash monitor`
      (swap the port if yours is different)
+
+### PlatformIO Option
+1) Install [PlatformIO](https://platformio.org/install/cli)
+2) Configure WiFi in `sdkconfig`/`sdkconfig.esp32s3`:
+   - `CONFIG_WIFI_SSID`
+   - `CONFIG_WIFI_PASSWORD`
+   - `CONFIG_AIRPLAY_DEVICE_NAME`
+3) Build and flash:
+   - `pio run -e esp32s3 -t upload`
+4) Monitor:
+   - `pio run -e esp32s3 -t monitor`
 
 ## Usage
 After boot and WiFi connection, the device advertises `_airplay._tcp` and

--- a/boards/esp32s3-n16r8.json
+++ b/boards/esp32s3-n16r8.json
@@ -1,0 +1,53 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "esp32s3_out.ld",
+        "partitions": "default_16MB.csv",
+        "memory_type": "qio_opi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DARDUINO_ESP32S3_DEV",
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_USB_MODE=1",
+        "-DARDUINO_USB_CDC_ON_BOOT=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "psram_type": "opi",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "esp32s3"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "ESP32-S3-N16R8 (16MB QD, 8MB PSRAM OPI)",
+    "upload": {
+      "flash_size": "16MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 16777216,
+      "require_upload_port": true,
+      "speed": 1152000
+    },
+    "url": "",
+    "vendor": ""
+  }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -32,7 +32,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.0
 direct_dependencies:
 - espressif/esp_audio_codec
 - espressif/libsodium

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,31 @@
+[platformio]
+default_envs = esp32s3
+src_dir = main
+
+[env:esp32s3]
+platform = platformio/espressif32 @ ^6.12.0
+board = esp32s3-n16r8
+framework = espidf
+
+; ESP32-S3 Target Configuration
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+board_build.f_flash = 80000000L
+board_build.flash_mode = dio
+board_build.flash_size = 16MB
+board_build.partitions = partitions.csv
+
+; PSRAM Configuration (8MB Octal)
+board_build.psram_mode = octal
+board_build.psram_size = 8MB
+
+monitor_speed = 115200
+
+build_flags =
+    -Wno-maybe-uninitialized
+    -Os
+
+[env:esp32s3-jtag]
+extends = env:esp32s3
+upload_protocol = esp-builtin
+


### PR DESCRIPTION
This PR adds support for PlatformIO compilation. Just to simplify ESP-IDF installation as PlatformIO does it automatically.