### PR TITLE
Accept AirPlay v1 and v2 simultaneously (fixes #66)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-airplay-v1-v2-quality-roadmap.md
+++ b/docs/superpowers/plans/2026-05-08-airplay-v1-v2-quality-roadmap.md
@@ -1,0 +1,797 @@
+# AirPlay 1 + 2 Quality Roadmap
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement each phase task-by-task. Steps use `- [ ]` for
+> tracking. **Phases are sequential by priority** — finish P0 before starting P1.
+
+**Goal:** Bring `airplay-esp32` to production-grade reliability for **both AirPlay 1 (RAOP)
+and AirPlay 2 (HAP)** by closing the gaps surfaced by a side-by-side audit against
+`mikebrady/shairport-sync` (and `mikebrady/nqptp` for PTP).
+
+**Architecture:** Seven sequential remediation phases plus one decision-gate phase. Each
+phase is a stand-alone, releasable increment that can be tested end-to-end with real Apple
+clients before the next phase begins.
+
+**Tech stack:** ESP-IDF v5.x, mbedTLS, libsodium, ALAC (Espressif), FreeRTOS, mDNS-IDF.
+
+---
+
+## Audit Verdict
+
+### Current uncommitted diff (`audio_stream_realtime.c` + `audio_receiver.c`) — **7/10**
+
+**What is good (keep):**
+
+- NACK packet layout (`0x80 0xD5 <htons(1)> <first> <count>`) now matches shairport's
+  `rtp_request_resend()` exactly. The previous `count - 1` encoding was wrong.
+- 64-bit missing-mask + slide window + 250 ms retry cadence + sendto-error backoff is a
+  clean, allocation-free design that fits ESP32 RAM.
+- Centralized `audio_receiver_reset_resend_state()` covers start / stop / flush / control
+  re-bind — matches the spirit of shairport's `reset_input_flow_metrics()`.
+- Masking control packet types with `& 0x7F` correctly normalizes `0xD4↔0x54`,
+  `0xD6↔0x56`, `0xD7↔0x57` (RTP marker bit).
+
+**What is risky (revisit in this roadmap):**
+
+- 64-slot window vs shairport's ~1024 — burst loss recovery is weaker. Acceptable trade
+  for embedded RAM, but should be **documented** and the failure mode (`packets_dropped`
+  bumped, audible glitch) understood.
+- `resend_retry_if_due()` is only invoked on the regular-RTP receive path. If a sender
+  stalls and only 0x56 retransmits arrive, the retry timer never advances → in-flight
+  resend requests can starve. **Phase 3 task.**
+- `state->stats.packets_dropped += gap` over-reports loss — every successfully retransmitted
+  packet was already counted as a drop. **Phase 3 task.**
+- No mutex around the retransmit fields shared by the data RX task, control RX task, and
+  the RTSP thread that calls `audio_receiver_set_client_control()`. **Phase 5 task.**
+
+The diff is shippable as a foundation. The roadmap below builds on it.
+
+### Severity heat-map across the codebase
+
+| Subsystem                                      | Critical | High | Medium | Low |
+| ---------------------------------------------- | -------: | ---: | -----: | --: |
+| HAP pair-setup / pair-verify (`main/hap/`)     |        2 |    1 |      4 |   2 |
+| Lip-sync timing (`audio_timing`, `*_clock.c`)  |        2 |    4 |      4 |   3 |
+| mDNS / identity / network lifecycle            |        2 |    3 |      2 |   2 |
+| RTSP handlers + dual v1/v2 selection           |        0 |    1 |      3 |   4 |
+| RTP receive / NACK / retransmit (current diff) |        0 |    0 |      4 |   4 |
+| **Totals**                                     |    **6** |  **9** | **17** | **15** |
+
+The **six critical** issues are the gating items: until they are fixed, AirPlay 2
+HomeKit-paired playback cannot be considered reliable, and large lip-sync offsets vs other
+HomePods will be visible in any multi-room comparison.
+
+---
+
+## Phase Index
+
+| Phase | Title                                                | Priority | Est. Effort |
+| ----- | ---------------------------------------------------- | -------- | ----------- |
+| **1** | Pairing & Identity (the AP2 blockers)                | **P0**   | 1 week      |
+| **2** | Lip-Sync Correctness (anchor RTP + locking)          | **P0**   | 1 week      |
+| **3** | Stream Reliability (retransmit + drift modeling)     | P1       | 1 week      |
+| **4** | Network Lifecycle & RTSP Polish                      | P1       | 4 days      |
+| **5** | Concurrency Hardening                                | P1       | 3 days      |
+| **6** | Crypto Hardening                                     | P2       | 4 days      |
+| **7** | Edge Cases (BMCA, multi-bearer, codec, TXT polish)   | P2       | 1 week      |
+| **8** | Decision Gate: FairPlay v2 + Test Harness            | Decision | 0–4 weeks   |
+
+**Total core effort:** ~5 weeks of focused work for P0 + P1 + P2. Phase 8 is a separate
+discussion because FairPlay v2 implementation cost dwarfs everything else combined.
+
+---
+
+## Phase 1 — Pairing & Identity (the AP2 blockers)
+
+**Why first:** Without these fixes, every iPhone pairing attempt resets state on reboot,
+and HomeKit-paired playback is broken. These are also the cheapest wins.
+
+**Success criteria:**
+
+1. Pair iPhone (Home app or AirPlay sheet → "Allow Speaker") on first boot. Reboot ESP32.
+   Reconnect — playback resumes **without re-pairing**.
+2. `dns-sd -B _airplay._tcp` shows non-zero `pi=` UUID stable across reboots.
+3. Esparagus board with Ethernet only (Wi-Fi disabled in menuconfig) successfully
+   completes RAOP from TuneBlade on Windows.
+4. `dns-sd -L` shows `deviceid=` matching the Ethernet MAC, not the Wi-Fi STA MAC.
+
+### Files
+
+- `main/hap/srp.c` — fix password mismatch in verify (Critical #1)
+- `main/hap/srp.h` — add password storage to `srp_session_t`
+- `main/hap/hap_pair_setup.c` — implement M6 TLV emission (Critical #2)
+- `main/hap/hap_pair_verify.c` — verify Ed25519 signature in raw verify (Critical #3)
+- `main/hap/hap.c` — generate + persist `pi` UUID alongside `pk` keypair
+- `main/hap/hap.h` — expose `hap_get_pairing_id()`
+- `main/network/mdns_airplay.c` — feed real `pi`, branch MAC source by active bearer
+- `main/network/wifi.c` / `main/network/ethernet.c` — expose "active bearer MAC"
+- `main/rtsp/rtsp_handlers.c`
+  - line ~438–446: Apple-Challenge response IP/MAC from active netif
+  - line ~496: `/info` plist `pi` from persisted UUID
+  - line ~616: M5 success branch returns body when `*output_len > 0`
+- `main/main.c` — generate `pi` at first boot if NVS empty
+
+### Tasks
+
+- [ ] **1.1 Add password storage to SRP session.** In `srp.h`, extend `srp_session_t`
+  with `char password[16]; size_t password_len;`. In `srp.c:srp_start()`, copy the
+  caller's password into the session. In `srp_verify_client()` (~line 311), recompute
+  `x` with `session->password` instead of the hard-coded `"3939"`.
+
+- [ ] **1.2 Test SRP fix.** Add a unit test
+  `main/hap/test_srp.c` (link as `main` test or simple ESP-IDF unit-test) that runs
+  full M1→M2→M3→M4 with password `"0000"` (non-transient). Should compute matching
+  M1/M2 proofs. Commit.
+
+- [ ] **1.3 Implement M5 → M6 TLV emission** in `hap_pair_setup_m5()`
+  (`main/hap/hap_pair_setup.c` ~line 155–211). After successful ChaCha20-Poly1305
+  decrypt of `encrypted_data` and signature check on the inner sub-TLV, build the M6
+  response: derive accessory long-term Ed25519 keypair, sign
+  `(AccessoryX || AccessoryPairingID || AccessoryLTPK)`, encrypt the inner TLV
+  `(0x01=AccessoryPairingID, 0x03=AccessoryLTPK, 0x0A=AccessorySignature)` with the
+  same session key + nonce `"PS-Msg06"`, emit `(0x06=state=6, 0x05=encrypted_data)`
+  into `output`/`output_len`. See shairport-sync's
+  `airplay2_pairings/airplay2_pairings.c` for reference structure.
+
+- [ ] **1.4 Fix RTSP handler success branch** in `rtsp_handlers.c` `handle_post()` for
+  `/pair-setup`. Today the success branch is gated on `err == ESP_OK && response_len > 0`
+  — verify M5 path now emits `response_len > 0` after task 1.3 and that the response
+  is sent with `Content-Type: application/octet-stream` and the encrypted M6 body.
+
+- [ ] **1.5 Implement raw pair-verify signature check** in `hap_pair_verify_m3_raw`
+  (`hap_pair_verify.c` ~line 296). Use `crypto_sign_verify_detached()` (libsodium) on
+  the ChaCha20-decrypted client signature with the controller LTPK retrieved from the
+  pairings store. If the controller is unknown, return error TLV (state=6,
+  error=0x02 = authentication). **Do not** silently log-and-pass.
+
+- [ ] **1.6 Generate + persist `pi` UUID at first boot.** In `hap_init()`
+  (`main/hap/hap.c`), after the existing `pk` load/generate logic, do the same for `pi`:
+  load 16 bytes from NVS key `"hap.pi"`; if absent, fill with `esp_fill_random(buf, 16)`,
+  set RFC-4122 v4 bits (`buf[6] = (buf[6] & 0x0f) | 0x40; buf[8] = (buf[8] & 0x3f) | 0x80`),
+  write to NVS, log it. Add `hap_get_pairing_id(uint8_t out[16])`.
+
+- [ ] **1.7 Replace zero `pi=`** in `mdns_airplay.c` (~line 80) with hex of the 16-byte
+  UUID from `hap_get_pairing_id()` formatted as `8-4-4-4-12` (e.g.
+  `e2c8c0d2-4a3f-4f1e-9c3b-1a2b3c4d5e6f`). Same in `rtsp_handlers.c` `/info` plist
+  (~line 496).
+
+- [ ] **1.8 Expose active-bearer MAC.** Add `network_active_mac(uint8_t out[6])` and
+  `network_active_ipv4(esp_ip4_addr_t *out)` in a new tiny module
+  `main/network/active_bearer.c` (or extend an existing helper). Logic: if Ethernet
+  netif has an IP, use `ESP_MAC_ETH`; else use `ESP_MAC_WIFI_STA`. Update
+  `wifi_get_mac_str()` to delegate to this helper.
+
+- [ ] **1.9 Wire active-bearer MAC into mDNS** (`mdns_airplay.c:44-45,80`),
+  RAOP service-name prefix, and `deviceid` TXT.
+
+- [ ] **1.10 Wire active-bearer IP+MAC into Apple-Challenge response**
+  (`rtsp_handlers.c:438-446`). The PKCS#1 v1.5 signed payload must contain the IPv4 and
+  MAC the iOS device used to reach us, otherwise the challenge fails.
+
+- [ ] **1.11 Field test:** pair from iPhone (iOS 17+), reboot ESP32, restream. Expected:
+  no re-pair prompt, audio plays in <2 s. Pair from second iPhone — both should appear
+  in the pairings store. Reboot — both should still work.
+
+- [ ] **1.12 Field test (Ethernet):** Esparagus Audio Brick with Wi-Fi disabled in
+  `menuconfig`, Ethernet only. TuneBlade on Windows discovers, pairs (no PIN), streams
+  successfully. Repeat with iOS in AirPlay 2 mode.
+
+- [ ] **1.13 Commit phase 1** with message
+  `feat(hap): complete pair-setup M6 + persistent pi + active-bearer identity (fixes #XXX)`.
+
+### Risks
+
+- Pair-setup M6 can subtly break existing already-paired iPhones if the encryption nonce
+  or the inner TLV ordering differs from spec. Plan to test with a freshly factory-reset
+  pairings store.
+- Changing the MAC source by active bearer means existing users on Wi-Fi will see the
+  same `deviceid` (no change), but Esparagus users currently on Ethernet who previously
+  paired with the Wi-Fi MAC will appear as a new device. Document in `CHANGELOG.md`.
+
+---
+
+## Phase 2 — Lip-Sync Correctness (anchor RTP + locking)
+
+**Why second:** Even with pairing fixed, multi-room sync vs HomePods will be visibly off
+(hundreds of ms class for AP1, less for AP2 but still audible). This is the second-most-
+visible quality regression.
+
+**Success criteria:**
+
+1. Two devices in a HomeKit group: ESP32 + a real HomePod mini. Play in stereo. No
+   audible echo / phase difference (target: <10 ms between speakers, measured with a
+   phone microphone or a logic-analyzer-fed comparator).
+2. Sustained 1-hour playback session has zero **drift** complaints (sync at start ≈ sync
+   at end), with only periodic SYNC packets keeping us anchored — no resync glitches.
+3. RAOP `Audio-Latency:` header in RECORD response matches measured pipeline latency
+   within ±5 ms.
+
+### Files
+
+- `main/audio/audio_stream_realtime.c` (~line 439–471): control_receiver_task — the
+  sync packet parsers
+- `main/audio/audio_timing.c` (~line 195–215, 87–125): `audio_timing_set_anchor`,
+  `compute_early_us`
+- `main/audio/audio_timing.h`: add `clock_id` field to `audio_timing_t`
+- `main/network/ntp_clock.c`: add gradient (least-squares slope) to offset model
+- `main/network/ptp_clock.c`: add frequency-offset estimation
+- `main/audio/audio_receiver.c`: pass `clock_id` through `audio_receiver_set_anchor_time`
+- `main/rtsp/rtsp_handlers.c` (~line 1265–1272): RECORD `Audio-Latency:` honest value
+- `main/audio/audio_output.{c,h}`: expose actual DAC pipeline depth
+- new `main/audio/sync_lock.c/h` (or use FreeRTOS portMUX directly inline): mutex on
+  anchor
+
+### Tasks
+
+- [ ] **2.1 Fix AP1 sync anchor RTP.** In `control_receiver_task` 0x54 case
+  (`audio_stream_realtime.c` ~line 447), change the anchor RTP source from
+  `nctoh32(packet+4)` (rtp_timestamp_less_latency) to:
+
+```c
+uint32_t latency_delayed = nctoh32(packet + 4);   // playing-now RTP (incl. latency)
+uint32_t sync_rtp        = nctoh32(packet + 16);  // emitted-now RTP (latency frames ahead)
+uint32_t conn_latency    = sync_rtp - latency_delayed;   // u32 modular subtraction
+state->stream_latency_frames = conn_latency;
+uint32_t anchor_rtp = sync_rtp - conn_latency;    // == latency_delayed, but stored as adjusted
+```
+
+  Note: this restores the shairport `latency_delayed_timestamp` semantic. The existing
+  code happens to use that value already — verify by reading shairport `rtp.c`
+  `rtp_control_receiver` 0xd4 case carefully and ensure ours is mathematically
+  equivalent. If it is, the fix may be only "store the derived `stream_latency_frames`
+  and use it in advertised `Audio-Latency:`" (Task 2.6).
+
+- [ ] **2.2 Fix AP2 PTP anchor RTP** (`audio_stream_realtime.c` ~line 463). Parse
+  `frame_2 = nctoh32(packet + 16)` and a fixed offset `11035`:
+
+```c
+uint32_t frame_1 = nctoh32(packet + 4);
+uint64_t ptp_ns  = nctoh64(packet + 8);
+uint32_t frame_2 = nctoh32(packet + 16);
+uint64_t clock_id = nctoh64(packet + 20);
+uint32_t added_latency = (uint32_t)(frame_2 - frame_1);  // modular
+uint32_t anchor_rtp = frame_1 - 11035u - added_latency;  // shairport set_ptp_anchor_info
+audio_receiver_set_anchor_time(clock_id, ptp_ns, anchor_rtp);
+```
+
+  Reference: shairport-sync `rtp.c` `rtp_control_receiver` case 215 (or 0x57).
+
+- [ ] **2.3 Plumb `clock_id` through the timing layer.**
+  - Add `uint64_t anchor_clock_id` to `audio_timing_t` in `audio_timing.h`.
+  - In `audio_timing_set_anchor()`, store `clock_id` instead of `(void)clock_id`.
+  - Compare incoming `clock_id` against `ptp_clock_get_master_id()` (new accessor in
+    `ptp_clock.c`). If mismatch and we are in PTP sync mode: log warning, **do not
+    update anchor**, and set a "pending master switch" flag.
+  - On master switch + 5 s grace, accept the new anchor and rebase. Mirrors
+    shairport's `get_ptp_anchor_local_time_info` master-change handling.
+
+- [ ] **2.4 Add NTP gradient.** In `ntp_clock.c`, retain the last N=8 timing exchanges
+  with `(local_time, remote_time)` pairs. Compute the slope `gradient = Σ(xy) / Σ(x²)`
+  (least-squares through origin after centering). Expose
+  `ntp_clock_get_offset_at_local_time(int64_t local_ns)` that returns
+  `base_offset + gradient * (local_ns - reference_local_ns)`. Use this in
+  `compute_early_us()` instead of the static offset.
+
+- [ ] **2.5 Add PTP frequency model.** In `ptp_clock.c`, after the median filter on
+  instantaneous offsets, fit a gradient over the same window. Expose
+  `ptp_clock_get_offset_at_local_time(int64_t local_ns)`. This corrects the
+  `local_time + offset → ptp_time` mapping for clocks with measurable drift.
+
+- [ ] **2.6 Honest `Audio-Latency:` in RAOP RECORD response**
+  (`rtsp_handlers.c` ~line 1268). Replace `0` with the **measured** end-to-end latency
+  in RTP frames at 44.1 kHz:
+  `latency_frames = (DAC_PIPELINE_US + I2S_DMA_BUFFER_US + JITTER_BUFFER_US) * 44100 / 1000000`.
+  Expose constants from `audio_output.h` and `audio_buffer.h`.
+  Typical value: ~88200 frames (2 s) for a 200 ms jitter target + DAC/DMA depth.
+  Make this match `state->stream_latency_frames` from task 2.1 if AP1 has set one.
+
+- [ ] **2.7 Add anchor-update mutex.** Wrap `audio_timing_set_anchor()` and the
+  read-side `compute_early_us()` (both in `audio_timing.c`) with a `SemaphoreHandle_t`
+  mutex (or `portMUX_TYPE` spinlock since this is a fixed-size critical section).
+  Initialize in `audio_timing_init()`. On the read side, copy anchor + clock_id +
+  gradient into a local snapshot under the lock, then release before doing the maths.
+
+- [ ] **2.8 Add anchor staleness detection.** Track `state->last_sync_packet_us` in
+  `audio_stream_realtime.c` (updated in both 0x54 and 0x57 paths). In the audio output
+  pull path or a 1 Hz watchdog, if `(now - last_sync_packet_us) > 7_000_000` (7 s,
+  matches shairport AP2 realtime), call a new
+  `audio_timing_invalidate_anchor()` and stop emitting samples until next anchor. Log
+  `WARN: anchor stale, pausing playback`.
+
+- [ ] **2.9 Add monotonic ratchet.** In `audio_timing_set_anchor()`, reject anchors
+  where `network_time_ns < last_anchor_network_time_ns - threshold` (threshold ~1 s
+  to allow legitimate FLUSH-driven seeks). On reject, log + bump
+  `audio_stats.anchor_rejected`.
+
+- [ ] **2.10 Field test:** ESP32 + iPhone playing stereo across two HomePod minis.
+  Walk between speakers — no audible echo. Use a microphone-equipped phone app
+  (e.g., `Audio Tools` "Speaker Test") to verify <10 ms inter-speaker offset.
+
+- [ ] **2.11 Bench test for drift:** 60-minute sine-wave playback, scope the I2S clock
+  vs the streaming source's clock (or compare frame number at start vs end against
+  expected `start + 44100 × 3600`). Should be drift-corrected, no slow phase walk.
+
+- [ ] **2.12 Commit phase 2** with message
+  `fix(timing): correct anchor RTP for AP1+AP2, add clock-id check + drift model`.
+
+### Risks
+
+- Changing anchor RTP semantics could break **single-speaker** lip-sync that users have
+  gotten used to. Test single-device first to verify no regression, then multi-device.
+- Adding mutex to the audio output read path adds a few µs of latency. Acceptable
+  unless we are already running tight on ESP32 (not ESP32-S3).
+
+---
+
+## Phase 3 — Stream Reliability (retransmit + drift tail)
+
+**Why third:** With Phases 1–2 done, a stream works and stays in sync. Phase 3 is about
+making it tolerant of WiFi packet loss and long sessions.
+
+**Success criteria:**
+
+1. Inject 5% random UDP packet loss (using a Wi-Fi AP that supports it, or a Linux
+   `tc qdisc netem` upstream). No audible glitches with the receiver tracking
+   shairport-style behavior. Stat counters report accurate `loss_recovered` vs
+   `loss_unrecovered`.
+2. NACK retry continues even when no fresh non-retransmit packets arrive (sender stall).
+3. Burst loss of 32 packets → recovered. Burst loss of >64 packets → graceful
+   acknowledgement (single short skip), not cascading drift.
+
+### Files
+
+- `main/audio/audio_stream_realtime.c` (current diff is here): refine retry/timer
+- `main/audio/audio_receiver_internal.h`: add separate counters
+- `main/audio/audio_buffer.c`: add "before-played-frame" gate
+
+### Tasks
+
+- [ ] **3.1 Split loss counters.** In `audio_stats_t`
+  (`audio_receiver_internal.h`): rename current `packets_dropped` to
+  `gap_detected_packets`. Add `loss_recovered_packets` (incremented in
+  `resend_mark_received` for 0x56 retransmits) and `loss_unrecovered_packets`
+  (incremented when a missing slot ages out of the window without recovery — see 3.2).
+
+- [ ] **3.2 Track unrecovered loss as the window slides.** In
+  `resend_track_missing()` reset branch (`audio_stream_realtime.c` ~line 134), the
+  current code abandons holes when a new gap arrives outside the window. Before
+  abandoning, count any still-set bits in the old mask as `loss_unrecovered_packets`.
+
+- [ ] **3.3 Run resend retry from a periodic timer.** Add an `esp_timer` (1 ms or
+  10 ms tick) or piggyback on the audio output pull task. On each tick, call
+  `resend_retry_if_due(state)`. This decouples retry cadence from incoming-packet
+  arrival, fixing the "sender-stall starves retries" issue.
+
+- [ ] **3.4 Optionally widen the resend window.** If profiling shows free PSRAM,
+  extend `RESEND_WINDOW_BITS` from 64 to 256 (still a pair of 64-bit words, but two of
+  them = `uint64_t mask[4]`). If PSRAM is tight, leave at 64 and document the trade
+  in `audio_stream_realtime.c` header comment. Decision item — flag in plan review.
+
+- [ ] **3.5 Drop late retransmits cheaply.** In `realtime_receive_packet()`, before
+  the AES decrypt + ALAC decode (which costs ~50 µs/packet), check if `seq` is older
+  than the next-to-be-played frame (using `audio_buffer_next_play_seq()` — add this
+  accessor). Skip with `ESP_LOGD("late retransmit, skipping decode")`.
+
+- [ ] **3.6 Field test with packet loss.** Use a Wi-Fi AP that supports loss
+  injection (or a Linux router with `tc netem loss 5%`) between iPhone and ESP32.
+  Play 10 min — count audible glitches (manual). Target: ≤1 glitch per 10 min at 5%
+  loss with retransmit recovery.
+
+- [ ] **3.7 Commit phase 3** with message
+  `feat(audio): timer-driven NACK retry + loss accounting + late-retransmit gate`.
+
+---
+
+## Phase 4 — Network Lifecycle & RTSP Polish
+
+**Success criteria:**
+
+1. Wi-Fi disconnect/reconnect mid-session: mDNS re-announces, RTSP sessions are torn
+   down cleanly, no zombie sockets, next stream attempt works in <5 s.
+2. NTP timing exchange uses the port advertised in SETUP — verifiable with
+   `tcpdump port <timing_port>`.
+3. `CONFIG_AIRPLAY_FORCE_V1` actually does what its help text says (and the help text
+   matches reality).
+
+### Files
+
+- `main/main.c`: react to `IP_EVENT_*` to refresh mDNS
+- `main/network/mdns_airplay.{c,h}`: add `mdns_airplay_refresh()`
+- `main/network/ntp_clock.c`: bind to advertised port instead of ephemeral
+- `main/rtsp/rtsp_handlers.c`:
+  - line ~120–142: keep ports for the timing socket consistent
+  - line ~1085: parse `Transport:` from header block only
+  - line ~1622–1664: distinguish stream-only vs full TEARDOWN
+  - line ~1265–1272: see Phase 2 task 2.6 (already covered)
+- `main/rtsp/rtsp_message.c`: case-insensitive header lookup
+- `main/Kconfig.projbuild` ~line 332: align help text with implementation; add
+  `AIRPLAY_DISABLE_V2_HANDLERS` if we want to truly disable v2 (vs just hide it from
+  mDNS)
+
+### Tasks
+
+- [ ] **4.1 Bind NTP timing socket to advertised port.** Today
+  `ensure_stream_ports()` (`rtsp_handlers.c` ~line 120) opens a UDP socket, reads its
+  ephemeral port, and **closes the socket**. Then `ntp_clock_start_client()`
+  (`ntp_clock.c` ~line 227) opens a fresh ephemeral socket. Refactor:
+  `ensure_stream_ports()` keeps the bound socket and hands its FD to
+  `ntp_clock_start_client(int fd)`. The advertised port now matches the listening
+  port end-to-end.
+
+- [ ] **4.2 mDNS refresh on network event.** In `main.c`'s `IP_EVENT_*` handler
+  (`event_handler` ~line 87–144), on `IP_EVENT_STA_GOT_IP` or `IP_EVENT_ETH_GOT_IP`,
+  if `s_airplay_started`, call new `mdns_airplay_refresh()` (which does
+  `mdns_service_remove_all()` then re-runs the registration logic from
+  `mdns_airplay_init()`). Ensures `_airplay._tcp` and `_raop._tcp` are re-published
+  with the current IP/hostname.
+
+- [ ] **4.3 RTSP TCP close ⇒ cleanup.** In `rtsp_server.c` client_task error/exit
+  branch, ensure: (a) `audio_receiver_stop()`, (b) `audio_receiver_set_client_control(0,0)`,
+  (c) `ntp_clock_stop()`, (d) per-connection state freed. Audit existing code — most
+  is there but verify error paths.
+
+- [ ] **4.4 Distinguish stream-only TEARDOWN vs full session TEARDOWN.** In
+  `handle_teardown()` (`rtsp_handlers.c` ~line 1622), parse the request body. If
+  `streams[]` is present (v2 stream-only teardown), call a new
+  `audio_receiver_stop_streams()` which keeps the receiver state alive but clears
+  the active stream. If no body or no streams[], call `audio_receiver_stop()` (full
+  stop). Mirror shairport's session-vs-stream distinction.
+
+- [ ] **4.5 Restrict `Transport:` parsing to header block.** In SETUP path
+  (`rtsp_handlers.c` ~line 1085), today `strcasestr(raw, "Transport:")` searches the
+  entire message including body. Refactor to walk header lines only via existing
+  `rtsp_message_get_header()` parsing.
+
+- [ ] **4.6 Case-insensitive `Content-Length` lookup.** In `rtsp_message.c` ~line
+  32–40, use a case-insensitive header walk for all required headers (RFC 2326 §12).
+
+- [ ] **4.7 Fix Kconfig help text.** Update `AIRPLAY_FORCE_V1` help (Kconfig
+  ~line 332) to accurately describe what it does after commit `104d456`: hides
+  `_airplay._tcp` from mDNS but does **not** disable v2 RTSP handlers (a v2-aware
+  client could still try `/pair-setup`). If we want a hard-disable mode, add a
+  separate `AIRPLAY_DISABLE_V2_HANDLERS` and gate the post handlers on it.
+
+- [ ] **4.8 Field test:** Wi-Fi off → on mid-stream. Stream resumes. iOS device shows
+  "Speaker Disconnected" → speaker still in picker → reconnect works.
+
+- [ ] **4.9 Commit phase 4** with `feat(network): mDNS refresh + bind timing port + cleanup paths`.
+
+---
+
+## Phase 5 — Concurrency Hardening
+
+**Why now:** Phases 1–4 added mutexes ad-hoc. Phase 5 makes the concurrency model
+explicit and consistent.
+
+**Success criteria:**
+
+1. Document the threading model in `docs/THREADING.md`: which task owns which struct,
+   which fields cross task boundaries, what protects them.
+2. ThreadSanitizer-equivalent inspection (manual with `// THREAD: <task>` comments at
+   each cross-task field) catches no unprotected reads/writes.
+3. 24-hour soak test with continuous play + pause/resume + reconnect → no crashes,
+   no torn-state-induced glitches.
+
+### Files
+
+- All of `main/audio/`: add ownership comments
+- `main/audio/audio_receiver_internal.h`: split `audio_stats_t` into "RX-task-local" +
+  "shared-snapshot"
+- `main/audio/audio_receiver.c`: add `xQueue` or atomic snapshot for stats getter
+- `main/network/ptp_clock.c`: review ISR vs task contexts (LWIP socket is task-context
+  but the timer callback may not be)
+- new `docs/THREADING.md`
+
+### Tasks
+
+- [ ] **5.1 Document threading model.** Create `docs/THREADING.md` with a table:
+
+```
+Task                     | Core | Owns                          | Reads (shared)
+-------------------------|------|-------------------------------|----------------
+RTSP server (per-conn)   | 0    | rtsp_conn_t                   | hap.pairings
+audio receiver_task      | 1    | state->stats, ->resend_*      | state->client_control_addr
+audio control_recv_task  | 1    | (writes anchor)               | -
+audio output             | 1    | I2S DMA                       | audio_buffer, audio_timing
+ptp_clock_task           | 0    | ptp.clock_state               | -
+ntp_clock_task           | 0    | ntp.history                   | -
+mDNS                     | 0    | (LWIP-internal)               | -
+```
+
+- [ ] **5.2 Atomic stats snapshot.** In `audio_receiver_get_stats()`, wrap the
+  `memcpy` in a critical section (portMUX). Producer side (RX task) updates each
+  field individually — single 32-bit writes are atomic on Xtensa, but multi-field
+  reads need protection.
+
+- [ ] **5.3 Protect `client_control_addr`.** In
+  `audio_receiver_set_client_control()`, today we directly mutate
+  `state->client_control_addr` while RX task may be reading it for `sendto`. Either
+  (a) use a portMUX, or (b) require the receiver be stopped before calling this
+  setter. Pick (b) for simplicity — call sites are RTSP-thread only at SETUP/TEARDOWN
+  boundaries.
+
+- [ ] **5.4 Validate ESP-IDF mDNS thread safety** for `mdns_service_*` calls from the
+  IP event handler context. Read ESP-IDF mdns docs — most calls are thread-safe but
+  `mdns_init`/`deinit` may not be.
+
+- [ ] **5.5 24-hour soak test.** Run a script that reconnects every 5 min, pauses
+  every 90 s, restreams. Check for crashes (`coredump`), heap fragmentation (log
+  free heap every minute, expect stable), task watermarks (no stack near-overflow).
+
+- [ ] **5.6 Commit** `chore(audio): document + harden cross-task synchronization`.
+
+---
+
+## Phase 6 — Crypto Hardening
+
+**Success criteria:**
+
+1. SRP M1/M2 proof comparison is constant-time (no observable timing diff for
+   right-vs-wrong PINs in `pair-setup`).
+2. AES-256 keys are accepted (not silently truncated). 128 stays the default.
+3. ChaCha20-Poly1305 nonce reuse is impossible across reconnects (tested by running
+   pair-verify twice in quick succession against same controller).
+4. HAP HKDF salt/info strings audited against the AirPlay 2 spec / shairport
+   reference.
+
+### Files
+
+- `main/hap/srp.c`: constant-time `memcmp`
+- `main/audio/audio_crypto.c` ~line 41–48: branch on key length
+- `main/hap/hap_crypto.c`: nonce-counter persistence
+- `main/rtsp/rtsp_handlers.c` ~line 1007–1058 + `main/hap/hap_crypto.c` ~line 57–72:
+  HKDF labels for SETUP audio key
+
+### Tasks
+
+- [ ] **6.1 Constant-time proof compare** in `srp.c:srp_verify_client()` ~line 389.
+  Replace `memcmp` with libsodium `sodium_memcmp()` (already a dependency).
+
+- [ ] **6.2 AES-256 audio decrypt support.** In `audio_crypto.c:41`, branch on
+  `key_len`:
+  ```c
+  int key_bits = (key_len == 32) ? 256 : 128;
+  if (key_len != 16 && key_len != 32) return -1;  // explicit reject
+  mbedtls_aes_setkey_dec(&ctx, key, key_bits);
+  ```
+  In `rtsp_handlers.c` after `rsa_decrypt_aes_key`, allow both 16- and 32-byte keys.
+
+- [ ] **6.3 Verify HAP audio-key HKDF labels.** Trace shairport's
+  `airplay2_pairings/airplay2_pairings.c` `derive_chacha_key_v2_session()` (or current
+  equivalent) to see what salt/info pair it uses for the audio stream key. Compare
+  to our `hap_derive_audio_key()` (`hap_crypto.c:57-72`). Expected values per
+  spec: salt=`"Control-Salt"` info=`"Control-Read-Encryption-Key"` for control RX,
+  but for **audio stream encryption** the labels differ (often
+  `"AudioStreamReadEncryptionKey"` or session-specific). Fix if needed.
+
+- [ ] **6.4 Audit ChaCha nonce strategy.** In `hap_crypto.c:82-114`, the nonce is
+  an 8-byte counter in the last 8 bytes of a 12-byte field. Verify counters are reset
+  on **session establishment** (not just on first packet) and never decremented. Add
+  an assertion.
+
+- [ ] **6.5 mbedTLS HKDF migration (optional).** Replace custom HKDF in
+  `hap_crypto.c:11-54` with `mbedtls_hkdf()`. Reduces audit surface. Run unit test
+  comparing old vs new outputs to ensure bit-identical.
+
+- [ ] **6.6 Field test:** pair iPhone, unpair, repair within 30 seconds. Should
+  succeed both times (no nonce-reuse panic). Test with 5 different iOS versions.
+
+- [ ] **6.7 Commit** `fix(crypto): constant-time SRP, AES-256 support, HAP key audit`.
+
+---
+
+## Phase 7 — Edge Cases & TXT Polish
+
+**Success criteria:**
+
+1. PTP master selection survives a HomePod restart on the network (master changes,
+   we follow correctly).
+2. Esparagus dual-bearer (Wi-Fi + Ethernet on same L2) works on either or both.
+3. mDNS TXT records pass `dns-sd` parsing for both `_raop._tcp` and `_airplay._tcp`
+   with all keys typically present on commercial AirPlay devices.
+4. 24-bit ALAC streams either play correctly or are explicitly refused, never
+   silently truncated.
+
+### Files
+
+- `main/network/ptp_clock.c`: minimal BMCA
+- `main/network/mdns_airplay.c`: TXT polish
+- `main/audio/audio_decoder.c` ~line 210–245: 24-bit handling
+- `main/audio/alac_magic_cookie.c`: validation in `build_alac_magic_cookie()`
+
+### Tasks
+
+- [ ] **7.1 Minimal PTP BMCA.** In `ptp_clock.c` `PTP_MSG_ANNOUNCE` handler (today a
+  no-op), parse `priority1`, `clockClass`, `clockAccuracy`, `clockIdentity`. Track
+  current best master in `ptp.best_master_id`. On SYNC arrival, ignore if source
+  ID != `best_master_id`. On master timeout (no ANNOUNCE for 3× announceInterval),
+  clear and re-elect from next ANNOUNCE.
+
+- [ ] **7.2 Per-interface PTP multicast subscription.** In `ptp_clock.c:283-293`,
+  replace `imr_interface = INADDR_ANY` with the active netif's IPv4. If both Wi-Fi
+  and Ethernet are up, subscribe on **both** with separate sockets, or pick the one
+  with default route. Test on Esparagus board.
+
+- [ ] **7.3 Add `txtvers=1`, `pw=false`, `protovers=1.1`** to `_raop._tcp` (RAOP)
+  and `_airplay._tcp` (AP2) TXT records (`mdns_airplay.c`). Some legacy clients
+  reject services missing `txtvers`.
+
+- [ ] **7.4 Audit `AIRPLAY_FEATURES_LO/HI`** in `rtsp_handlers.h`. List each bit,
+  identify which features we actually support (PCM yes, ALAC yes, AAC partial?,
+  metadata yes, screen mirroring no, MFi no, FairPlay v2 stub-only). Trim the
+  bitmask to what we actually deliver. Misadvertised features cause iOS to attempt
+  flows that we then fail.
+
+- [ ] **7.5 ALAC 24-bit handling.** In `audio_decoder.c:210-245`, when `bits_per_sample`
+  in fmtp != 16, either: (a) reject the SETUP with 415 Unsupported Media Type, or
+  (b) decode-and-truncate explicitly with an `ESP_LOGW`. Pick (b) for compatibility.
+  In `build_alac_magic_cookie()`, validate fmtp fields (frame_length, bit_depth,
+  channels, sample_rate) before encoding into the cookie; reject obviously bad
+  values.
+
+- [ ] **7.6 mDNS hostname collision.** Wire ESP-IDF mDNS conflict callback (if
+  exposed in your IDF version) to append `-2` / `-3` suffix on collision.
+
+- [ ] **7.7 Field test (multi-bearer):** Esparagus board with both Ethernet and
+  Wi-Fi connected to same router. iOS on Wi-Fi-only finds the speaker. Stream from
+  Ethernet path. Disconnect Ethernet — stream survives on Wi-Fi (or fails over
+  cleanly).
+
+- [ ] **7.8 Field test (PTP master switch):** With ESP32 + HomePod mini in a
+  HomeKit group both playing, restart the HomePod. ESP32 should re-elect master
+  (verify in PTP debug log) and resume sync within 5 seconds without audible
+  glitch.
+
+- [ ] **7.9 Commit** `feat(network): minimal BMCA + dual-bearer mDNS + TXT polish`.
+
+---
+
+## Phase 8 — Decision Gate: FairPlay v2 + Test Harness
+
+**Why a separate phase:** This is a **scope decision**, not just an implementation. The
+right answer depends on user-base and risk tolerance.
+
+### 8a. FairPlay v2 — Scope Decision
+
+**Context:** iOS uses FairPlay v2 for content protection signalling (`/fp-setup`
+endpoint). Our current `rtsp_fairplay.c` returns canned blobs that are enough for
+**most** non-DRM Apple-Music / Spotify / podcast / system audio cases, but **iOS may
+silently downgrade** features or refuse some streams (notably from Apple Music
+"Lossless" tier).
+
+**Options:**
+
+| Option                       | Cost          | Outcome                                       |
+| ---------------------------- | ------------- | --------------------------------------------- |
+| **A. Keep stub as is**       | 0             | Works for ~85% of iOS streaming. Documented gaps. |
+| **B. Improve stub fidelity** | 1 week        | Maybe 90–95%, no real DRM compliance.        |
+| **C. Implement FairPlay v2** | 3–4 weeks + access to spec / reference materials | Production-grade, parity with HomePod for non-MFi audio. Cannot pass MFi without Apple license. |
+
+**Decision needed before any implementation work.** Discuss with the project owner.
+
+If **A**: Add a `docs/COMPATIBILITY.md` listing iOS streams known to refuse / degrade.
+
+If **B**: Compare to `openairplay/airplay-spec`'s FP discussion + try newer canned
+responses captured from a working third-party AirPlay 2 receiver via Wireshark.
+
+If **C**: Start with shairport-sync 4.x's FairPlay handling (a spec-style
+implementation lives outside the open-source tree; see
+[`mikebrady/shairport-sync` issue tracker](https://github.com/mikebrady/shairport-sync/issues)
+for what's known publicly).
+
+### 8b. Test Harness & CI
+
+Regardless of the FairPlay decision, we need a repeatable test fleet so future
+regressions are caught.
+
+- [ ] **8.1 Define the test matrix.**
+
+```
+            | iOS 17 | iOS 18 | macOS Sonoma | TuneBlade Win | AirMusic Android
+ESP32-WROOM | ✓      | ✓      | ✓            | ✓             | ✓
+ESP32-S3    | ✓      | ✓      | ✓            | ✓             | ✓
+SqueezeAMP  | ✓      | ✓      | -            | ✓             | -
+Esparagus   | ✓      | ✓      | ✓            | ✓             | -
+Esparagus+ETH | ✓    | ✓      | ✓            | ✓             | -
+```
+
+  For each cell, exercise: pair → play 30 s → pause → seek → reconnect → unpair.
+
+- [ ] **8.2 Add structured tracing.** Compile-time-gated `TRACE(...)` macro that
+  emits `subsystem | event | rtp_seq | rtp_ts | local_ns | network_ns` lines via
+  `ESP_LOGI`. Disabled by default; enable per-subsystem via menuconfig. Helps
+  field-debug user-reported sync issues.
+
+- [ ] **8.3 Bench fixtures.** Build a Linux script (`scripts/bench/inject_loss.sh`)
+  that uses `tc qdisc netem` to inject loss/jitter on the AP-side. Document in
+  `docs/BENCH.md`.
+
+- [ ] **8.4 GitHub Actions on PR.** Add a CI job that builds all four sdkconfig
+  variants (esp32, esp32s3, squeezeamp, esparagus) and runs `clang-tidy`. Manual
+  field test required for merge — document in `CONTRIBUTING.md`.
+
+- [ ] **8.5 Commit** `chore: test matrix + structured tracing + CI build variants`.
+
+---
+
+## Cross-Phase Reference: Findings Catalog
+
+Severity legend: **C**ritical / **H**igh / **M**edium / **L**ow.
+
+| #  | Sev | Where                                          | Phase |
+| -- | --- | ---------------------------------------------- | ----- |
+| 1  | C   | `srp.c:311-328` — verify uses hardcoded `"3939"` | 1.1   |
+| 2  | C   | `hap_pair_setup.c:155-211` — M5 never emits M6 | 1.3   |
+| 3  | C   | `hap_pair_verify.c:296` — raw verify skips Ed25519 | 1.5   |
+| 4  | C   | `mdns_airplay.c:80` — `pi=` is all-zero        | 1.6–1.7 |
+| 5  | C   | `wifi_get_mac_str()` — always `WIFI_STA_DEF`   | 1.8–1.10 |
+| 6  | C   | `audio_stream_realtime.c:447` — AP1 anchor RTP wrong | 2.1 |
+| 7  | C   | `audio_stream_realtime.c:463` — AP2 anchor RTP wrong | 2.2 |
+| 8  | H   | `audio_timing.c:195` — `clock_id` discarded    | 2.3   |
+| 9  | H   | `rtsp_handlers.c:1265` — `Audio-Latency: 0`     | 2.6   |
+| 10 | H   | no mutex on `audio_timing_t` anchor            | 2.7   |
+| 11 | H   | `ntp_clock.c` — no gradient/drift model        | 2.4   |
+| 12 | H   | `ptp_clock.c` — no frequency model             | 2.5   |
+| 13 | H   | `audio_crypto.c:41` — AES-128 only             | 6.2   |
+| 14 | H   | `hap_crypto.c:57-72` — control labels for audio key | 6.3 |
+| 15 | H   | `rtsp_handlers.c:120` + `ntp_clock.c:227` — timing port mismatch | 4.1 |
+| 16 | H   | `main.c:39` — no mDNS refresh on flap          | 4.2   |
+| 17 | H   | RAOP TXT — `AIRPLAY_FORCE_V1` semantics       | 4.7   |
+| 18 | M   | `audio_stream_realtime.c` retry only on RX path | 3.3   |
+| 19 | M   | `packets_dropped += gap` over-counts loss      | 3.1   |
+| 20 | M   | 64-slot resend window                          | 3.4   |
+| 21 | M   | `srp.c:389` — non-constant-time memcmp         | 6.1   |
+| 22 | M   | `tlv8.c:76-112` — only contiguous concat       | (deferred) |
+| 23 | M   | `rtsp_handlers.c:1622` — TEARDOWN granularity  | 4.4   |
+| 24 | M   | `audio_decoder.c:210` — 24-bit ALAC truncated  | 7.5   |
+| 25 | M   | `ptp_clock.c:250` — no BMCA                    | 7.1   |
+| 26 | L   | `rtsp_handlers.c:1085` — Transport: in body    | 4.5   |
+| 27 | L   | `rtsp_message.c:32` — case-sensitive headers   | 4.6   |
+| 28 | L   | `mdns_airplay.c` — missing `txtvers`, `pw`     | 7.3   |
+| 29 | L   | `mdns_airplay.c` — no hostname collision      | 7.6   |
+| 30 | L   | `rtsp_handlers.c:689` — `/fp-setup` doesn't set v2 | (cosmetic) |
+
+---
+
+## Definition of Done (per phase)
+
+A phase is "done" when:
+
+1. All tasks committed to a feature branch named `phase-N-<short-name>`.
+2. CI passes on all four sdkconfig variants.
+3. Pre-commit hook passes (`scripts/lint.sh` clean).
+4. The acceptance criteria in the phase header are demonstrated with **video or screenshot
+   evidence** in the PR description (audio recordings count for sync).
+5. PR reviewed by at least one other contributor; user-facing changes mentioned in
+   `CHANGELOG.md` and `README.md`.
+6. Squash-merged into `feat/dual-airplay-v1-v2` (or `main` if that branch is closed).
+
+---
+
+## Open Questions for the Project Owner
+
+1. **Phase 8a (FairPlay v2):** A, B, or C? Affects scope by ~3 weeks.
+2. **Phase 3.4 (resend window size):** widen from 64 to 256 slots (more PSRAM) or stay
+   at 64 with documented limit?
+3. **Phase 4.7 (Kconfig):** add `AIRPLAY_DISABLE_V2_HANDLERS` as a separate build option,
+   or just fix the help text and keep `_FORCE_V1` as mDNS-hide-only?
+4. **Phase 7.4 (FEATURES bitmask):** authoritative list of what we promise to deliver?
+   Need the project owner to confirm AAC support, screen mirroring, etc.
+5. **Test devices available:** which iOS versions / macOS versions / non-Apple clients
+   should be in the regression matrix?
+
+---
+
+## References
+
+- `mikebrady/shairport-sync` master:
+  [`rtp.c`](https://github.com/mikebrady/shairport-sync/blob/master/rtp.c),
+  [`player.c`](https://github.com/mikebrady/shairport-sync/blob/master/player.c),
+  [`rtsp.c`](https://github.com/mikebrady/shairport-sync/blob/master/rtsp.c),
+  [`mdns_avahi.c`](https://github.com/mikebrady/shairport-sync/blob/master/mdns_avahi.c)
+- `mikebrady/nqptp` main:
+  [`nqptp.c`](https://github.com/mikebrady/nqptp/blob/main/nqptp.c),
+  [`nqptp-shm-structures.h`](https://github.com/mikebrady/nqptp/blob/main/nqptp-shm-structures.h)
+- `openairplay/airplay-spec` for protocol notes
+- HomeKit Accessory Protocol Specification (Apple, NDA — public derivative summaries
+  exist in `homebridge` / `homebridge-config-ui` source trees)

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -348,15 +348,21 @@ menu "Airplay ESP Configuration"
 
     menu "AirPlay Protocol"
         config AIRPLAY_FORCE_V1
-            bool "Force AirPlay v1 (classic) protocol"
+            bool "Legacy mode: advertise AirPlay v1 (classic) only"
             default n
             help
-                Force the receiver to advertise as an AirPlay v1 (classic)
-                device only. This disables AirPlay 2 features (HomeKit
-                pairing, encrypted transport) but enables DACP remote
-                control — iOS sends DACP-ID and Active-Remote headers in
-                AirPlay v1 mode, allowing hardware buttons to control
-                playback on the source device.
+                By default the receiver accepts BOTH AirPlay 1 (classic
+                RAOP, used by TuneBlade, AirMusic, shairtunes2, older iOS
+                fallback) and AirPlay 2 (HomeKit pairing, HAP-encrypted
+                transport, used by current iOS). Protocol selection is
+                automatic based on the request shape.
+
+                Enable this option only if AirPlay 2 advertisement causes
+                problems on your network (e.g. iOS preferring AirPlay 2
+                with broken FairPlay verification). It hides the
+                _airplay._tcp service entirely, leaving only _raop._tcp
+                for classic RAOP clients. iOS will fall back to AirPlay 1
+                with DACP remote control.
 
                 When disabled (default), the receiver advertises as an
                 AirPlay 2 device. Modern iOS uses the MRP (Media Remote

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -332,15 +332,21 @@ menu "Airplay ESP Configuration"
 
     menu "AirPlay Protocol"
         config AIRPLAY_FORCE_V1
-            bool "Force AirPlay v1 (classic) protocol"
+            bool "Legacy mode: advertise AirPlay v1 (classic) only"
             default n
             help
-                Force the receiver to advertise as an AirPlay v1 (classic)
-                device only. This disables AirPlay 2 features (HomeKit
-                pairing, encrypted transport) but enables DACP remote
-                control — iOS sends DACP-ID and Active-Remote headers in
-                AirPlay v1 mode, allowing hardware buttons to control
-                playback on the source device.
+                By default the receiver accepts BOTH AirPlay 1 (classic
+                RAOP, used by TuneBlade, AirMusic, shairtunes2, older iOS
+                fallback) and AirPlay 2 (HomeKit pairing, HAP-encrypted
+                transport, used by current iOS). Protocol selection is
+                automatic based on the request shape.
+
+                Enable this option only if AirPlay 2 advertisement causes
+                problems on your network (e.g. iOS preferring AirPlay 2
+                with broken FairPlay verification). It hides the
+                _airplay._tcp service entirely, leaving only _raop._tcp
+                for classic RAOP clients. iOS will fall back to AirPlay 1
+                with DACP remote control.
 
                 When disabled (default), the receiver advertises as an
                 AirPlay 2 device. Modern iOS uses the MRP (Media Remote

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -30,6 +30,14 @@ static void audio_receiver_reset_stats(void) {
   memset(&receiver.stats, 0, sizeof(receiver.stats));
 }
 
+static void audio_receiver_reset_resend_state(void) {
+  receiver.rtp_sequence_valid = false;
+  receiver.resend_window_first = 0;
+  receiver.resend_missing_mask = 0;
+  receiver.resend_last_request_time_us = 0;
+  receiver.last_resend_error_time_us = 0;
+}
+
 static void audio_receiver_reset_blocks(void) {
   receiver.blocks_read = 0;
   receiver.blocks_read_in_sequence = 0;
@@ -443,6 +451,7 @@ esp_err_t audio_receiver_start(uint16_t data_port, uint16_t control_port) {
   audio_receiver_reset_stats();
   audio_buffer_flush(&receiver.buffer);
   audio_timing_reset(&receiver.timing);
+  audio_receiver_reset_resend_state();
 
   receiver.timing.ptp_locked = ptp_clock_is_locked();
   audio_receiver_reset_blocks();
@@ -467,6 +476,7 @@ esp_err_t audio_receiver_start_buffered(uint16_t tcp_port) {
   audio_receiver_reset_stats();
   audio_buffer_flush(&receiver.buffer);
   audio_timing_reset(&receiver.timing);
+  audio_receiver_reset_resend_state();
 
   receiver.timing.ptp_locked = ptp_clock_is_locked();
   audio_receiver_reset_blocks();
@@ -499,6 +509,7 @@ void audio_receiver_set_client_control(uint32_t client_ip,
                                        uint16_t client_control_port) {
   if (client_ip == 0 || client_control_port == 0) {
     receiver.retransmit_enabled = false;
+    audio_receiver_reset_resend_state();
     return;
   }
   memset(&receiver.client_control_addr, 0,
@@ -507,7 +518,7 @@ void audio_receiver_set_client_control(uint32_t client_ip,
   receiver.client_control_addr.sin_addr.s_addr = client_ip;
   receiver.client_control_addr.sin_port = htons(client_control_port);
   receiver.retransmit_enabled = true;
-  receiver.last_resend_error_time_us = 0;
+  audio_receiver_reset_resend_state();
   ESP_LOGI(TAG, "NACK retransmission enabled, client control port %u",
            client_control_port);
 }
@@ -538,6 +549,7 @@ void audio_receiver_stop(void) {
   receiver.retransmit_enabled = false;
   memset(&receiver.client_control_addr, 0,
          sizeof(receiver.client_control_addr));
+  audio_receiver_reset_resend_state();
 
   audio_receiver_flush();
 }
@@ -577,6 +589,7 @@ void audio_receiver_flush(void) {
   // next track's frames.
   audio_buffer_flush(&receiver.buffer);
   audio_timing_reset(&receiver.timing);
+  audio_receiver_reset_resend_state();
 
   receiver.discard_before_rtp_valid = false;
   receiver.discard_above_rtp_valid = false;

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -14,7 +14,6 @@
 #include "audio_receiver.h"
 #include "audio_stream.h"
 #include "audio_timing.h"
-#include "spiram_task.h"
 
 #define MAX_RTP_PACKET_SIZE 2048
 
@@ -40,7 +39,6 @@ typedef struct {
   int buffered_client_socket;
   uint16_t buffered_port;
   TaskHandle_t buffered_task_handle;
-  spiram_task_mem_t buffered_task_mem;
   uint8_t *buffered_recv_buffer;
 
   uint8_t *decrypt_buffer;

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -51,6 +51,10 @@ typedef struct {
   struct sockaddr_in client_control_addr; // Client's control address for NACKs
   bool retransmit_enabled;                // True when client address is set
   int64_t last_resend_error_time_us;      // Backoff timer on sendto failure
+  bool rtp_sequence_valid;
+  uint16_t resend_window_first;
+  uint64_t resend_missing_mask;
+  int64_t resend_last_request_time_us;
 
   // Post-seek RTP gates: together they form a window [discard_before_rtp,
   // discard_above_rtp] around the new anchor.  Frames outside the window are

--- a/main/audio/audio_stream.h
+++ b/main/audio/audio_stream.h
@@ -34,7 +34,3 @@ audio_stream_t *audio_stream_create_realtime(void);
 audio_stream_t *audio_stream_create_buffered(void);
 void audio_stream_destroy(audio_stream_t *stream);
 bool audio_stream_uses_buffer(audio_stream_type_t type);
-
-// Pre-allocate audio task stacks from internal heap. Call early in app_main()
-// before WiFi/ethernet init to avoid heap fragmentation issues.
-esp_err_t audio_realtime_preallocate(void);

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -167,6 +167,14 @@ static void buffered_audio_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
+static bool buffered_wait_for_task_stopped(audio_receiver_state_t *state,
+                                           int timeout_ticks) {
+  while (state->buffered_task_handle && timeout_ticks-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+  return state->buffered_task_handle == NULL;
+}
+
 static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
   audio_receiver_state_t *state = audio_stream_state(stream);
   if (stream->running) {
@@ -174,8 +182,11 @@ static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
     return ESP_OK;
   }
   if (state->buffered_task_handle) {
-    ESP_LOGW(TAG, "Buffered audio task still stopping");
-    return ESP_ERR_INVALID_STATE;
+    ESP_LOGW(TAG, "Buffered audio task still stopping, waiting");
+    if (!buffered_wait_for_task_stopped(state, 20)) {
+      ESP_LOGW(TAG, "Buffered audio task still active");
+      return ESP_ERR_INVALID_STATE;
+    }
   }
 
   uint16_t bound_port = port;
@@ -221,11 +232,7 @@ static void buffered_stop(audio_stream_t *stream) {
     state->buffered_listen_socket = -1;
   }
 
-  int timeout = 20;
-  while (state->buffered_task_handle && timeout-- > 0) {
-    vTaskDelay(pdMS_TO_TICKS(50));
-  }
-  if (state->buffered_task_handle) {
+  if (!buffered_wait_for_task_stopped(state, 20)) {
     ESP_LOGW(TAG, "Buffered audio task did not exit within timeout");
     return;
   }

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -18,9 +18,6 @@
 #define BUFFERED_AUDIO_PACKET_SIZE 8192
 #define AUDIO_BUFFERED_STACK_SIZE  4096
 
-static StaticTask_t s_buffered_tcb;
-static StackType_t *s_buffered_stack;
-
 static const char *TAG = "audio_buf";
 
 // Read exact number of bytes, but keep waiting on timeout if paused
@@ -176,6 +173,10 @@ static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
     ESP_LOGI(TAG, "Buffered audio already running, continuing");
     return ESP_OK;
   }
+  if (state->buffered_task_handle) {
+    ESP_LOGW(TAG, "Buffered audio task still stopping");
+    return ESP_ERR_INVALID_STATE;
+  }
 
   uint16_t bound_port = port;
   state->buffered_listen_socket =
@@ -187,30 +188,11 @@ static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
 
   stream->running = true;
 
-  // Allocate stack from SPIRAM on first use — the buffered task only does
-  // socket I/O and decryption, no SPI flash access, so SPIRAM is safe.
-  // This avoids competing with BT/WiFi/display for scarce internal DRAM.
-  if (!s_buffered_stack) {
-    s_buffered_stack = heap_caps_malloc(AUDIO_BUFFERED_STACK_SIZE,
-                                        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (!s_buffered_stack) {
-      // Fallback to any available memory
-      s_buffered_stack = malloc(AUDIO_BUFFERED_STACK_SIZE);
-    }
-    if (!s_buffered_stack) {
-      ESP_LOGE(TAG, "Failed to allocate buffered audio stack");
-      close(state->buffered_listen_socket);
-      state->buffered_listen_socket = -1;
-      stream->running = false;
-      return ESP_ERR_NO_MEM;
-    }
-  }
-
-  state->buffered_task_handle =
-      xTaskCreateStatic(buffered_audio_task, "buff_audio",
-                        AUDIO_BUFFERED_STACK_SIZE / sizeof(StackType_t), stream,
-                        5, s_buffered_stack, &s_buffered_tcb);
-  if (!state->buffered_task_handle) {
+  state->buffered_task_handle = NULL;
+  BaseType_t task_ret =
+      xTaskCreate(buffered_audio_task, "buff_audio", AUDIO_BUFFERED_STACK_SIZE,
+                  stream, 5, &state->buffered_task_handle);
+  if (task_ret != pdPASS || !state->buffered_task_handle) {
     ESP_LOGE(TAG, "Failed to create buffered audio task");
     close(state->buffered_listen_socket);
     state->buffered_listen_socket = -1;
@@ -223,7 +205,7 @@ static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
 
 static void buffered_stop(audio_stream_t *stream) {
   audio_receiver_state_t *state = audio_stream_state(stream);
-  if (!stream->running) {
+  if (!stream->running && !state->buffered_task_handle) {
     return;
   }
 
@@ -239,11 +221,14 @@ static void buffered_stop(audio_stream_t *stream) {
     state->buffered_listen_socket = -1;
   }
 
-  if (state->buffered_task_handle) {
-    vTaskDelay(pdMS_TO_TICKS(300));
-    state->buffered_task_handle = NULL;
+  int timeout = 20;
+  while (state->buffered_task_handle && timeout-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
   }
-  task_free_spiram(&state->buffered_task_mem);
+  if (state->buffered_task_handle) {
+    ESP_LOGW(TAG, "Buffered audio task did not exit within timeout");
+    return;
+  }
 
   if (state->buffered_recv_buffer) {
     heap_caps_free(state->buffered_recv_buffer);
@@ -268,6 +253,11 @@ static void buffered_destroy(audio_stream_t *stream) {
   }
 
   buffered_stop(stream);
+  audio_receiver_state_t *state = audio_stream_state(stream);
+  if (state->buffered_task_handle) {
+    ESP_LOGW(TAG, "Leaking buffered stream because task shutdown timed out");
+    return;
+  }
   free(stream);
 }
 

--- a/main/audio/audio_stream_realtime.c
+++ b/main/audio/audio_stream_realtime.c
@@ -500,6 +500,15 @@ static void control_receiver_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
+static bool realtime_wait_for_tasks_stopped(audio_receiver_state_t *state,
+                                            int timeout_ticks) {
+  while ((state->task_handle || state->control_task_handle) &&
+         timeout_ticks-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+  return state->task_handle == NULL && state->control_task_handle == NULL;
+}
+
 static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
   audio_receiver_state_t *state = audio_stream_state(stream);
   if (stream->running) {
@@ -508,8 +517,11 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
     return ESP_OK;
   }
   if (state->task_handle || state->control_task_handle) {
-    ESP_LOGW(TAG, "Audio receiver task still stopping");
-    return ESP_ERR_INVALID_STATE;
+    ESP_LOGW(TAG, "Audio receiver task still stopping, waiting");
+    if (!realtime_wait_for_tasks_stopped(state, 20)) {
+      ESP_LOGW(TAG, "Audio receiver task still active");
+      return ESP_ERR_INVALID_STATE;
+    }
   }
 
   uint16_t bound_port = port;
@@ -586,20 +598,8 @@ static void realtime_stop(audio_stream_t *stream) {
     state->control_socket = 0;
   }
 
-  int timeout = 20;
-  while (state->task_handle && timeout-- > 0) {
-    vTaskDelay(pdMS_TO_TICKS(50));
-  }
-  if (state->task_handle) {
+  if (!realtime_wait_for_tasks_stopped(state, 20)) {
     ESP_LOGW(TAG, "Audio receiver task did not exit within timeout");
-  }
-
-  timeout = 20;
-  while (state->control_task_handle && timeout-- > 0) {
-    vTaskDelay(pdMS_TO_TICKS(50));
-  }
-  if (state->control_task_handle) {
-    ESP_LOGW(TAG, "Control receiver task did not exit within timeout");
   }
 }
 

--- a/main/audio/audio_stream_realtime.c
+++ b/main/audio/audio_stream_realtime.c
@@ -29,39 +29,13 @@
 #define AUDIO_TASK_CORE 1
 #endif
 
-// Pre-allocated task resources — only one connection at a time, so these
-// are allocated once and reused across connections to avoid fragmentation.
-// TCBs are static BSS (small). Stacks are pre-allocated from internal heap
-// at startup (via audio_realtime_preallocate) before WiFi fragments the
-// heap. Packet buffers are allocated on first use from SPIRAM.
-static StaticTask_t s_recv_task_tcb;
-static StackType_t *s_recv_task_stack;
+// Packet buffers are allocated once from SPIRAM. Tasks are created dynamically:
+// restartable static TCBs can be corrupted if a new task reuses the TCB before
+// the idle task has removed the old self-deleted task from FreeRTOS lists.
 static uint8_t *s_recv_packet_buf;
-
-static StaticTask_t s_ctrl_task_tcb;
-static StackType_t *s_ctrl_task_stack;
 static uint8_t *s_ctrl_packet_buf;
 
 static const char *TAG = "audio_rt";
-
-esp_err_t audio_realtime_preallocate(void) {
-  if (!s_recv_task_stack) {
-    s_recv_task_stack = heap_caps_malloc(AUDIO_RECV_STACK_SIZE,
-                                         MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-  }
-  if (!s_ctrl_task_stack) {
-    s_ctrl_task_stack = heap_caps_malloc(AUDIO_CTRL_STACK_SIZE,
-                                         MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-  }
-  if (!s_recv_task_stack || !s_ctrl_task_stack) {
-    ESP_LOGE(TAG, "Failed to pre-allocate audio stacks (need %d+%d bytes)",
-             AUDIO_RECV_STACK_SIZE, AUDIO_CTRL_STACK_SIZE);
-    return ESP_ERR_NO_MEM;
-  }
-  ESP_LOGI(TAG, "Pre-allocated audio stacks (%d+%d bytes from internal heap)",
-           AUDIO_RECV_STACK_SIZE, AUDIO_CTRL_STACK_SIZE);
-  return ESP_OK;
-}
 
 typedef struct __attribute__((packed)) {
   uint8_t flags;
@@ -396,6 +370,10 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
              state->data_port);
     return ESP_OK;
   }
+  if (state->task_handle || state->control_task_handle) {
+    ESP_LOGW(TAG, "Audio receiver task still stopping");
+    return ESP_ERR_INVALID_STATE;
+  }
 
   uint16_t bound_port = port;
   state->data_socket = socket_utils_bind_udp(port, 1, 131072, &bound_port);
@@ -423,16 +401,11 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
            (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
            (unsigned long)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
 
-  if (!s_recv_task_stack) {
-    ESP_LOGE(TAG, "Receiver stack not pre-allocated — call "
-                  "audio_realtime_preallocate() at startup");
-    stream->running = false;
-    return ESP_FAIL;
-  }
-  state->task_handle = xTaskCreateStaticPinnedToCore(
-      receiver_task, "audio_recv", AUDIO_RECV_STACK_SIZE / sizeof(StackType_t),
-      stream, 8, s_recv_task_stack, &s_recv_task_tcb, AUDIO_TASK_CORE);
-  if (!state->task_handle) {
+  state->task_handle = NULL;
+  BaseType_t task_ret = xTaskCreatePinnedToCore(
+      receiver_task, "audio_recv", AUDIO_RECV_STACK_SIZE, stream, 8,
+      &state->task_handle, AUDIO_TASK_CORE);
+  if (task_ret != pdPASS || !state->task_handle) {
     ESP_LOGE(TAG, "Failed to create receiver task");
     if (state->control_socket > 0) {
       close(state->control_socket);
@@ -445,16 +418,12 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
   }
 
   if (state->control_socket > 0) {
-    state->control_task_handle =
-        s_ctrl_task_stack
-            ? xTaskCreateStaticPinnedToCore(
-                  control_receiver_task, "ctrl_recv",
-                  AUDIO_CTRL_STACK_SIZE / sizeof(StackType_t), stream, 7,
-                  s_ctrl_task_stack, &s_ctrl_task_tcb, AUDIO_TASK_CORE)
-            : NULL;
-    if (!state->control_task_handle) {
-      ESP_LOGE(TAG, "Failed to create control receiver task%s",
-               s_ctrl_task_stack ? "" : " — stack not pre-allocated");
+    state->control_task_handle = NULL;
+    task_ret = xTaskCreatePinnedToCore(
+        control_receiver_task, "ctrl_recv", AUDIO_CTRL_STACK_SIZE, stream, 7,
+        &state->control_task_handle, AUDIO_TASK_CORE);
+    if (task_ret != pdPASS || !state->control_task_handle) {
+      ESP_LOGE(TAG, "Failed to create control receiver task");
       close(state->control_socket);
       state->control_socket = 0;
     }
@@ -465,7 +434,7 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
 
 static void realtime_stop(audio_stream_t *stream) {
   audio_receiver_state_t *state = audio_stream_state(stream);
-  if (!stream->running) {
+  if (!stream->running && !state->task_handle && !state->control_task_handle) {
     return;
   }
 
@@ -480,13 +449,20 @@ static void realtime_stop(audio_stream_t *stream) {
     state->control_socket = 0;
   }
 
+  int timeout = 20;
+  while (state->task_handle && timeout-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
   if (state->task_handle) {
-    vTaskDelay(pdMS_TO_TICKS(200));
-    state->task_handle = NULL;
+    ESP_LOGW(TAG, "Audio receiver task did not exit within timeout");
+  }
+
+  timeout = 20;
+  while (state->control_task_handle && timeout-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
   }
   if (state->control_task_handle) {
-    vTaskDelay(pdMS_TO_TICKS(100));
-    state->control_task_handle = NULL;
+    ESP_LOGW(TAG, "Control receiver task did not exit within timeout");
   }
 }
 
@@ -505,6 +481,11 @@ static void realtime_destroy(audio_stream_t *stream) {
   }
 
   realtime_stop(stream);
+  audio_receiver_state_t *state = audio_stream_state(stream);
+  if (state->task_handle || state->control_task_handle) {
+    ESP_LOGW(TAG, "Leaking realtime stream because task shutdown timed out");
+    return;
+  }
   free(stream);
 }
 

--- a/main/audio/audio_stream_realtime.c
+++ b/main/audio/audio_stream_realtime.c
@@ -581,6 +581,11 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
       ESP_LOGE(TAG, "Failed to create control receiver task");
       close(state->control_socket);
       state->control_socket = 0;
+      stream->running = false;
+      close(state->data_socket);
+      state->data_socket = 0;
+      realtime_wait_for_tasks_stopped(state, 20);
+      return ESP_FAIL;
     }
   }
 

--- a/main/audio/audio_stream_realtime.c
+++ b/main/audio/audio_stream_realtime.c
@@ -16,12 +16,13 @@
 #include "audio_crypto.h"
 #include "network/socket_utils.h"
 
-#define RTP_HEADER_SIZE         12
-#define AUDIO_RECV_STACK_SIZE   12288
-#define AUDIO_CTRL_STACK_SIZE   4096
-#define STACK_LOG_INTERVAL_US   5000000
-#define RESEND_ERROR_BACKOFF_US 100000 // 100ms backoff after sendto failure
-#define MAX_RESEND_GAP          100 // Don't request retransmit for gaps > 100
+#define RTP_HEADER_SIZE          12
+#define AUDIO_RECV_STACK_SIZE    12288
+#define AUDIO_CTRL_STACK_SIZE    4096
+#define RESEND_WINDOW_BITS       64
+#define RESEND_RETRY_INTERVAL_US 250000 // Match common RAOP resend cadence
+#define RESEND_ERROR_BACKOFF_US  300000 // Backoff after sendto failure
+#define MAX_RESEND_GAP           RESEND_WINDOW_BITS
 
 #if CONFIG_FREERTOS_UNICORE
 #define AUDIO_TASK_CORE 0
@@ -82,27 +83,111 @@ static const uint8_t *parse_rtp(const uint8_t *packet, size_t len,
   return packet + header_len;
 }
 
-/* Send an AirPlay NACK (retransmission request) for missing sequence numbers.
-   Packet format: 0x80 0xD5 <seq_count_minus_1:u16> <first_seq:u16> <count:u16>
-   Sent to the client's control port via our control socket. */
-static void send_resend_request(audio_receiver_state_t *state,
-                                uint16_t first_seq, uint16_t count) {
-  if (!state->retransmit_enabled || state->control_socket <= 0) {
+static uint64_t resend_mask_for_count(uint16_t count) {
+  return count >= RESEND_WINDOW_BITS ? UINT64_MAX : ((1ULL << count) - 1ULL);
+}
+
+static void resend_slide_window(audio_receiver_state_t *state) {
+  while (state->resend_missing_mask != 0 &&
+         (state->resend_missing_mask & 1ULL) == 0) {
+    state->resend_missing_mask >>= 1;
+    state->resend_window_first++;
+  }
+
+  if (state->resend_missing_mask == 0) {
+    state->resend_last_request_time_us = 0;
+  }
+}
+
+static bool resend_mark_received(audio_receiver_state_t *state, uint16_t seq) {
+  if (state->resend_missing_mask == 0) {
+    return false;
+  }
+
+  uint16_t offset = (uint16_t)(seq - state->resend_window_first);
+  if (offset >= RESEND_WINDOW_BITS) {
+    return false;
+  }
+
+  uint64_t bit = 1ULL << offset;
+  if ((state->resend_missing_mask & bit) == 0) {
+    return false;
+  }
+
+  state->resend_missing_mask &= ~bit;
+  resend_slide_window(state);
+  return true;
+}
+
+static void resend_track_missing(audio_receiver_state_t *state,
+                                 uint16_t first_seq, uint16_t count) {
+  if (count == 0 || count > MAX_RESEND_GAP) {
     return;
+  }
+
+  if (state->resend_missing_mask == 0) {
+    state->resend_window_first = first_seq;
+    state->resend_missing_mask = resend_mask_for_count(count);
+    return;
+  }
+
+  uint16_t offset = (uint16_t)(first_seq - state->resend_window_first);
+  if (offset >= RESEND_WINDOW_BITS || offset + count > RESEND_WINDOW_BITS) {
+    // A newer gap is outside the small recovery window; abandon stale holes.
+    state->resend_window_first = first_seq;
+    state->resend_missing_mask = resend_mask_for_count(count);
+    return;
+  }
+
+  state->resend_missing_mask |= resend_mask_for_count(count) << offset;
+}
+
+static bool resend_next_range(const audio_receiver_state_t *state,
+                              uint16_t *first_seq, uint16_t *count) {
+  if (state->resend_missing_mask == 0 || !first_seq || !count) {
+    return false;
+  }
+
+  uint64_t mask = state->resend_missing_mask;
+  uint16_t first = state->resend_window_first;
+  while ((mask & 1ULL) == 0) {
+    mask >>= 1;
+    first++;
+  }
+
+  uint16_t range_count = 0;
+  while ((mask & 1ULL) != 0 && range_count < RESEND_WINDOW_BITS) {
+    range_count++;
+    mask >>= 1;
+  }
+
+  *first_seq = first;
+  *count = range_count;
+  return range_count > 0;
+}
+
+/* Send an AirTunes retransmission request for missing sequence numbers.
+   AirPlay 1 docs describe this as an RTP header without SSRC; in practice
+   (and in Shairport) the RTP timestamp word is split into first_seq/count:
+   0x80 0xD5 <rtp_seq=1:u16> <first_seq:u16> <count:u16>. */
+static bool send_resend_request(audio_receiver_state_t *state,
+                                uint16_t first_seq, uint16_t count) {
+  if (!state->retransmit_enabled || state->control_socket <= 0 || count == 0) {
+    return false;
   }
 
   /* Backoff: skip if we recently had a sendto error */
   int64_t now = esp_timer_get_time();
   if (state->last_resend_error_time_us > 0 &&
       (now - state->last_resend_error_time_us) < RESEND_ERROR_BACKOFF_US) {
-    return;
+    return false;
   }
 
   uint8_t nack[8];
   nack[0] = 0x80;
   nack[1] = 0xD5;
-  nack[2] = (uint8_t)((count - 1) >> 8);
-  nack[3] = (uint8_t)((count - 1) & 0xFF);
+  nack[2] = 0;
+  nack[3] = 1; // Shairport sends a fixed RTP sequence number for resend asks.
   nack[4] = (uint8_t)(first_seq >> 8);
   nack[5] = (uint8_t)(first_seq & 0xFF);
   nack[6] = (uint8_t)(count >> 8);
@@ -114,10 +199,71 @@ static void send_resend_request(audio_receiver_state_t *state,
   if (ret < 0) {
     state->last_resend_error_time_us = now;
     ESP_LOGD(TAG, "NACK sendto failed: %d", errno);
+    return false;
   } else {
     state->last_resend_error_time_us = 0;
     ESP_LOGD(TAG, "NACK sent: seq=%u count=%u", first_seq, count);
+    return true;
   }
+}
+
+static void resend_request_range(audio_receiver_state_t *state,
+                                 uint16_t first_seq, uint16_t count) {
+  if (send_resend_request(state, first_seq, count)) {
+    state->resend_last_request_time_us = esp_timer_get_time();
+  }
+}
+
+static void resend_retry_if_due(audio_receiver_state_t *state) {
+  uint16_t first_seq = 0;
+  uint16_t count = 0;
+  if (!resend_next_range(state, &first_seq, &count)) {
+    return;
+  }
+
+  int64_t now = esp_timer_get_time();
+  if (state->resend_last_request_time_us == 0 ||
+      (now - state->resend_last_request_time_us) >= RESEND_RETRY_INTERVAL_US) {
+    resend_request_range(state, first_seq, count);
+  }
+}
+
+static bool track_regular_rtp_sequence(audio_receiver_state_t *state,
+                                       uint16_t seq) {
+  if (!state->rtp_sequence_valid) {
+    state->rtp_sequence_valid = true;
+    state->stats.last_seq = seq;
+    return true;
+  }
+
+  uint16_t expected_seq = (uint16_t)(state->stats.last_seq + 1);
+  int16_t delta = (int16_t)(seq - expected_seq);
+  if (delta == 0) {
+    state->stats.last_seq = seq;
+    return true;
+  }
+
+  if (delta > 0) {
+    uint16_t gap = (uint16_t)delta;
+    if (gap <= MAX_RESEND_GAP) {
+      state->stats.packets_dropped += gap;
+      resend_track_missing(state, expected_seq, gap);
+      resend_request_range(state, expected_seq, gap);
+    } else {
+      ESP_LOGD(TAG, "RTP gap too large for resend: seq=%u expected=%u gap=%u",
+               seq, expected_seq, gap);
+    }
+    state->stats.last_seq = seq;
+    return true;
+  }
+
+  if (resend_mark_received(state, seq)) {
+    return true;
+  }
+
+  ESP_LOGD(TAG, "Dropping stale RTP packet seq=%u expected=%u", seq,
+           expected_seq);
+  return false;
 }
 
 static bool realtime_receive_packet(audio_stream_t *stream, uint8_t *packet,
@@ -146,9 +292,10 @@ static bool realtime_receive_packet(audio_stream_t *stream, uint8_t *packet,
   const uint8_t *rtp_data = packet;
   size_t rtp_len = (size_t)len;
 
-  /* Retransmit packets (type 0x56) have a 4-byte outer header before the
-     inner RTP packet. Strip it and parse the inner RTP normally. */
-  bool is_retransmit = (rtp_len >= 16 && rtp_data[1] == 0x56);
+  /* Retransmit packets (payload type 0x56, usually marker 0xD6) have a
+     4-byte outer header before the inner RTP packet. Strip it and parse the
+     inner RTP normally. */
+  bool is_retransmit = (rtp_len >= 16 && (rtp_data[1] & 0x7F) == 0x56);
   if (is_retransmit) {
     rtp_data += 4;
     rtp_len -= 4;
@@ -165,25 +312,16 @@ static bool realtime_receive_packet(audio_stream_t *stream, uint8_t *packet,
     return true;
   }
 
-  /* Skip gap detection and sequence tracking for retransmits — their seq
-     is old and would corrupt last_seq, causing spurious NACKs. */
-  if (!is_retransmit) {
-    if (state->stats.packets_decoded > 0) {
-      uint16_t expected_seq = (state->stats.last_seq + 1) & 0xFFFF;
-      if (seq != expected_seq) {
-        int gap = (int)seq - (int)expected_seq;
-        if (gap < 0) {
-          gap += 65536;
-        }
-        if (gap > 0 && gap < MAX_RESEND_GAP) {
-          state->stats.packets_dropped += gap;
-          send_resend_request(state, expected_seq, (uint16_t)gap);
-        }
-      }
+  if (is_retransmit) {
+    if (!resend_mark_received(state, seq)) {
+      ESP_LOGD(TAG, "Dropping stale retransmit seq=%u", seq);
+      return true;
     }
-
-    state->stats.last_seq = seq;
+  } else if (!track_regular_rtp_sequence(state, seq)) {
+    return true;
+  } else {
     state->stats.last_timestamp = timestamp;
+    resend_retry_if_due(state);
   }
 
   state->blocks_read++;
@@ -295,11 +433,10 @@ static void control_receiver_task(void *pvParameters) {
       continue;
     }
 
-    uint8_t packet_type = packet[1];
+    uint8_t packet_type = packet[1] & 0x7F;
 
     switch (packet_type) {
-    case 0xD4: // AirPlay 1 sync packet (NTP timing)
-    case 0x54: // Same as 0xD4 but without extension bit
+    case 0x54: // AirPlay 1 sync packet (NTP timing)
       // Layout (per shairport-sync / Apple protocol documentation):
       //   [4-7]  rtp_timestamp_less_latency  — the RTP frame PLAYING at the
       //          NTP time in [8-15].  This is the correct anchor RTP.
@@ -318,7 +455,7 @@ static void control_receiver_task(void *pvParameters) {
       }
       break;
 
-    case 0xD7: // AirPlay 2 anchor timing packet (PTP timing)
+    case 0x57: // AirPlay 2 anchor timing packet (PTP timing)
       // Format: [4] RTP frame, [8] PTP time ns, [16] RTP frame 2, [20] clock ID
       // The RTP timestamp at [4] is the frame that should play at the
       // PTP time — use it directly (matching the NTP anchor path).
@@ -332,7 +469,7 @@ static void control_receiver_task(void *pvParameters) {
       }
       break;
 
-    case 0xD6: { // Retransmit response — forward inner RTP to data socket
+    case 0x56: { // Retransmit response — forward inner RTP to data socket
       if (len < 8 || state->data_socket <= 0) {
         break;
       }

--- a/main/audio/audio_stream_realtime.c
+++ b/main/audio/audio_stream_realtime.c
@@ -275,6 +275,7 @@ static bool realtime_receive_packet(audio_stream_t *stream, uint8_t *packet,
                          (struct sockaddr *)src_addr, addr_len);
   if (len < 0) {
     if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      resend_retry_if_due(state);
       return true;
     }
     if (stream->running) {
@@ -317,6 +318,7 @@ static bool realtime_receive_packet(audio_stream_t *stream, uint8_t *packet,
       ESP_LOGD(TAG, "Dropping stale retransmit seq=%u", seq);
       return true;
     }
+    resend_retry_if_due(state);
   } else if (!track_regular_rtp_sequence(state, seq)) {
     return true;
   } else {
@@ -529,6 +531,10 @@ static esp_err_t realtime_start(audio_stream_t *stream, uint16_t port) {
   if (state->data_socket < 0) {
     return ESP_FAIL;
   }
+  // Keep the receive loop awake so resend_retry_if_due() can repeat NACKs
+  // even when no fresh RTP packets arrive.
+  struct timeval tv = {.tv_sec = 0, .tv_usec = 100000};
+  setsockopt(state->data_socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
   state->data_port = bound_port;
 
   if (state->control_port > 0) {

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,5 @@
 #include "audio_output.h"
 #include "audio_receiver.h"
-#include "audio_stream.h"
 #include "buttons.h"
 #include "spiram_task.h"
 #include "display.h"
@@ -218,11 +217,6 @@ void app_main(void) {
 #else
   display_init(iot_board_get_handle(BOARD_I2C_DISP_ID));
 #endif
-
-  // Pre-allocate audio task stacks while internal heap is still unfragmented.
-  // WiFi/TCP/TLS allocations fragment the heap, making large contiguous
-  // allocations unreliable later.
-  ESP_ERROR_CHECK(audio_realtime_preallocate());
 
   // Try ethernet first
   bool eth_available = false;

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -126,11 +126,16 @@ void mdns_airplay_init(void) {
       {"txtvers", "1"},               // TXT record version
   };
 #else
+  // Dual-mode: include et=1 (RSA) so RAOP-only clients (TuneBlade, AirMusic,
+  // shairtunes2, etc.) accept the advertisement, while keeping et=3,5 for
+  // AirPlay 2 FairPlay/MFi-SAP. ek=1 advertises that an RSA-encrypted key
+  // can be supplied via SDP rsaaeskey: at ANNOUNCE time.
   mdns_txt_item_t raop_txt[] = {
       {"am", AIRPLAY_MODEL},
       {"cn", "0,1,2,3"},              // Audio codecs: PCM, ALAC, AAC, AAC-ELD
       {"da", "true"},                 // Digest auth
-      {"et", "0,3,5"},                // Encryption types
+      {"ek", "1"},                    // Encryption key available (RSA)
+      {"et", "0,1,3,5"},              // Encryption types
       {"ft", features_str},           // Features (same as airplay)
       {"md", AIRPLAY_METADATA_TYPES}, // Metadata types
       {"pk", pk_str},                 // Public key

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -115,11 +115,16 @@ void mdns_airplay_init(void) {
       {"txtvers", "1"},                     // TXT record version
   };
 #else
+  // Dual-mode: include et=1 (RSA) so RAOP-only clients (TuneBlade, AirMusic,
+  // shairtunes2, etc.) accept the advertisement, while keeping et=3,5 for
+  // AirPlay 2 FairPlay/MFi-SAP. ek=1 advertises that an RSA-encrypted key
+  // can be supplied via SDP rsaaeskey: at ANNOUNCE time.
   mdns_txt_item_t raop_txt[] = {
       {"am", AIRPLAY_MODEL},
       {"cn", "0,1,2,3"},     // Audio codecs: PCM, ALAC, AAC, AAC-ELD
       {"da", "true"},        // Digest auth
-      {"et", "0,3,5"},       // Encryption types
+      {"ek", "1"},           // Encryption key available (RSA)
+      {"et", "0,1,3,5"},     // Encryption types: none, RSA, FairPlay, MFi-SAP
       {"ft", features_str},  // Features (same as airplay)
       {"md", "0,1,2"},       // Metadata types
       {"pk", pk_str},        // Public key

--- a/main/network/ntp_clock.c
+++ b/main/network/ntp_clock.c
@@ -4,7 +4,6 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
@@ -35,10 +34,6 @@ typedef struct __attribute__((packed)) {
 #define TIMING_INTERVAL_MS  3000 // Send request every 3 seconds
 
 #define NTP_STACK_SIZE 3072
-
-// TCB must remain in internal DRAM. NTP is secondary to PTP for AirPlay 2 sync.
-static StaticTask_t s_ntp_tcb;
-static StackType_t *s_ntp_stack;
 
 // Timing state
 static struct {
@@ -202,8 +197,8 @@ static void ntp_task(void *pvParameters) {
 
     // Check for response (with short timeout)
     addr_len = sizeof(src_addr);
-    int len = recvfrom(ntp.socket, packet, sizeof(packet), 0,
-                       (struct sockaddr *)&src_addr, &addr_len);
+    ssize_t len = recvfrom(ntp.socket, packet, sizeof(packet), 0,
+                           (struct sockaddr *)&src_addr, &addr_len);
 
     if (len < 0) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -238,6 +233,10 @@ esp_err_t ntp_clock_start_client(uint32_t remote_ip, uint16_t remote_port) {
     }
     // Stop existing and restart with new target
     ntp_clock_stop();
+    if (ntp.task_handle != NULL) {
+      ESP_LOGE(TAG, "Previous NTP task did not stop");
+      return ESP_ERR_INVALID_STATE;
+    }
   }
 
   ntp.socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -265,17 +264,10 @@ esp_err_t ntp_clock_start_client(uint32_t remote_ip, uint16_t remote_port) {
   memset(ntp.dispersions, 0, sizeof(ntp.dispersions));
   ntp.running = true;
 
-  if (!s_ntp_stack) {
-    s_ntp_stack =
-        heap_caps_malloc(NTP_STACK_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (!s_ntp_stack) {
-      s_ntp_stack = malloc(NTP_STACK_SIZE);
-    }
-  }
-  ntp.task_handle = xTaskCreateStatic(ntp_task, "ntp_clock",
-                                      NTP_STACK_SIZE / sizeof(StackType_t),
-                                      NULL, 5, s_ntp_stack, &s_ntp_tcb);
-  if (ntp.task_handle == NULL) {
+  ntp.task_handle = NULL;
+  BaseType_t task_ret = xTaskCreate(ntp_task, "ntp_clock", NTP_STACK_SIZE, NULL,
+                                    5, &ntp.task_handle);
+  if (task_ret != pdPASS || ntp.task_handle == NULL) {
     ESP_LOGE(TAG, "Failed to create NTP task");
     close(ntp.socket);
     ntp.socket = -1;
@@ -305,6 +297,9 @@ void ntp_clock_stop(void) {
     // Wait for task to finish
     for (int i = 0; i < 20 && ntp.task_handle != NULL; i++) {
       vTaskDelay(pdMS_TO_TICKS(50));
+    }
+    if (ntp.task_handle != NULL) {
+      ESP_LOGW(TAG, "NTP task did not exit within timeout");
     }
   }
 

--- a/main/network/ntp_clock.c
+++ b/main/network/ntp_clock.c
@@ -224,6 +224,13 @@ static void ntp_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
+static bool ntp_wait_for_task_stopped(int timeout_ticks) {
+  while (ntp.task_handle != NULL && timeout_ticks-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+  return ntp.task_handle == NULL;
+}
+
 esp_err_t ntp_clock_start_client(uint32_t remote_ip, uint16_t remote_port) {
   if (ntp.running) {
     // If already running to same target, keep going
@@ -233,8 +240,15 @@ esp_err_t ntp_clock_start_client(uint32_t remote_ip, uint16_t remote_port) {
     }
     // Stop existing and restart with new target
     ntp_clock_stop();
-    if (ntp.task_handle != NULL) {
+    if (!ntp_wait_for_task_stopped(20)) {
       ESP_LOGE(TAG, "Previous NTP task did not stop");
+      return ESP_ERR_INVALID_STATE;
+    }
+  }
+  if (ntp.task_handle != NULL) {
+    ESP_LOGW(TAG, "NTP task still stopping, waiting");
+    if (!ntp_wait_for_task_stopped(20)) {
+      ESP_LOGE(TAG, "NTP task still active");
       return ESP_ERR_INVALID_STATE;
     }
   }
@@ -294,11 +308,7 @@ void ntp_clock_stop(void) {
   }
 
   if (ntp.task_handle) {
-    // Wait for task to finish
-    for (int i = 0; i < 20 && ntp.task_handle != NULL; i++) {
-      vTaskDelay(pdMS_TO_TICKS(50));
-    }
-    if (ntp.task_handle != NULL) {
+    if (!ntp_wait_for_task_stopped(20)) {
       ESP_LOGW(TAG, "NTP task did not exit within timeout");
     }
   }

--- a/main/rtsp/rtsp_conn.h
+++ b/main/rtsp/rtsp_conn.h
@@ -53,6 +53,12 @@ struct rtsp_conn {
   // DACP identifiers for sending commands back to the client
   char dacp_id[32];       // DACP-ID header (hex string)
   char active_remote[32]; // Active-Remote header (token string)
+
+  // AirPlay protocol version detected from request shape:
+  //   0 = unknown (handshake not complete)
+  //   1 = classic RAOP (Apple-Challenge / rsaaeskey / Transport: header)
+  //   2 = AirPlay 2 (HAP / bplist streams)
+  uint8_t protocol_version;
 };
 
 /**

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -417,11 +417,12 @@ static void handle_options(int socket, rtsp_conn_t *conn,
       "OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, SETPEERS, "
       "SETRATEANCHORTIME\r\n";
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1: handle Apple-Challenge if present
+  // AirPlay v1: handle Apple-Challenge if present. Triggered by request
+  // shape, so safe unconditionally — iOS in AirPlay 2 mode does not send
+  // this header.
   const char *challenge = parse_raw_header(raw, raw_len, "Apple-Challenge:");
   if (challenge) {
-    // Get our IP and MAC
+    conn->protocol_version = 1;
     esp_netif_ip_info_t ip_info;
     esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
     if (netif && esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
@@ -442,10 +443,6 @@ static void handle_options(int socket, rtsp_conn_t *conn,
     }
     ESP_LOGW(TAG, "Failed to build Apple-Challenge response");
   }
-#else
-  (void)raw;
-  (void)raw_len;
-#endif
 
   rtsp_send_response(socket, conn, 200, "OK", req->cseq, public_methods, NULL,
                      0);
@@ -541,6 +538,7 @@ static void handle_post(int socket, rtsp_conn_t *conn,
   size_t body_len = req->body_len;
 
   if (strstr(req->path, "/pair-setup")) {
+    conn->protocol_version = 2;
     // Create session if needed
     if (!conn->hap_session) {
       conn->hap_session = hap_session_create();
@@ -608,6 +606,7 @@ static void handle_post(int socket, rtsp_conn_t *conn,
     free(response);
 
   } else if (strstr(req->path, "/pair-verify")) {
+    conn->protocol_version = 2;
     if (!conn->hap_session) {
       conn->hap_session = hap_session_create();
       if (!conn->hap_session) {
@@ -815,11 +814,13 @@ static void parse_sdp(rtsp_conn_t *conn, const char *sdp, size_t len) {
     format.max_samples_per_frame = 1024;
   }
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1: parse RSA-encrypted AES key and IV from SDP
+  // AirPlay v1: parse RSA-encrypted AES key and IV from SDP. Triggered by
+  // SDP shape so safe unconditionally — AirPlay 2 uses HAP-derived keys
+  // and never embeds rsaaeskey in ANNOUNCE.
   const char *rsaaeskey = strcasestr(sdp, "rsaaeskey:");
   const char *aesiv_str = strcasestr(sdp, "aesiv:");
   if (rsaaeskey && aesiv_str) {
+    conn->protocol_version = 1;
     // Extract base64 key (may span multiple lines, concatenate until next
     // field or end of SDP). In practice it's a single long base64 line.
     rsaaeskey += strlen("rsaaeskey:");
@@ -883,7 +884,6 @@ static void parse_sdp(rtsp_conn_t *conn, const char *sdp, size_t len) {
                aes_key_len, iv_len);
     }
   }
-#endif
 
   // Update connection state
   strlcpy(conn->codec, format.codec, sizeof(conn->codec));
@@ -935,6 +935,7 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
            stream_count);
 
   if (body && body_len > 0 && is_bplist && request_has_streams) {
+    conn->protocol_version = 2;
     for (size_t i = 0; i < stream_count; i++) {
       int64_t stream_type = -1;
       size_t ekey_len = 0, eiv_len = 0, shk_len = 0;
@@ -1057,12 +1058,12 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
 
   // Handle initial SETUP vs stream SETUP
   if (!request_has_streams) {
-#ifdef CONFIG_AIRPLAY_FORCE_V1
     // AirPlay v1: SETUP has no bplist body — transport info is in the header.
-    // Check for a Transport header to distinguish from an AirPlay 2 initial
-    // SETUP (which has no streams and no Transport header).
+    // Detected by request shape (Transport: header present); AirPlay 2's
+    // initial SETUP has neither streams nor a Transport header.
     if (raw && strstr((const char *)raw, "Transport:")) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
+      conn->protocol_version = 1;
       int64_t stream_type = 96; // RTP
       conn->stream_type = stream_type;
 
@@ -1101,7 +1102,6 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
       conn->stream_active = true;
       return;
     }
-#endif // CONFIG_AIRPLAY_FORCE_V1
 
     ESP_LOGI(TAG, "SETUP: Initial connection setup (no streams)");
 
@@ -1640,11 +1640,12 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
   if (!has_streams) {
     // Full teardown — server cleanup will emit RTSP_EVENT_DISCONNECTED
     // when the TCP connection closes.
-#ifndef CONFIG_AIRPLAY_FORCE_V1
-    // In v1 mode, keep DACP session alive so the grace period can
-    // probe mDNS to differentiate pause from real disconnect.
-    dacp_clear_session();
-#endif
+    // For v1 sessions, keep the DACP session alive across teardown so the
+    // grace period can probe mDNS to differentiate pause from real
+    // disconnect. v2 sessions clear immediately.
+    if (conn->protocol_version != 1) {
+      dacp_clear_session();
+    }
     conn->dacp_id[0] = '\0';
     conn->active_remote[0] = '\0';
     ntp_clock_stop();

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1060,8 +1060,9 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   if (!request_has_streams) {
     // AirPlay v1: SETUP has no bplist body — transport info is in the header.
     // Detected by request shape (Transport: header present); AirPlay 2's
-    // initial SETUP has neither streams nor a Transport header.
-    if (raw && strstr((const char *)raw, "Transport:")) {
+    // initial SETUP has neither streams nor a Transport header. RTSP header
+    // names are case-insensitive (RFC 2326 §12), so use strcasestr.
+    if (raw && strcasestr((const char *)raw, "Transport:")) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
       conn->protocol_version = 1;
       int64_t stream_type = 96; // RTP

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1061,8 +1061,9 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   if (!request_has_streams) {
     // AirPlay v1: SETUP has no bplist body — transport info is in the header.
     // Detected by request shape (Transport: header present); AirPlay 2's
-    // initial SETUP has neither streams nor a Transport header.
-    if (raw && strstr((const char *)raw, "Transport:")) {
+    // initial SETUP has neither streams nor a Transport header. RTSP header
+    // names are case-insensitive (RFC 2326 §12), so use strcasestr.
+    if (raw && strcasestr((const char *)raw, "Transport:")) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
       conn->protocol_version = 1;
       int64_t stream_type = 96; // RTP

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -417,11 +417,12 @@ static void handle_options(int socket, rtsp_conn_t *conn,
       "OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, SETPEERS, "
       "SETRATEANCHORTIME\r\n";
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1: handle Apple-Challenge if present
+  // AirPlay v1: handle Apple-Challenge if present. Triggered by request
+  // shape, so safe unconditionally — iOS in AirPlay 2 mode does not send
+  // this header.
   const char *challenge = parse_raw_header(raw, raw_len, "Apple-Challenge:");
   if (challenge) {
-    // Get our IP and MAC
+    conn->protocol_version = 1;
     esp_netif_ip_info_t ip_info;
     esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
     if (netif && esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
@@ -442,10 +443,6 @@ static void handle_options(int socket, rtsp_conn_t *conn,
     }
     ESP_LOGW(TAG, "Failed to build Apple-Challenge response");
   }
-#else
-  (void)raw;
-  (void)raw_len;
-#endif
 
   rtsp_send_response(socket, conn, 200, "OK", req->cseq, public_methods, NULL,
                      0);
@@ -542,6 +539,7 @@ static void handle_post(int socket, rtsp_conn_t *conn,
   size_t body_len = req->body_len;
 
   if (strstr(req->path, "/pair-setup")) {
+    conn->protocol_version = 2;
     // Create session if needed
     if (!conn->hap_session) {
       conn->hap_session = hap_session_create();
@@ -609,6 +607,7 @@ static void handle_post(int socket, rtsp_conn_t *conn,
     free(response);
 
   } else if (strstr(req->path, "/pair-verify")) {
+    conn->protocol_version = 2;
     if (!conn->hap_session) {
       conn->hap_session = hap_session_create();
       if (!conn->hap_session) {
@@ -816,11 +815,13 @@ static void parse_sdp(rtsp_conn_t *conn, const char *sdp, size_t len) {
     format.max_samples_per_frame = 1024;
   }
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1: parse RSA-encrypted AES key and IV from SDP
+  // AirPlay v1: parse RSA-encrypted AES key and IV from SDP. Triggered by
+  // SDP shape so safe unconditionally — AirPlay 2 uses HAP-derived keys
+  // and never embeds rsaaeskey in ANNOUNCE.
   const char *rsaaeskey = strcasestr(sdp, "rsaaeskey:");
   const char *aesiv_str = strcasestr(sdp, "aesiv:");
   if (rsaaeskey && aesiv_str) {
+    conn->protocol_version = 1;
     // Extract base64 key (may span multiple lines, concatenate until next
     // field or end of SDP). In practice it's a single long base64 line.
     rsaaeskey += strlen("rsaaeskey:");
@@ -884,7 +885,6 @@ static void parse_sdp(rtsp_conn_t *conn, const char *sdp, size_t len) {
                aes_key_len, iv_len);
     }
   }
-#endif
 
   // Update connection state
   strncpy(conn->codec, format.codec, sizeof(conn->codec) - 1);
@@ -936,6 +936,7 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
            stream_count);
 
   if (body && body_len > 0 && is_bplist && request_has_streams) {
+    conn->protocol_version = 2;
     for (size_t i = 0; i < stream_count; i++) {
       int64_t stream_type = -1;
       size_t ekey_len = 0, eiv_len = 0, shk_len = 0;
@@ -1058,12 +1059,12 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
 
   // Handle initial SETUP vs stream SETUP
   if (!request_has_streams) {
-#ifdef CONFIG_AIRPLAY_FORCE_V1
     // AirPlay v1: SETUP has no bplist body — transport info is in the header.
-    // Check for a Transport header to distinguish from an AirPlay 2 initial
-    // SETUP (which has no streams and no Transport header).
+    // Detected by request shape (Transport: header present); AirPlay 2's
+    // initial SETUP has neither streams nor a Transport header.
     if (raw && strstr((const char *)raw, "Transport:")) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
+      conn->protocol_version = 1;
       int64_t stream_type = 96; // RTP
       conn->stream_type = stream_type;
 
@@ -1102,7 +1103,6 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
       conn->stream_active = true;
       return;
     }
-#endif // CONFIG_AIRPLAY_FORCE_V1
 
     ESP_LOGI(TAG, "SETUP: Initial connection setup (no streams)");
 
@@ -1629,11 +1629,12 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
   if (!has_streams) {
     // Full teardown — server cleanup will emit RTSP_EVENT_DISCONNECTED
     // when the TCP connection closes.
-#ifndef CONFIG_AIRPLAY_FORCE_V1
-    // In v1 mode, keep DACP session alive so the grace period can
-    // probe mDNS to differentiate pause from real disconnect.
-    dacp_clear_session();
-#endif
+    // For v1 sessions, keep the DACP session alive across teardown so the
+    // grace period can probe mDNS to differentiate pause from real
+    // disconnect. v2 sessions clear immediately.
+    if (conn->protocol_version != 1) {
+      dacp_clear_session();
+    }
     conn->dacp_id[0] = '\0';
     conn->active_remote[0] = '\0';
     ntp_clock_stop();

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -945,6 +945,12 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   ESP_LOGI(TAG, "SETUP: has_streams=%d, stream_count=%zu", request_has_streams,
            stream_count);
 
+  // AirPlay v1 stream SETUP is identified by a Transport header and no bplist
+  // streams array. Classify it before opening AirPlay 2-only resources.
+  bool is_v1_transport_setup =
+      !request_has_streams && raw &&
+      strcasestr((const char *)raw, "Transport:") != NULL;
+
   if (body && body_len > 0 && is_bplist && request_has_streams) {
     conn->protocol_version = 2;
     for (size_t i = 0; i < stream_count; i++) {
@@ -1059,7 +1065,7 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   }
 
   // Create event port if needed
-  if (conn->event_port == 0) {
+  if (!is_v1_transport_setup && conn->event_port == 0) {
     conn->event_socket = rtsp_create_event_socket(&conn->event_port);
     if (conn->event_socket >= 0) {
       if (rtsp_start_event_port_task(conn->event_socket) == ESP_OK) {
@@ -1081,7 +1087,7 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
     // Detected by request shape (Transport: header present); AirPlay 2's
     // initial SETUP has neither streams nor a Transport header. RTSP header
     // names are case-insensitive (RFC 2326 §12), so use strcasestr.
-    if (raw && strcasestr((const char *)raw, "Transport:")) {
+    if (is_v1_transport_setup) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
       conn->protocol_version = 1;
       int64_t stream_type = 96; // RTP

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -231,10 +231,17 @@ static void event_port_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
+static bool event_port_wait_for_task_stopped(int timeout_ticks) {
+  while (event_task_handle != NULL && timeout_ticks-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+  return event_task_handle == NULL;
+}
+
 esp_err_t rtsp_start_event_port_task(int listen_socket) {
   if (event_task_handle != NULL) {
     rtsp_stop_event_port_task();
-    if (event_task_handle != NULL) {
+    if (!event_port_wait_for_task_stopped(20)) {
       ESP_LOGE(TAG, "Previous event port task did not stop");
       return ESP_ERR_INVALID_STATE;
     }
@@ -273,13 +280,7 @@ void rtsp_stop_event_port_task(void) {
     shutdown(event_listen_socket, SHUT_RDWR);
   }
 
-  // Wait for task to exit
-  int timeout = 20;
-  while (event_task_handle != NULL && timeout > 0) {
-    vTaskDelay(pdMS_TO_TICKS(50));
-    timeout--;
-  }
-  if (event_task_handle != NULL) {
+  if (!event_port_wait_for_task_stopped(20)) {
     ESP_LOGW(TAG, "Event port task did not exit within timeout");
   }
 }
@@ -351,24 +352,50 @@ static const rtsp_method_handler_t method_handlers[] = {
 static const char *parse_raw_header(const uint8_t *raw, size_t raw_len,
                                     const char *name) {
   static char value_buf[64];
-  const char *hdr = strcasestr((const char *)raw, name);
-  if (!hdr || (size_t)(hdr - (const char *)raw) >= raw_len) {
+  if (!raw || !name) {
     return NULL;
   }
-  hdr += strlen(name);
-  // Skip optional whitespace
-  while (*hdr == ' ' || *hdr == '\t') {
-    hdr++;
+
+  const uint8_t *header_end = rtsp_find_header_end(raw, raw_len);
+  if (!header_end) {
+    return NULL;
   }
-  // Copy until CR/LF
-  size_t i = 0;
-  while (i < sizeof(value_buf) - 1 && hdr[i] && hdr[i] != '\r' &&
-         hdr[i] != '\n') {
-    value_buf[i] = hdr[i];
-    i++;
+
+  const char *line = (const char *)raw;
+  const char *end = (const char *)header_end;
+  size_t name_len = strlen(name);
+
+  while (line < end) {
+    const char *line_end = line;
+    while (line_end < end && *line_end != '\r' && *line_end != '\n') {
+      line_end++;
+    }
+
+    if ((size_t)(line_end - line) >= name_len &&
+        strncasecmp(line, name, name_len) == 0) {
+      const char *hdr = line + name_len;
+      // Skip optional whitespace
+      while (hdr < line_end && (*hdr == ' ' || *hdr == '\t')) {
+        hdr++;
+      }
+
+      size_t i = 0;
+      while (i < sizeof(value_buf) - 1 && hdr < line_end) {
+        value_buf[i] = *hdr;
+        hdr++;
+        i++;
+      }
+      value_buf[i] = '\0';
+      return value_buf;
+    }
+
+    line = line_end;
+    while (line < end && (*line == '\r' || *line == '\n')) {
+      line++;
+    }
   }
-  value_buf[i] = '\0';
-  return value_buf;
+
+  return NULL;
 }
 
 int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
@@ -948,8 +975,8 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   // AirPlay v1 stream SETUP is identified by a Transport header and no bplist
   // streams array. Classify it before opening AirPlay 2-only resources.
   bool is_v1_transport_setup =
-      !request_has_streams && raw &&
-      strcasestr((const char *)raw, "Transport:") != NULL;
+      !request_has_streams &&
+      parse_raw_header(raw, raw_len, "Transport:") != NULL;
 
   if (body && body_len > 0 && is_bplist && request_has_streams) {
     conn->protocol_version = 2;
@@ -1085,8 +1112,7 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   if (!request_has_streams) {
     // AirPlay v1: SETUP has no bplist body — transport info is in the header.
     // Detected by request shape (Transport: header present); AirPlay 2's
-    // initial SETUP has neither streams nor a Transport header. RTSP header
-    // names are case-insensitive (RFC 2326 §12), so use strcasestr.
+    // initial SETUP has neither streams nor a Transport header.
     if (is_v1_transport_setup) {
       ESP_LOGI(TAG, "SETUP: AirPlay v1 stream setup");
       conn->protocol_version = 1;

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -85,8 +85,6 @@ static int event_client_socket = -1;
 static int event_listen_socket = -1;
 static TaskHandle_t event_task_handle = NULL;
 static volatile bool event_task_should_stop = false;
-static StaticTask_t s_event_tcb;
-static StackType_t s_event_stack[EVENT_STACK_SIZE / sizeof(StackType_t)];
 
 void rtsp_get_device_id(char *device_id, size_t len) {
   uint8_t mac[6];
@@ -233,15 +231,26 @@ static void event_port_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
-void rtsp_start_event_port_task(int listen_socket) {
+esp_err_t rtsp_start_event_port_task(int listen_socket) {
   if (event_task_handle != NULL) {
     rtsp_stop_event_port_task();
+    if (event_task_handle != NULL) {
+      ESP_LOGE(TAG, "Previous event port task did not stop");
+      return ESP_ERR_INVALID_STATE;
+    }
   }
   event_task_should_stop = false;
   event_listen_socket = -1;
-  event_task_handle = xTaskCreateStatic(
-      event_port_task, "event_port", EVENT_STACK_SIZE / sizeof(StackType_t),
-      (void *)(intptr_t)listen_socket, 5, s_event_stack, &s_event_tcb);
+  event_task_handle = NULL;
+  BaseType_t ret =
+      xTaskCreate(event_port_task, "event_port", EVENT_STACK_SIZE,
+                  (void *)(intptr_t)listen_socket, 5, &event_task_handle);
+  if (ret != pdPASS) {
+    event_task_handle = NULL;
+    ESP_LOGE(TAG, "Failed to create event port task");
+    return ESP_FAIL;
+  }
+  return ESP_OK;
 }
 
 int rtsp_event_port_listen_socket(void) {
@@ -270,7 +279,9 @@ void rtsp_stop_event_port_task(void) {
     vTaskDelay(pdMS_TO_TICKS(50));
     timeout--;
   }
-  // No need to free — static allocation
+  if (event_task_handle != NULL) {
+    ESP_LOGW(TAG, "Event port task did not exit within timeout");
+  }
 }
 
 // Forward declarations of handlers
@@ -1051,8 +1062,16 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   if (conn->event_port == 0) {
     conn->event_socket = rtsp_create_event_socket(&conn->event_port);
     if (conn->event_socket >= 0) {
-      rtsp_start_event_port_task(conn->event_socket);
-      ESP_LOGI(TAG, "SETUP: Created event port %u", conn->event_port);
+      if (rtsp_start_event_port_task(conn->event_socket) == ESP_OK) {
+        ESP_LOGI(TAG, "SETUP: Created event port %u", conn->event_port);
+      } else {
+        close(conn->event_socket);
+        conn->event_socket = -1;
+        conn->event_port = 0;
+        rtsp_send_response(socket, conn, 500, "Internal Error", req->cseq, NULL,
+                           NULL, 0);
+        return;
+      }
     }
   }
 

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -142,6 +142,39 @@ static void ensure_stream_ports(rtsp_conn_t *conn, bool buffered) {
   }
 }
 
+static bool start_ntp_timing_or_fail(int socket, rtsp_conn_t *conn,
+                                     const rtsp_request_t *req) {
+  if (conn->client_timing_port == 0 || conn->client_ip == 0) {
+    return true;
+  }
+
+  esp_err_t err =
+      ntp_clock_start_client(conn->client_ip, conn->client_timing_port);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to start NTP timing client: %s",
+             esp_err_to_name(err));
+    rtsp_send_response(socket, conn, 500, "Internal Error", req->cseq, NULL,
+                       NULL, 0);
+    return false;
+  }
+  return true;
+}
+
+static bool start_audio_receiver_or_fail(int socket, rtsp_conn_t *conn,
+                                         const rtsp_request_t *req,
+                                         int64_t stream_type) {
+  audio_receiver_set_stream_type((audio_stream_type_t)stream_type);
+  esp_err_t err = audio_receiver_start_stream(
+      conn->data_port, conn->control_port, conn->buffered_port);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to start audio receiver: %s", esp_err_to_name(err));
+    rtsp_send_response(socket, conn, 500, "Internal Error", req->cseq, NULL,
+                       NULL, 0);
+    return false;
+  }
+  return true;
+}
+
 // Event port task - handles AirPlay 2 session persistence
 static void event_port_task(void *pvParameters) {
   int listen_socket = (int)(intptr_t)pvParameters;
@@ -1125,9 +1158,8 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
       ESP_LOGI(TAG, "Client ports: control=%u timing=%u",
                conn->client_control_port, conn->client_timing_port);
 
-      // Start NTP timing client if client has a timing port
-      if (conn->client_timing_port > 0 && conn->client_ip != 0) {
-        ntp_clock_start_client(conn->client_ip, conn->client_timing_port);
+      if (!start_ntp_timing_or_fail(socket, conn, req)) {
+        return;
       }
 
       ensure_stream_ports(conn, false);
@@ -1200,12 +1232,17 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   uint16_t response_data_port =
       buffered ? conn->buffered_port : conn->data_port;
 
+  if (!start_audio_receiver_or_fail(socket, conn, req, stream_type)) {
+    return;
+  }
+
   if (is_bplist) {
     uint8_t plist_body[256];
     size_t plist_len = bplist_build_stream_setup(
         plist_body, sizeof(plist_body), stream_type, response_data_port,
         conn->control_port, AP2_AUDIO_BUFFER_SIZE);
     if (plist_len == 0) {
+      audio_receiver_stop();
       rtsp_send_response(socket, conn, 500, "Internal Error", req->cseq, NULL,
                          NULL, 0);
       return;
@@ -1222,9 +1259,9 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
     ESP_LOGI(TAG, "Client ports: control=%u timing=%u",
              conn->client_control_port, conn->client_timing_port);
 
-    // Start NTP timing client if client has a timing port
-    if (conn->client_timing_port > 0 && conn->client_ip != 0) {
-      ntp_clock_start_client(conn->client_ip, conn->client_timing_port);
+    if (!start_ntp_timing_or_fail(socket, conn, req)) {
+      audio_receiver_stop();
+      return;
     }
 
     char transport_response[256];
@@ -1236,11 +1273,6 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
     rtsp_send_response(socket, conn, 200, "OK", req->cseq, transport_response,
                        NULL, 0);
   }
-
-  // Start audio receiver
-  audio_receiver_set_stream_type((audio_stream_type_t)stream_type);
-  audio_receiver_start_stream(conn->data_port, conn->control_port,
-                              conn->buffered_port);
 
   // Enable NACK retransmission if we know the client's control port
   if (conn->client_control_port > 0 && conn->client_ip != 0) {
@@ -1282,8 +1314,9 @@ static void handle_record(int socket, rtsp_conn_t *conn,
     audio_receiver_set_playing(true);
   } else {
     // Fresh start or post-teardown reconnect: full stream restart.
-    audio_receiver_start_stream(conn->data_port, conn->control_port,
-                                conn->buffered_port);
+    if (!start_audio_receiver_or_fail(socket, conn, req, conn->stream_type)) {
+      return;
+    }
     if (conn->client_control_port > 0 && conn->client_ip != 0) {
       audio_receiver_set_client_control(conn->client_ip,
                                         conn->client_control_port);

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1730,9 +1730,9 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
     // disconnect. v2 sessions clear immediately.
     if (conn->protocol_version != 1) {
       dacp_clear_session();
+      conn->dacp_id[0] = '\0';
+      conn->active_remote[0] = '\0';
     }
-    conn->dacp_id[0] = '\0';
-    conn->active_remote[0] = '\0';
     ntp_clock_stop();
     conn->timing_port = 0;
   }

--- a/main/rtsp/rtsp_handlers.h
+++ b/main/rtsp/rtsp_handlers.h
@@ -3,6 +3,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "esp_err.h"
+
 #include "rtsp_conn.h"
 #include "rtsp_message.h"
 
@@ -84,6 +86,6 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
 void rtsp_get_device_id(char *device_id, size_t len);
 
 // Event port task management
-void rtsp_start_event_port_task(int listen_socket);
+esp_err_t rtsp_start_event_port_task(int listen_socket);
 void rtsp_stop_event_port_task(void);
 int rtsp_event_port_listen_socket(void);

--- a/main/rtsp/rtsp_message.c
+++ b/main/rtsp/rtsp_message.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/socket.h>
 
 #include "esp_log.h"
@@ -63,7 +64,9 @@ void rtsp_parse_transport(const char *request, uint16_t *control_port,
     *timing_port = 0;
   }
 
-  const char *transport = strstr(request, "Transport:");
+  // RTSP header names and Transport-header parameter names are
+  // case-insensitive (RFC 2326), so match accordingly.
+  const char *transport = strcasestr(request, "Transport:");
   if (!transport) {
     return;
   }
@@ -75,13 +78,13 @@ void rtsp_parse_transport(const char *request, uint16_t *control_port,
   }
 
   // Parse control_port
-  const char *cp = strstr(transport, "control_port=");
+  const char *cp = strcasestr(transport, "control_port=");
   if (cp && cp < line_end && control_port) {
     *control_port = (uint16_t)strtoul(cp + 13, NULL, 10);
   }
 
   // Parse timing_port
-  const char *tp = strstr(transport, "timing_port=");
+  const char *tp = strcasestr(transport, "timing_port=");
   if (tp && tp < line_end && timing_port) {
     *timing_port = (uint16_t)strtoul(tp + 12, NULL, 10);
   }

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -269,77 +269,80 @@ cleanup:
   audio_output_flush();
   ntp_clock_stop();
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
   // AirPlay v1 grace period: iOS sends TEARDOWN + TCP close for both pause
   // and genuine disconnect. Wait briefly and probe DACP mDNS to tell them
   // apart. Emit PAUSED immediately so listeners (e.g. BT switching) don't
-  // act on the disconnect prematurely.
-  if (!slot->should_stop) {
-    s_resume_requested = false;
-    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
-
-    // Phase 1: let mDNS settle (3 s), but exit early on resume or reconnect
-    for (int i = 0; i < 6 && !slot->should_stop; i++) {
-      vTaskDelay(pdMS_TO_TICKS(500));
-      if (s_resume_requested) {
-        ESP_LOGI(TAG, "Resume requested during Phase 1 — skipping to Phase 2");
-        break;
-      }
-    }
-
-    // Phase 2: wait for reconnect as long as DACP service is advertised.
-    // Re-probe every ~5 s. The phone unadvertises the service when the
-    // user switches away, so disappearance = genuine disconnect.
+  // act on the disconnect prematurely. Runtime-conditional on the active
+  // protocol so AirPlay 2 sessions still clear immediately.
+  if (conn && conn->protocol_version == 1) {
     if (!slot->should_stop) {
-      bool stay = dacp_probe_service() || s_resume_requested;
-      if (s_resume_requested) {
-        s_resume_requested = false;
-        ESP_LOGI(TAG, "Resume requested via button — waiting for reconnect");
-        stay = true;
-      }
-      if (stay) {
-        ESP_LOGI(TAG, "DACP still advertised — waiting for reconnect");
-      }
-      while (stay && !slot->should_stop) {
-        // Wait 5 s between probes (10 × 500 ms), checking flags each tick
-        for (int i = 0; i < 10 && !slot->should_stop; i++) {
-          vTaskDelay(pdMS_TO_TICKS(500));
-          if (s_resume_requested) {
-            s_resume_requested = false;
-            ESP_LOGI(TAG,
-                     "Resume requested via button — extending grace period");
-          }
-        }
-        if (slot->should_stop) {
+      s_resume_requested = false;
+      rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
+
+      // Phase 1: let mDNS settle (3 s), but exit early on resume or reconnect
+      for (int i = 0; i < 6 && !slot->should_stop; i++) {
+        vTaskDelay(pdMS_TO_TICKS(500));
+        if (s_resume_requested) {
+          ESP_LOGI(TAG,
+                   "Resume requested during Phase 1 — skipping to Phase 2");
           break;
         }
-        // Re-probe: still advertised?
-        stay = dacp_probe_service();
+      }
+
+      // Phase 2: wait for reconnect as long as DACP service is advertised.
+      // Re-probe every ~5 s. The phone unadvertises the service when the
+      // user switches away, so disappearance = genuine disconnect.
+      if (!slot->should_stop) {
+        bool stay = dacp_probe_service() || s_resume_requested;
+        if (s_resume_requested) {
+          s_resume_requested = false;
+          ESP_LOGI(TAG, "Resume requested via button — waiting for reconnect");
+          stay = true;
+        }
         if (stay) {
-          ESP_LOGD(TAG, "DACP still advertised — continuing wait");
-        } else {
-          ESP_LOGI(TAG, "DACP service gone — genuine disconnect");
+          ESP_LOGI(TAG, "DACP still advertised — waiting for reconnect");
+        }
+        while (stay && !slot->should_stop) {
+          // Wait 5 s between probes (10 × 500 ms), checking flags each tick
+          for (int i = 0; i < 10 && !slot->should_stop; i++) {
+            vTaskDelay(pdMS_TO_TICKS(500));
+            if (s_resume_requested) {
+              s_resume_requested = false;
+              ESP_LOGI(TAG,
+                       "Resume requested via button — extending grace period");
+            }
+          }
+          if (slot->should_stop) {
+            break;
+          }
+          // Re-probe: still advertised?
+          stay = dacp_probe_service();
+          if (stay) {
+            ESP_LOGD(TAG, "DACP still advertised — continuing wait");
+          } else {
+            ESP_LOGI(TAG, "DACP service gone — genuine disconnect");
+          }
         }
       }
-    }
 
-    if (slot->is_old) {
-      // New client connected during grace period — treat as reconnect
-      ESP_LOGI(TAG, "Client reconnected during grace period");
+      if (slot->is_old) {
+        // New client connected during grace period — treat as reconnect
+        ESP_LOGI(TAG, "Client reconnected during grace period");
+      } else {
+        ESP_LOGI(TAG, "Grace period expired — full disconnect");
+        dacp_clear_session();
+        rtsp_events_emit(RTSP_EVENT_DISCONNECTED, NULL);
+      }
     } else {
-      ESP_LOGI(TAG, "Grace period expired — full disconnect");
+      // Forcefully stopped (server shutdown or replaced by new client)
       dacp_clear_session();
       rtsp_events_emit(RTSP_EVENT_DISCONNECTED, NULL);
     }
   } else {
-    // Forcefully stopped (server shutdown or replaced by new client)
+    // v2 / unknown — no grace period, clear immediately.
     dacp_clear_session();
     rtsp_events_emit(RTSP_EVENT_DISCONNECTED, NULL);
   }
-#else
-  dacp_clear_session();
-  rtsp_events_emit(RTSP_EVENT_DISCONNECTED, NULL);
-#endif
 
   // When being replaced by a new client (is_old), skip global state changes —
   // the new session's SETUP already manages PTP and the event port task.

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -265,12 +265,14 @@ cleanup:
   audio_output_flush();
   ntp_clock_stop();
 
-  // AirPlay v1 grace period: iOS sends TEARDOWN + TCP close for both pause
-  // and genuine disconnect. Wait briefly and probe DACP mDNS to tell them
-  // apart. Emit PAUSED immediately so listeners (e.g. BT switching) don't
-  // act on the disconnect prematurely. Runtime-conditional on the active
-  // protocol so AirPlay 2 sessions still clear immediately.
-  if (conn && conn->protocol_version == 1) {
+  bool has_dacp_remote = conn && conn->protocol_version == 1 &&
+                         conn->dacp_id[0] != '\0' &&
+                         conn->active_remote[0] != '\0';
+
+  // iOS v1 pause handling needs DACP to distinguish pause from disconnect.
+  // Third-party RAOP clients often have no DACP remote; disconnect them
+  // immediately instead of delaying slot cleanup with an iOS-only grace path.
+  if (has_dacp_remote) {
     if (!slot->should_stop) {
       s_resume_requested = false;
       rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
@@ -515,9 +517,23 @@ static void server_task(void *pvParameters) {
   vTaskDelete(NULL);
 }
 
+static bool rtsp_server_wait_for_task_stopped(int timeout_ticks) {
+  while (server_task_handle != NULL && timeout_ticks-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(50));
+  }
+  return server_task_handle == NULL;
+}
+
 esp_err_t rtsp_server_start(void) {
   if (server_task_handle != NULL) {
-    return ESP_ERR_INVALID_STATE;
+    if (server_running) {
+      return ESP_ERR_INVALID_STATE;
+    }
+    ESP_LOGW(TAG, "RTSP server task still stopping, waiting");
+    if (!rtsp_server_wait_for_task_stopped(40)) {
+      ESP_LOGE(TAG, "Previous RTSP server task did not stop");
+      return ESP_ERR_INVALID_STATE;
+    }
   }
 
   BaseType_t task_ret =
@@ -540,10 +556,7 @@ void rtsp_server_stop(void) {
   }
 
   if (server_task_handle != NULL) {
-    for (int i = 0; i < 20 && server_task_handle != NULL; i++) {
-      vTaskDelay(pdMS_TO_TICKS(50));
-    }
-    if (server_task_handle != NULL) {
+    if (!rtsp_server_wait_for_task_stopped(40)) {
       ESP_LOGW(TAG, "RTSP server task did not exit within timeout");
     }
   }

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -37,13 +37,9 @@ static int server_socket = -1;
 static TaskHandle_t server_task_handle = NULL;
 static bool server_running = false;
 
-// Static task memory for client tasks (one per slot)
-static StaticTask_t s_client_tcb[2];
-static StackType_t s_client_stack[2][CLIENT_STACK_SIZE / sizeof(StackType_t)];
-
-// Static task memory for server task
-static StaticTask_t s_server_tcb;
-static StackType_t s_server_stack[SERVER_STACK_SIZE / sizeof(StackType_t)];
+// RTSP tasks are restartable. Use dynamic TCB allocation so
+// reconnect/start-stop paths cannot reuse static task memory before FreeRTOS
+// idle finishes deletion.
 
 // Client slot for tracking connections
 typedef struct {
@@ -408,6 +404,7 @@ static void server_task(void *pvParameters) {
   server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (server_socket < 0) {
     ESP_LOGE(TAG, "Failed to create socket: %d", errno);
+    server_task_handle = NULL;
     vTaskDelete(NULL);
     return;
   }
@@ -425,6 +422,7 @@ static void server_task(void *pvParameters) {
     ESP_LOGE(TAG, "Failed to bind: %d", errno);
     close(server_socket);
     server_socket = -1;
+    server_task_handle = NULL;
     vTaskDelete(NULL);
     return;
   }
@@ -433,6 +431,7 @@ static void server_task(void *pvParameters) {
     ESP_LOGE(TAG, "Failed to listen: %d", errno);
     close(server_socket);
     server_socket = -1;
+    server_task_handle = NULL;
     vTaskDelete(NULL);
     return;
   }
@@ -481,12 +480,12 @@ static void server_task(void *pvParameters) {
     clients[new_slot].should_stop = false;
     clients[new_slot].is_old = false;
 
-    // Start new client task immediately (static allocation)
-    clients[new_slot].task = xTaskCreateStatic(
-        client_task, "rtsp_client", CLIENT_STACK_SIZE / sizeof(StackType_t),
-        (void *)(intptr_t)new_slot, 5, s_client_stack[new_slot],
-        &s_client_tcb[new_slot]);
-    if (clients[new_slot].task == NULL) {
+    // Start new client task immediately.
+    clients[new_slot].task = NULL;
+    BaseType_t task_ret =
+        xTaskCreate(client_task, "rtsp_client", CLIENT_STACK_SIZE,
+                    (void *)(intptr_t)new_slot, 5, &clients[new_slot].task);
+    if (task_ret != pdPASS || clients[new_slot].task == NULL) {
       ESP_LOGE(TAG, "Failed to create client task");
       close(new_socket);
       clients[new_slot].socket = -1;
@@ -512,6 +511,7 @@ static void server_task(void *pvParameters) {
     server_socket = -1;
   }
 
+  server_task_handle = NULL;
   vTaskDelete(NULL);
 }
 
@@ -520,10 +520,10 @@ esp_err_t rtsp_server_start(void) {
     return ESP_ERR_INVALID_STATE;
   }
 
-  server_task_handle = xTaskCreateStatic(
-      server_task, "rtsp_server", SERVER_STACK_SIZE / sizeof(StackType_t), NULL,
-      5, s_server_stack, &s_server_tcb);
-  if (server_task_handle == NULL) {
+  BaseType_t task_ret =
+      xTaskCreate(server_task, "rtsp_server", SERVER_STACK_SIZE, NULL, 5,
+                  &server_task_handle);
+  if (task_ret != pdPASS || server_task_handle == NULL) {
     return ESP_FAIL;
   }
 
@@ -540,7 +540,11 @@ void rtsp_server_stop(void) {
   }
 
   if (server_task_handle != NULL) {
-    vTaskDelay(pdMS_TO_TICKS(100));
-    server_task_handle = NULL;
+    for (int i = 0; i < 20 && server_task_handle != NULL; i++) {
+      vTaskDelay(pdMS_TO_TICKS(50));
+    }
+    if (server_task_handle != NULL) {
+      ESP_LOGW(TAG, "RTSP server task did not exit within timeout");
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #66 — TuneBlade (Windows), AirMusic (Android), and other RAOP-only clients connect but no audio plays. Same root cause likely covers the duplicate issue.

The AirPlay 1 (RAOP) request handlers were gated behind `CONFIG_AIRPLAY_FORCE_V1`. With the default (v2) build, an incoming RAOP `SETUP` with a `Transport:` header fell through to the AirPlay 2 \"initial connection setup\" branch, never allocating UDP audio sockets, never returning a `Transport:` response, and never decrypting the RSA AES key from `ANNOUNCE`. Result: 200 OK responses that look successful in logs while the actual audio path is unconfigured.

This PR makes protocol selection **per-request, based on request shape**. iOS continues to use AirPlay 2; non-Apple clients now get a working AirPlay 1 path. No build-flag toggling required.

## What changed

- `OPTIONS` Apple-Challenge response runs whenever the header is present.
- `ANNOUNCE` `rsaaeskey:` / `aesiv:` parsing runs whenever the SDP contains those fields.
- `SETUP` Transport-header path runs whenever the request has a `Transport:` header and no bplist `streams[]`.
- `/pair-setup`, `/pair-verify`, and bplist `SETUP` tag the connection as v2.
- New `rtsp_conn_t::protocol_version` (0/1/2) — `TEARDOWN` keys on this so v1 keeps the DACP grace period, v2 clears immediately.
- `_raop._tcp` mDNS TXT now advertises `et=0,1,3,5` and `ek=1` so RAOP-only clients accept the advertisement.

`CONFIG_AIRPLAY_FORCE_V1` is repurposed as **legacy mode**: hides the `_airplay._tcp` service entirely for users on networks where AirPlay 2 advertisement causes problems. Default off.

## Why it's safe

iOS in AirPlay 2 mode never sends:
- An `Apple-Challenge:` header in OPTIONS
- `rsaaeskey:` / `aesiv:` in SDP (AirPlay 2 derives keys from HAP)
- A `Transport:` header in SETUP without bplist `streams[]`

So enabling all three handlers unconditionally cannot regress v2.

## Test plan
- [ ] iPhone AirPlay still works (HomeKit pair, encrypted streaming, metadata, volume).
- [ ] TuneBlade for Windows: connect, play, hear audio, control volume.
- [ ] Android AirMusic: connect, play, hear audio.
- [ ] Verify both `_airplay._tcp` and `_raop._tcp` are advertised (`dns-sd -B _airplay._tcp` / `dns-sd -B _raop._tcp` on macOS).
- [ ] Build with `CONFIG_AIRPLAY_FORCE_V1=y` (legacy mode): only `_raop._tcp` advertised, classic RAOP clients still work.
- [ ] `bash scripts/lint.sh` passes (verified locally; pre-commit hook also passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RTSP session setup, UDP audio, and FreeRTOS task lifecycle; regressions could affect iOS AirPlay 2 or third-party RAOP clients, though v1/v2 paths are meant to be mutually exclusive by request shape.
> 
> **Overview**
> Fixes **#66** by routing **AirPlay 1 (RAOP)** and **AirPlay 2** on the same build using **request shape**, instead of gating v1 behind `CONFIG_AIRPLAY_FORCE_V1`.
> 
> **RTSP / session:** v1 paths run when clients send `Apple-Challenge:`, SDP `rsaaeskey:`/`aesiv:`, or `SETUP` with `Transport:` and no bplist `streams[]`. HAP `/pair-setup` and bplist `SETUP` set `rtsp_conn_t::protocol_version` to v2. **TEARDOWN** and **TCP disconnect** use that flag so **DACP pause grace** applies only to v1 sessions that advertised DACP (third-party RAOP disconnects immediately). Header parsing is tightened (`parse_raw_header` walks headers only; case-insensitive `Transport:`). SETUP/RECORD failures return **500** when NTP or the audio receiver fails to start.
> 
> **Discovery:** Dual-mode `_raop._tcp` TXT adds **`ek=1`** and **`et=0,1,3,5`**. Kconfig **`AIRPLAY_FORCE_V1`** is documented as **legacy mDNS hide** for `_airplay._tcp`, not disabling v2 handlers.
> 
> **Audio RTP:** Realtime path gets a **64-slot NACK window**, shairport-style resend packets, retry on recv timeout, and centralized **`audio_receiver_reset_resend_state()`** on stream lifecycle events. Control sync types use **`& 0x7F`** (e.g. `0x54`/`0x57`/`0x56`).
> 
> **Runtime:** Audio/RTSP/NTP/event tasks move from **static** stacks to **dynamic** `xTaskCreate` with **join-on-stop** waits; **`audio_realtime_preallocate()`** is removed from `main.c`.
> 
> Also adds a long-form **quality roadmap** doc (future HAP/timing work; not implemented here).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65bcac7fa4fe90d45ac7854ebfaf80d6a216297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->