### PR TITLE
SqueezeAMP board support with modular LED system

### DIFF
--- a/main/led.c
+++ b/main/led.c
@@ -148,8 +148,8 @@ static void status_led_init(void) {
     return;
   }
 
-  s_status_timer =
-      xTimerCreate("status_led", pdMS_TO_TICKS(500), pdFALSE, NULL, status_timer_cb);
+  s_status_timer = xTimerCreate("status_led", pdMS_TO_TICKS(500), pdFALSE, NULL,
+                                status_timer_cb);
 
   ESP_LOGI(TAG, "Status LED initialized on GPIO %d", CONFIG_LED_STATUS_GPIO);
 }
@@ -195,9 +195,14 @@ static void status_led_set_vu(float norm) {
 }
 
 #else
-static void status_led_init(void) {}
-static void status_led_set_mode(led_mode_t mode) { (void)mode; }
-static void status_led_set_vu(float norm) { (void)norm; }
+static void status_led_init(void) {
+}
+static void status_led_set_mode(led_mode_t mode) {
+  (void)mode;
+}
+static void status_led_set_vu(float norm) {
+  (void)norm;
+}
 #endif
 
 // ============================================================================
@@ -234,8 +239,11 @@ static void error_led_set(bool on) {
 }
 
 #else
-static void error_led_init(void) {}
-static void error_led_set(bool on) { (void)on; }
+static void error_led_init(void) {
+}
+static void error_led_set(bool on) {
+  (void)on;
+}
 #endif
 
 // ============================================================================
@@ -344,14 +352,18 @@ static void rgb_led_set_vu(float norm, float bass_ratio) {
 }
 
 #else
-static void rgb_led_init(void) {}
-static void rgb_led_set_mode(led_mode_t mode) { (void)mode; }
+static void rgb_led_init(void) {
+}
+static void rgb_led_set_mode(led_mode_t mode) {
+  (void)mode;
+}
 static void rgb_led_set_color(uint8_t r, uint8_t g, uint8_t b) {
   (void)r;
   (void)g;
   (void)b;
 }
-static void rgb_led_clear(void) {}
+static void rgb_led_clear(void) {
+}
 static void rgb_led_set_vu(float norm, float bass_ratio) {
   (void)norm;
   (void)bass_ratio;

--- a/main/led.h
+++ b/main/led.h
@@ -6,10 +6,10 @@
 typedef enum {
   LED_OFF,
   LED_STEADY,
-  LED_BLINK_SLOW,    // 100ms on, 2500ms off (standby)
-  LED_BLINK_MEDIUM,  // 500ms on/off (paused)
-  LED_BLINK_FAST,    // 250ms on/off
-  LED_VU,            // Audio visualization
+  LED_BLINK_SLOW,   // 100ms on, 2500ms off (standby)
+  LED_BLINK_MEDIUM, // 500ms on/off (paused)
+  LED_BLINK_FAST,   // 250ms on/off
+  LED_VU,           // Audio visualization
 } led_mode_t;
 
 /**


### PR DESCRIPTION
## Summary
- Adds SqueezeAMP board support (DAC TAS57xx control)
- Implements modular LED system with RTSP event-based architecture
- Configurable LED behavior via Kconfig

## Changes from original PR #5
This PR incorporates the work from @emlynmac's #5 and adds:

- **RTSP Events system** (`rtsp_events.c/h`): Observer pattern allowing multiple listeners to react to playback state changes without coupling
- **Unified LED module** (`led.c/h`): Centralized LED management with:
  - Status LED (single color with patterns)
  - Error LED
  - RGB LED (WS2812) with VU meter support
  - Configurable behavior per state via Kconfig
- **Simplified SqueezeAMP module**: Now only handles DAC power control, LED handling moved to led.c
- **Clean separation**: RTSP code no longer has board-specific `#ifdef` blocks

## Configuration
LED behavior is configurable in menuconfig under "LED Configuration":
- GPIO assignments per LED type (status, error, RGB)
- Behavior overrides per state (playing, paused, standby)
- RGB color settings

## Default Behavior
| State | Status LED | RGB LED |
|-------|------------|---------|
| Playing | Solid | VU meter |
| Paused | Blink medium | Blue |
| Standby | Blink slow | Off |
| Error | Blink fast | Red |

Supersedes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)