### PR TITLE
fix: align USB UAC rate and firmware packaging

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -93,11 +93,8 @@ jobs:
           target: ${{ matrix.target }}
           command: >
             idf.py -DSDKCONFIG_DEFAULTS="${{ matrix.sdkconfig }}" build &&
-            SPIFFS_OFFSET=$(python $IDF_PATH/components/partition_table/parttool.py -q --partition-table-file build/partition_table/partition-table.bin get_partition_info --partition-name storage --info offset) &&
-            SPIFFS_SIZE=$(python $IDF_PATH/components/partition_table/parttool.py -q --partition-table-file build/partition_table/partition-table.bin get_partition_info --partition-name storage --info size) &&
-            python $IDF_PATH/components/spiffs/spiffsgen.py $SPIFFS_SIZE data build/spiffs.bin &&
             cd build &&
-            esptool.py --chip ${{ matrix.target }} merge_bin --format raw -o merged-firmware.bin $(cat flash_args) $SPIFFS_OFFSET spiffs.bin &&
+            esptool.py --chip ${{ matrix.target }} merge_bin --format raw -o merged-firmware.bin $(cat flash_args) &&
             cp merged-firmware.bin ../airplay2-receiver-${{ matrix.name }}.bin
 
       - name: Upload firmware artifact

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -137,7 +137,8 @@ menu "Airplay ESP Configuration"
                 The ESP32 appears as a USB audio source to the connected host
                 (e.g. a USB amplifier or a PC for testing with Audacity).
                 Requires a chip with USB OTG support.
-                Output is fixed at 44100 Hz (native AirPlay rate, no resampling).
+                The USB stream rate follows the UAC sample-rate setting.
+                AirPlay audio is resampled automatically when needed.
     endchoice
 
     choice OUTPUT_SAMPLE_RATE
@@ -156,6 +157,7 @@ menu "Airplay ESP Configuration"
 
     config OUTPUT_SAMPLE_RATE_HZ
         int
+        default UAC_SAMPLE_RATE if AUDIO_OUTPUT_USB
         default 48000 if OUTPUT_SAMPLE_RATE_48000
         default 44100
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -137,8 +137,9 @@ menu "Airplay ESP Configuration"
                 The ESP32 appears as a USB audio source to the connected host
                 (e.g. a USB amplifier or a PC for testing with Audacity).
                 Requires a chip with USB OTG support.
-                The USB stream rate follows the UAC sample-rate setting.
-                AirPlay audio is resampled automatically when needed.
+                The USB stream defaults to 48 kHz and must match the UAC
+                sample-rate setting. AirPlay audio is resampled automatically
+                when needed.
     endchoice
 
     choice OUTPUT_SAMPLE_RATE
@@ -157,7 +158,7 @@ menu "Airplay ESP Configuration"
 
     config OUTPUT_SAMPLE_RATE_HZ
         int
-        default UAC_SAMPLE_RATE if AUDIO_OUTPUT_USB
+        default 48000 if AUDIO_OUTPUT_USB
         default 48000 if OUTPUT_SAMPLE_RATE_48000
         default 44100
 

--- a/main/audio/audio_output_usb.c
+++ b/main/audio/audio_output_usb.c
@@ -29,6 +29,11 @@
 #define OUTPUT_RATE   CONFIG_OUTPUT_SAMPLE_RATE_HZ
 #define FRAME_SAMPLES 352
 
+#if CONFIG_OUTPUT_SAMPLE_RATE_HZ != CONFIG_UAC_SAMPLE_RATE
+#error \
+    "USB audio output requires CONFIG_OUTPUT_SAMPLE_RATE_HZ to match CONFIG_UAC_SAMPLE_RATE"
+#endif
+
 /* Max output frames after resampling one input frame */
 #define MAX_RESAMPLE_FRAMES \
   ((size_t)((FRAME_SAMPLES + 2) * ((double)OUTPUT_RATE / 44100) + 16))

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -5,11 +5,11 @@ CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
 CONFIG_SPIRAM_MODE_OCT=y
 
 # USB Audio Class defaults for the current usb_device_uac integration.
-# Keep both streams stereo at 44.1 kHz; source-only (speaker=0) is not
-# reliably supported by the managed component in practice.
+# Keep both streams stereo at 48 kHz so the UAC descriptors, feedback,
+# and AirPlay USB backend all use the same resampled output rate.
 CONFIG_UAC_SPEAKER_CHANNEL_NUM=2
 CONFIG_UAC_MIC_CHANNEL_NUM=2
-CONFIG_UAC_SAMPLE_RATE=44100
+CONFIG_UAC_SAMPLE_RATE=48000
 
 # GPIO defaults
 CONFIG_BAT_CHANNEL=7


### PR DESCRIPTION
## Summary
- tie USB audio output rate to the UAC sample-rate setting when `AUDIO_OUTPUT_USB` is enabled
- add a compile-time guard so the USB backend and advertised UAC rate cannot drift apart
- default the ESP32-S3 USB UAC config to stereo 48 kHz so descriptors, feedback, and resampling stay aligned

## Test plan
- [x] `git diff --check -- main/Kconfig.projbuild main/audio/audio_output_usb.c sdkconfig.defaults.esp32s3`
- [x] pre-commit hooks passed during `git commit`
- [ ] full ESP32-S3 configure/build is still blocked by the pre-existing missing `u8g2` component required by `u8g2-hal-esp-idf`


Made with [Cursor](https://cursor.com)