### PR TITLE
fix: correct merge-bin flags in CI workflow

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -89,7 +89,7 @@ jobs:
           target: ${{ matrix.target }}
           command: >
             idf.py -DSDKCONFIG_DEFAULTS="${{ matrix.sdkconfig }}" build &&
-            idf.py merge-bin -o airplay2-receiver-${{ matrix.name }}.bin -f raw
+            idf.py merge-bin --format raw -o /project/airplay2-receiver-${{ matrix.name }}.bin
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- Use `--format` instead of `-f` (which means `--fill-flash-size`) for `idf.py merge-bin`
- Use absolute `/project/` path to ensure output lands in the Docker-mounted workspace

Fixes missing firmware binaries in releases.