### PR TITLE
Add support for inverted LED outputs in configuration

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -9,6 +9,22 @@ menu "Airplay ESP Configuration"
             help
                 Brightness level for the status LED (0=off, 255=max).
 
+        config LED_STATUS_INVERT
+            bool "Invert Status LED output (active-low)"
+            default n
+            help
+                If enabled, the status LED output is inverted (active-low).
+                Use this if your LED is connected with inverted logic
+                (e.g., LED cathode to GPIO instead of anode).
+
+        config LED_ERROR_INVERT
+            bool "Invert Error LED output (active-low)"
+            default n
+            help
+                If enabled, the error LED output is inverted (active-low).
+                Use this if your LED is connected with inverted logic
+                (e.g., LED cathode to GPIO instead of anode).
+
         menu "Status LED Behavior"
             choice LED_STATUS_ON_PLAYING
                 prompt "Status LED when playing"

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -9,6 +9,22 @@ menu "Airplay ESP Configuration"
             help
                 Brightness level for the status LED (0=off, 255=max).
 
+        config LED_STATUS_INVERT
+            bool "Invert Status LED output (active-low)"
+            default y
+            help
+                If enabled, the status LED output is inverted (active-low).
+                Use this if your LED is connected with inverted logic
+                (e.g., LED cathode to GPIO instead of anode).
+
+        config LED_ERROR_INVERT
+            bool "Invert Error LED output (active-low)"
+            default y
+            help
+                If enabled, the error LED output is inverted (active-low).
+                Use this if your LED is connected with inverted logic
+                (e.g., LED cathode to GPIO instead of anode).
+
         menu "Status LED Behavior"
             choice LED_STATUS_ON_PLAYING
                 prompt "Status LED when playing"

--- a/main/led.c
+++ b/main/led.c
@@ -12,6 +12,19 @@
 
 #include <math.h>
 
+// Convert Kconfig boolean values to C macros
+#ifdef CONFIG_LED_STATUS_INVERT
+#define LED_STATUS_INVERT_VAL 1
+#else
+#define LED_STATUS_INVERT_VAL 0
+#endif
+
+#ifdef CONFIG_LED_ERROR_INVERT
+#define LED_ERROR_INVERT_VAL 1
+#else
+#define LED_ERROR_INVERT_VAL 0
+#endif
+
 static const char *TAG = "led";
 
 // ============================================================================
@@ -93,12 +106,15 @@ static uint8_t s_status_duty = CONFIG_LED_STATUS_BRIGHTNESS;
 static void status_led_set_duty(uint8_t duty) {
   ledc_set_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL, duty);
   ledc_update_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL);
+  ESP_LOGV(TAG, "Status LED duty set to %d", duty);
 }
 
 static void status_timer_cb(TimerHandle_t xTimer) {
   (void)xTimer;
   s_status_on = !s_status_on;
   status_led_set_duty(s_status_on ? s_status_duty : 0);
+  ESP_LOGD(TAG, "Status LED timer: mode=%d, state=%s", s_status_mode, 
+           s_status_on ? "ON" : "OFF");
 
   uint32_t period_ms;
   switch (s_status_mode) {
@@ -119,7 +135,10 @@ static void status_timer_cb(TimerHandle_t xTimer) {
   if (ticks == 0) {
     ticks = 1;
   }
-  xTimerChangePeriod(s_status_timer, ticks, 10);
+  BaseType_t ret = xTimerChangePeriod(s_status_timer, ticks, 10);
+  if (ret != pdPASS) {
+    ESP_LOGW(TAG, "Failed to change timer period: %d", ret);
+  }
 }
 
 static void status_led_init(void) {
@@ -143,15 +162,23 @@ static void status_led_init(void) {
       .gpio_num = CONFIG_LED_STATUS_GPIO,
       .duty = 0,
       .hpoint = 0,
-      .flags = {.output_invert = true},
+      .flags = {.output_invert = LED_STATUS_INVERT_VAL},
   };
   if (ledc_channel_config(&ch_cfg) != ESP_OK) {
     ESP_LOGE(TAG, "Status LED channel init failed");
     return;
   }
 
+  // Explicitly apply initial duty (off)
+  ledc_set_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL, 0);
+  ledc_update_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL);
+
   s_status_timer = xTimerCreate("status_led", pdMS_TO_TICKS(500), pdFALSE, NULL,
                                 status_timer_cb);
+  if (s_status_timer == NULL) {
+    ESP_LOGE(TAG, "Failed to create status LED timer");
+    return;
+  }
 
   ESP_LOGI(TAG, "Status LED initialized on GPIO %d", CONFIG_LED_STATUS_GPIO);
 }
