### PR TITLE
fix(display): ignore spurious position_secs=0 mid-song

### DIFF
--- a/components/display/display.c
+++ b/components/display/display.c
@@ -319,6 +319,12 @@ static void on_rtsp_event(rtsp_event_t event, const rtsp_event_data_t *data,
 
   case RTSP_EVENT_METADATA:
     if (data) {
+      // Detect a real track change so we know when position=0 is legitimate
+      // (start of a new track) vs. a spurious mid-song reset from AirPlay.
+      bool track_changed = data->metadata.title[0] &&
+                           strncmp(s_display.title, data->metadata.title,
+                                   METADATA_STRING_MAX) != 0;
+
       // Only overwrite text fields when the event actually carries them;
       // progress-only updates arrive with zeroed strings.
       if (data->metadata.title[0]) {
@@ -333,8 +339,14 @@ static void on_rtsp_event(rtsp_event_t event, const rtsp_event_data_t *data,
       if (data->metadata.duration_secs) {
         s_display.duration_secs = data->metadata.duration_secs;
       }
-      s_display.position_secs = data->metadata.position_secs;
-      s_display.sync_time_us = esp_timer_get_time();
+      // AirPlay occasionally emits position_secs=0 mid-song without a track
+      // change, which would reset the progress bar. Only accept 0 on an
+      // actual track change; otherwise ignore it and keep the current
+      // interpolated position.
+      if (data->metadata.position_secs != 0 || track_changed) {
+        s_display.position_secs = data->metadata.position_secs;
+        s_display.sync_time_us = esp_timer_get_time();
+      }
       s_display.dirty = true;
       scroll_restart();
     }


### PR DESCRIPTION
## Summary
- AirPlay occasionally emits a metadata update with `position_secs=0` during active playback without a track change, which caused the display's progress bar to snap back to the start of the track.
- Detect a real track change by comparing the incoming title to the current one, and only accept `position_secs=0` when the title actually changed; otherwise keep the current interpolated position.

Fixes https://github.com/rbouteiller/airplay-esp32/issues/47

## Test plan
- [ ] Play a track via AirPlay on a display-equipped build (e.g. ESP32-S3 + OLED) and verify the progress bar advances smoothly without resetting mid-song.
- [ ] Skip to next/previous track and verify the progress bar resets to 0 on the actual track change.
- [ ] Pause / resume during a track and verify the position is preserved.