### PR TITLE
Flash spdiff with esp idf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,6 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_SOURCE_DIR}/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(airplay2-receiver VERSION ${PROJECT_VER})
+
+# Add SPIFFS parition
+spiffs_create_partition_image(storage "${CMAKE_SOURCE_DIR}/data" FLASH_IN_PROJECT)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ cd airplay-esp32
 # 3. Activate ESP-IDF environment
 source /path/to/esp-idf/export.sh
 
-# 4. Build and flash
+# 4. Build and flash incl. SPIFFS "storage" partition from data/
 idf.py set-target esp32s3
 idf.py build
 idf.py -p /dev/ttyUSB0 flash
@@ -276,8 +276,12 @@ data/
 **First time (serial only):** The partition table changes, so the first flash after upgrading must be done over serial — OTA won't work because the old partition layout doesn't include the storage partition.
 
 ```bash
-# Flash firmware + partition table + SPIFFS image
-pio run -e squeezeamp-bt -t upload && pio run -e squeezeamp-bt -t uploadfs
+# PlatformIO: flash firmware first, then the SPIFFS image from data/
+pio run -e squeezeamp-bt -t upload
+pio run -e squeezeamp-bt -t uploadfs
+
+# ESP-IDF: flash firmware + partition table + SPIFFS image in one step
+idf.py -p /dev/ttyUSB0 flash
 ```
 
 **Subsequent updates:** After the partition table is in place, you can update individual files over WiFi using the file management API (see below), or re-flash the full SPIFFS image over serial.
@@ -341,6 +345,8 @@ idf.py set-target esp32
 idf.py build
 idf.py -p /dev/ttyUSB0 flash
 ```
+
+`idf.py flash` also writes the SPIFFS `storage` partition populated from `data/`, so the captive-portal pages are available after first boot.
 
 The SqueezeAMP build selects the TAS57xx DAC driver automatically via Kconfig (`CONFIG_DAC_TAS57XX`) and configures the correct I2S/I2C pins. Buffer sizes are automatically reduced (2500 frames vs 5000) to fit the ESP32's more limited PSRAM access.
 

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -170,9 +170,11 @@ static void client_task(void *pvParameters) {
   if (getpeername(slot->socket, (struct sockaddr *)&peer_addr, &peer_len) ==
       0) {
     conn->client_ip = peer_addr.sin_addr.s_addr;
-    ESP_LOGI(TAG, "Client IP: %d.%d.%d.%d", conn->client_ip & 0xFF,
-             (conn->client_ip >> 8) & 0xFF, (conn->client_ip >> 16) & 0xFF,
-             (conn->client_ip >> 24) & 0xFF);
+    ESP_LOGI(TAG, "Client IP: %u.%u.%u.%u",
+             (unsigned int)(conn->client_ip & 0xFF),
+             (unsigned int)((conn->client_ip >> 8) & 0xFF),
+             (unsigned int)((conn->client_ip >> 16) & 0xFF),
+             (unsigned int)((conn->client_ip >> 24) & 0xFF));
   }
 
   // Allocate buffer


### PR DESCRIPTION
Hi. I've tried airplay-esp32 with plain esp-idf and got a 404 in the captive portal.
The PR adds the SPIFFS partition to the regular idf.py flash action.