@@ -160,30 +187,47 @@ static void status_led_set_mode(led_mode_t mode) {
   if (mode == s_status_mode) {
     return;
   }
+  ESP_LOGD(TAG, "Status LED mode change: %d -> %d", s_status_mode, mode);
   s_status_mode = mode;
 
   if (s_status_timer && xTimerIsTimerActive(s_status_timer)) {
-    xTimerStop(s_status_timer, 10);
+    BaseType_t ret = xTimerStop(s_status_timer, 10);
+    if (ret != pdPASS) {
+      ESP_LOGW(TAG, "Failed to stop status LED timer: %d", ret);
+    }
   }
 
   switch (mode) {
   case LED_OFF:
+    ESP_LOGD(TAG, "Status LED: OFF");
     status_led_set_duty(0);
     break;
   case LED_STEADY:
+    ESP_LOGD(TAG, "Status LED: STEADY (duty=%d)", s_status_duty);
     status_led_set_duty(s_status_duty);
     break;
   case LED_BLINK_SLOW:
   case LED_BLINK_MEDIUM:
   case LED_BLINK_FAST:
-    s_status_on = true;
-    status_led_set_duty(s_status_duty);
-    if (s_status_timer) {
-      xTimerStart(s_status_timer, 10);
+    // Reset state and turn LED on for first blink cycle
+    s_status_on = false;  // Will be toggled to true immediately in first timer callback
+    if (!s_status_timer) {
+      ESP_LOGE(TAG, "Status LED timer not initialized!");
+      break;
+    }
+    BaseType_t ret = xTimerStart(s_status_timer, 10);
+    if (ret != pdPASS) {
+      ESP_LOGE(TAG, "Failed to start status LED timer: %d", ret);
+    } else {
+      ESP_LOGD(TAG, "Status LED: BLINK mode %d started", mode);
+      // Immediately trigger first state to avoid initial delay
+      status_timer_cb(s_status_timer);
     }
     break;
   case LED_VU:
-    // VU mode handled by led_audio_feed
+    ESP_LOGD(TAG, "Status LED: VU mode (initial OFF)");
+    // Initialize to OFF, will be updated by led_audio_feed()
+    status_led_set_duty(0);
     break;
   }
 }
@@ -237,12 +281,17 @@ static void error_led_init(void) {
       .gpio_num = CONFIG_LED_ERROR_GPIO,
       .duty = 0,
       .hpoint = 0,
-      .flags = {.output_invert = true},
+      .flags = {.output_invert = LED_ERROR_INVERT_VAL},
   };
   if (ledc_channel_config(&ch_cfg) != ESP_OK) {
     ESP_LOGE(TAG, "Error LED channel init failed");
     return;
   }
+
+  // Explicitly apply initial duty (off)
+  ledc_set_duty(LEDC_LOW_SPEED_MODE, ERROR_LED_CHANNEL, 0);
+  ledc_update_duty(LEDC_LOW_SPEED_MODE, ERROR_LED_CHANNEL);
+
   ESP_LOGI(TAG, "Error LED initialized on GPIO %d", CONFIG_LED_ERROR_GPIO);
 }
 
@@ -401,6 +450,8 @@ static led_state_t s_current_state = STATE_STANDBY;
 static void apply_state(led_state_t state) {
   s_prev_state = s_current_state;
   s_current_state = state;
+  
+  ESP_LOGI(TAG, "LED state change: %d -> %d", s_prev_state, state);
 
   switch (state) {
   case STATE_PLAYING:
@@ -453,6 +504,7 @@ static void apply_state(led_state_t state) {
 
 static void on_rtsp_event(rtsp_event_t event, const rtsp_event_data_t *data,
                           void *user_data) {
+  ESP_LOGD(TAG, "RTSP event: %d", event);
   switch (event) {
   case RTSP_EVENT_CLIENT_CONNECTED:
     apply_state(STATE_PAUSED);
@@ -538,6 +590,12 @@ void led_audio_feed(const int16_t *pcm, size_t stereo_samples) {
 // ============================================================================
 
 void led_init(void) {
+  ESP_LOGI(TAG, "Initializing LED subsystem");
+  ESP_LOGI(TAG, "  Status LED GPIO: %d", CONFIG_LED_STATUS_GPIO);
+  ESP_LOGI(TAG, "  Error LED GPIO: %d", CONFIG_LED_ERROR_GPIO);
+  ESP_LOGI(TAG, "  RGB LED GPIO: %d", CONFIG_LED_RGB_GPIO);
+  ESP_LOGI(TAG, "  LED brightness: %d", CONFIG_LED_STATUS_BRIGHTNESS);
+
   status_led_init();
   error_led_init();
   rgb_led_init();
@@ -545,6 +603,7 @@ void led_init(void) {
   rtsp_events_register(on_rtsp_event, NULL);
 
   // Start in standby
+  ESP_LOGI(TAG, "Starting in STANDBY state");
   apply_state(STATE_STANDBY);
 
   ESP_LOGI(TAG, "LED subsystem initialized");

--- a/main/led.c
+++ b/main/led.c
@@ -12,6 +12,19 @@
 
 #include <math.h>
 
+// Convert Kconfig boolean values to C macros
+#ifdef CONFIG_LED_STATUS_INVERT
+#define LED_STATUS_INVERT_VAL 1
+#else
+#define LED_STATUS_INVERT_VAL 0
+#endif
+
+#ifdef CONFIG_LED_ERROR_INVERT
+#define LED_ERROR_INVERT_VAL 1
+#else
+#define LED_ERROR_INVERT_VAL 0
+#endif
+
 static const char *TAG = "led";
 
 // ============================================================================
@@ -93,12 +106,15 @@ static uint8_t s_status_duty = CONFIG_LED_STATUS_BRIGHTNESS;
 static void status_led_set_duty(uint8_t duty) {
   ledc_set_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL, duty);
   ledc_update_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL);
+  ESP_LOGV(TAG, "Status LED duty set to %d", duty);
 }
 
 static void status_timer_cb(TimerHandle_t xTimer) {
   (void)xTimer;
   s_status_on = !s_status_on;
   status_led_set_duty(s_status_on ? s_status_duty : 0);
+  ESP_LOGD(TAG, "Status LED timer: mode=%d, state=%s", s_status_mode,
+           s_status_on ? "ON" : "OFF");
 
   uint32_t period_ms;
   switch (s_status_mode) {
@@ -119,7 +135,10 @@ static void status_timer_cb(TimerHandle_t xTimer) {
   if (ticks == 0) {
     ticks = 1;
   }
-  xTimerChangePeriod(s_status_timer, ticks, 10);
+  BaseType_t ret = xTimerChangePeriod(s_status_timer, ticks, 10);
+  if (ret != pdPASS) {
+    ESP_LOGW(TAG, "Failed to change timer period: %d", ret);
+  }
 }
 
 static void status_led_init(void) {
@@ -143,15 +162,23 @@ static void status_led_init(void) {
       .gpio_num = CONFIG_LED_STATUS_GPIO,
       .duty = 0,
       .hpoint = 0,
-      .flags = {.output_invert = true},
+      .flags = {.output_invert = LED_STATUS_INVERT_VAL},
   };
   if (ledc_channel_config(&ch_cfg) != ESP_OK) {
     ESP_LOGE(TAG, "Status LED channel init failed");
     return;
   }
 
+  // Explicitly apply initial duty (off)
+  ledc_set_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL, 0);
+  ledc_update_duty(LEDC_LOW_SPEED_MODE, STATUS_LED_CHANNEL);
+
   s_status_timer = xTimerCreate("status_led", pdMS_TO_TICKS(500), pdFALSE, NULL,
                                 status_timer_cb);
+  if (s_status_timer == NULL) {
+    ESP_LOGE(TAG, "Failed to create status LED timer");
+    return;
+  }
 
   ESP_LOGI(TAG, "Status LED initialized on GPIO %d", CONFIG_LED_STATUS_GPIO);
 }
@@ -160,30 +187,48 @@ static void status_led_set_mode(led_mode_t mode) {
   if (mode == s_status_mode) {
     return;
   }
+  ESP_LOGD(TAG, "Status LED mode change: %d -> %d", s_status_mode, mode);
   s_status_mode = mode;
 
   if (s_status_timer && xTimerIsTimerActive(s_status_timer)) {
-    xTimerStop(s_status_timer, 10);
+    BaseType_t ret = xTimerStop(s_status_timer, 10);
+    if (ret != pdPASS) {
+      ESP_LOGW(TAG, "Failed to stop status LED timer: %d", ret);
+    }
   }
 
   switch (mode) {
   case LED_OFF:
+    ESP_LOGD(TAG, "Status LED: OFF");
     status_led_set_duty(0);
     break;
   case LED_STEADY:
+    ESP_LOGD(TAG, "Status LED: STEADY (duty=%d)", s_status_duty);
     status_led_set_duty(s_status_duty);
     break;
   case LED_BLINK_SLOW:
   case LED_BLINK_MEDIUM:
   case LED_BLINK_FAST:
-    s_status_on = true;
-    status_led_set_duty(s_status_duty);
-    if (s_status_timer) {
-      xTimerStart(s_status_timer, 10);
+    // Reset state and turn LED on for first blink cycle
+    s_status_on =
+        false; // Will be toggled to true immediately in first timer callback
+    if (!s_status_timer) {
+      ESP_LOGE(TAG, "Status LED timer not initialized!");
+      break;
+    }
+    BaseType_t ret = xTimerStart(s_status_timer, 10);
+    if (ret != pdPASS) {
+      ESP_LOGE(TAG, "Failed to start status LED timer: %d", ret);
+    } else {
+      ESP_LOGD(TAG, "Status LED: BLINK mode %d started", mode);
+      // Immediately trigger first state to avoid initial delay
+      status_timer_cb(s_status_timer);
     }
     break;
   case LED_VU:
-    // VU mode handled by led_audio_feed
+    ESP_LOGD(TAG, "Status LED: VU mode (initial OFF)");
+    // Initialize to OFF, will be updated by led_audio_feed()
+    status_led_set_duty(0);
     break;
   }
 }
@@ -237,12 +282,17 @@ static void error_led_init(void) {
       .gpio_num = CONFIG_LED_ERROR_GPIO,
       .duty = 0,
       .hpoint = 0,
-      .flags = {.output_invert = true},
+      .flags = {.output_invert = LED_ERROR_INVERT_VAL},
   };
   if (ledc_channel_config(&ch_cfg) != ESP_OK) {
     ESP_LOGE(TAG, "Error LED channel init failed");
     return;
   }
+
+  // Explicitly apply initial duty (off)
+  ledc_set_duty(LEDC_LOW_SPEED_MODE, ERROR_LED_CHANNEL, 0);
+  ledc_update_duty(LEDC_LOW_SPEED_MODE, ERROR_LED_CHANNEL);
+
   ESP_LOGI(TAG, "Error LED initialized on GPIO %d", CONFIG_LED_ERROR_GPIO);
 }
 
@@ -402,6 +452,8 @@ static void apply_state(led_state_t state) {
   s_prev_state = s_current_state;
   s_current_state = state;
 
+  ESP_LOGI(TAG, "LED state change: %d -> %d", s_prev_state, state);
+
   switch (state) {
   case STATE_PLAYING:
     status_led_set_mode(get_status_mode_playing());
@@ -453,6 +505,7 @@ static void apply_state(led_state_t state) {
 
 static void on_rtsp_event(rtsp_event_t event, const rtsp_event_data_t *data,
                           void *user_data) {
+  ESP_LOGD(TAG, "RTSP event: %d", event);
   switch (event) {
   case RTSP_EVENT_CLIENT_CONNECTED:
     apply_state(STATE_PAUSED);
@@ -538,6 +591,12 @@ void led_audio_feed(const int16_t *pcm, size_t stereo_samples) {
 // ============================================================================
 
 void led_init(void) {
+  ESP_LOGI(TAG, "Initializing LED subsystem");
+  ESP_LOGI(TAG, "  Status LED GPIO: %d", CONFIG_LED_STATUS_GPIO);
+  ESP_LOGI(TAG, "  Error LED GPIO: %d", CONFIG_LED_ERROR_GPIO);
+  ESP_LOGI(TAG, "  RGB LED GPIO: %d", CONFIG_LED_RGB_GPIO);
+  ESP_LOGI(TAG, "  LED brightness: %d", CONFIG_LED_STATUS_BRIGHTNESS);
+
   status_led_init();
   error_led_init();
   rgb_led_init();
@@ -545,6 +604,7 @@ void led_init(void) {
   rtsp_events_register(on_rtsp_event, NULL);
 
   // Start in standby
+  ESP_LOGI(TAG, "Starting in STANDBY state");
   apply_state(STATE_STANDBY);
 
   ESP_LOGI(TAG, "LED subsystem initialized");


### PR DESCRIPTION
## Summary

LED output inversion was previously hardcoded to `true` in `ledc_channel_config`. This PR makes it configurable via Kconfig, enabling boards where LEDs are wired active-high (anode to GPIO) to work correctly.

## Changes

**`main/Kconfig.projbuild`**
- New bool options `LED_STATUS_INVERT` and `LED_ERROR_INVERT` (default: `y`)
- Allows active-low (inverted) or active-high LED wiring to be selected at build time

**`main/led.c`**
- Replace hardcoded `output_invert = true` with `LED_STATUS_INVERT_VAL` / `LED_ERROR_INVERT_VAL` derived from Kconfig
- Explicit initial duty-to-zero after channel init to prevent glitch on startup
- Check return values of `xTimerStart`, `xTimerStop`, `xTimerChangePeriod` and log warnings on failure
- Fix blink startup: immediately invoke timer callback to avoid initial off-delay on first blink cycle
- Add debug/verbose logging throughout for easier diagnostics

## Notes

- Default behavior is preserved (`LED_*_INVERT = y`, active-low), matching the previous hardcoded `output_invert = true`. Boards with active-high LEDs can disable the option.