### PR TITLE
Replace PTP median filter with asymmetric smoothing (nqptp-style)

### DIFF
--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -28,6 +28,13 @@
 #define OUTPUT_RATE   CONFIG_OUTPUT_SAMPLE_RATE_HZ
 #define FRAME_SAMPLES 352
 
+// DMA ring-buffer configuration.  Total DMA latency (in samples) is
+//   I2S_DMA_DESC_NUM × I2S_DMA_FRAME_NUM
+// which at OUTPUT_RATE gives the hardware pipeline delay in µs.
+// Keep these in sync with the i2s_chan_config_t initialisation below.
+#define I2S_DMA_DESC_NUM  8
+#define I2S_DMA_FRAME_NUM 256
+
 /* Max output frames after resampling one input frame */
 #define MAX_RESAMPLE_FRAMES \
   ((size_t)((FRAME_SAMPLES + 2) * ((double)OUTPUT_RATE / 44100) + 16))
@@ -111,8 +118,8 @@ static void playback_task(void *arg) {
 esp_err_t audio_output_init(void) {
   i2s_chan_config_t chan_cfg =
       I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
-  chan_cfg.dma_desc_num = 8;
-  chan_cfg.dma_frame_num = 256;
+  chan_cfg.dma_desc_num = I2S_DMA_DESC_NUM;
+  chan_cfg.dma_frame_num = I2S_DMA_FRAME_NUM;
 
   ESP_RETURN_ON_ERROR(i2s_new_channel(&chan_cfg, &tx_handle, NULL), TAG,
                       "channel create failed");
@@ -202,4 +209,10 @@ void audio_output_set_source_rate(int rate) {
     source_rate = rate;
     resample_reinit_needed = true;
   }
+}
+
+uint32_t audio_output_get_hardware_latency_us(void) {
+  return (
+      uint32_t)(((uint64_t)I2S_DMA_DESC_NUM * I2S_DMA_FRAME_NUM * 1000000ULL) /
+                OUTPUT_RATE);
 }

--- a/main/audio/audio_output.h
+++ b/main/audio/audio_output.h
@@ -48,3 +48,15 @@ void audio_output_set_sample_rate(uint32_t rate);
  * The resampler is re-initialized if the rate changes.
  */
 void audio_output_set_source_rate(int rate);
+
+/**
+ * Return the I2S DMA pipeline latency in microseconds.
+ *
+ * This is computed from the DMA descriptor count and frame count
+ * (both set at init time) divided by the output sample rate — i.e.
+ *   (dma_desc_num × dma_frame_num × 1 000 000) / sample_rate
+ *
+ * Using this value instead of a hard-coded constant means the latency
+ * stays correct if the DMA config or sample rate is ever changed.
+ */
+uint32_t audio_output_get_hardware_latency_us(void);

--- a/main/audio/audio_output_spdif.c
+++ b/main/audio/audio_output_spdif.c
@@ -322,3 +322,10 @@ void audio_output_set_source_rate(int rate) {
     resample_reinit_needed = true;
   }
 }
+
+uint32_t audio_output_get_hardware_latency_us(void) {
+  // SPDIF DMA ring: DMA_BUF_COUNT half-blocks, each SPDIF_BLOCK/SPDIF_BUF_DIV
+  // audio samples (= 96 stereo frames per buffer).
+  const uint32_t audio_samples = DMA_BUF_COUNT * (SPDIF_BLOCK / SPDIF_BUF_DIV);
+  return (uint32_t)((uint64_t)audio_samples * 1000000ULL / OUTPUT_RATE);
+}

--- a/main/audio/audio_output_usb.c
+++ b/main/audio/audio_output_usb.c
@@ -188,3 +188,8 @@ void audio_output_set_source_rate(int rate) {
     resample_reinit_needed = true;
   }
 }
+
+uint32_t audio_output_get_hardware_latency_us(void) {
+  // USB isochronous audio: ~2ms double-buffered endpoint latency.
+  return 2000;
+}

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -184,32 +184,84 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
     return;
   }
 
-  // Detect a seek where the buffer content is far displaced from the new
-  // anchor position.  Threshold is 5 seconds of samples — large enough to
-  // clear normal pre-buffer depth after a pause (typically 1-3 s), but
-  // small enough to catch any real seek (which displaces by the full delta
-  // from the current song position).  Both directions are checked:
-  //   rtp_ahead > threshold  → backward seek (buffer ahead of new anchor)
-  //   rtp_ahead < -threshold → forward seek (buffer behind new anchor)
-  // Long-pause resume where the anchor advances over the pre-buffer is
-  // handled by the bulk-flush path in audio_timing_read, but catching it
-  // here avoids even the first DMA callback of silence.
-  // Window size for the upper RTP gate: 10 s of samples.  Large enough that
-  // a normal 2-4 s pre-buffer passes, but small enough to reject stale frames
-  // left in the TCP socket buffer after a backward seek (which are 60+ s ahead
-  // of the new anchor when seeking back to near the start of a track).
   int sample_rate = receiver.stream->format.sample_rate;
   if (sample_rate <= 0) {
     sample_rate = 44100;
   }
+  // Window size for the upper RTP gate: 10 s of samples.  Large enough that
+  // a normal 2-4 s pre-buffer passes, but small enough to reject stale frames
+  // left in the TCP socket buffer after a backward seek.
   const uint32_t gate_window = (uint32_t)(10 * sample_rate);
+  const int32_t seek_threshold = 5 * sample_rate;
 
+  // --- Phase 1: Arm RTP gates BEFORE opening the blanket gate -----------
+  //
+  // The blanket gate (discard_all_until_anchor) blocks ALL frames from the
+  // TCP task.  The per-RTP gates filter by timestamp range.  On single-core
+  // ESP32-S2, ESP_LOGI can yield to the scheduler, so any gap between
+  // clearing the blanket and arming the per-RTP gates lets the TCP task
+  // queue stale frames.  Arm first, then open.
+  bool gates_armed = false;
+
+  // Path A: seek_flush set arm_gate_on_next_anchor because the buffer was
+  // already empty when the flush happened (forward-seek).
+  if (receiver.arm_gate_on_next_anchor) {
+    receiver.arm_gate_on_next_anchor = false;
+    receiver.discard_before_rtp = rtp_time;
+    receiver.discard_before_rtp_valid = true;
+    receiver.discard_above_rtp = rtp_time + gate_window;
+    receiver.discard_above_rtp_valid = true;
+    gates_armed = true;
+    ESP_LOGI(TAG,
+             "RTP gates armed on anchor: discard_before=%lu discard_above=%lu",
+             (unsigned long)rtp_time, (unsigned long)(rtp_time + gate_window));
+  }
+
+  // Path B: Anchor-change detection — the phone changed track with a
+  // PAUSE → RESUME cycle but no FLUSHBUFFERED.  The buffer may already be
+  // empty (consumed during playback), so the seek-detection heuristic
+  // below (which needs oldest_rtp from the buffer) would miss it.
+  // Compare the new anchor's RTP with the previous one; a delta > 5 s of
+  // samples means a different track.
+  if (!gates_armed && receiver.timing.anchor_valid) {
+    int32_t delta = (int32_t)(rtp_time - receiver.timing.anchor_rtp_time);
+    int32_t abs_delta = delta < 0 ? -delta : delta;
+    if (abs_delta > seek_threshold) {
+      ESP_LOGI(TAG,
+               "Anchor change detected: old_rtp=%lu new_rtp=%lu "
+               "delta=%ld samples (%.1f s) — flushing & arming gates",
+               (unsigned long)receiver.timing.anchor_rtp_time,
+               (unsigned long)rtp_time, (long)delta,
+               (float)delta / sample_rate);
+      audio_buffer_flush(&receiver.buffer);
+      receiver.timing.playout_started = false;
+      receiver.timing.pending_valid = false;
+      receiver.timing.pending_frame_len = 0;
+      receiver.timing.ready_time_us = 0;
+      receiver.blocks_read_in_sequence = 0;
+      receiver.discard_before_rtp = rtp_time;
+      receiver.discard_before_rtp_valid = true;
+      receiver.discard_above_rtp = rtp_time + gate_window;
+      receiver.discard_above_rtp_valid = true;
+      receiver.timing.post_flush = true;
+      receiver.timing.post_flush_start_us = 0;
+      gates_armed = true;
+    }
+  }
+
+  // NOW safe to clear the blanket gate — per-RTP gates are active.
+  receiver.discard_all_until_anchor = false;
+
+  // --- Phase 2: Seek detection from buffer content ----------------------
+  //
+  // If stale data managed to enter the buffer (e.g. queued before
+  // seek_flush was called), detect it by comparing the oldest buffered
+  // RTP timestamp against the new anchor.
   uint32_t oldest_rtp = 0;
   if (audio_buffer_oldest_timestamp(&receiver.buffer, &oldest_rtp)) {
     int32_t rtp_ahead = (int32_t)(oldest_rtp - rtp_time);
-    int32_t flush_threshold = 5 * sample_rate; // 5 seconds of samples
     int32_t abs_ahead = rtp_ahead < 0 ? -rtp_ahead : rtp_ahead;
-    if (abs_ahead > flush_threshold) {
+    if (abs_ahead > seek_threshold) {
       ESP_LOGI(TAG,
                "Seek detected: oldest_rtp=%lu, new anchor rtp=%lu, "
                "delta=%ld samples (%.1f s) — flushing stale buffer",
@@ -221,31 +273,15 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
       receiver.blocks_read_in_sequence = 0;
-      // Arm both RTP gates so the TCP task discards stale frames at decode
-      // time rather than letting them fill the ring buffer and trigger repeated
-      // bulk-flushes in the DMA callback.
-      // discard_before_rtp catches forward-seek stale frames (RTP < anchor).
-      // discard_above_rtp catches backward-seek stale frames (RTP >> anchor).
-      receiver.discard_before_rtp = rtp_time;
-      receiver.discard_before_rtp_valid = true;
-      receiver.discard_above_rtp = rtp_time + gate_window;
-      receiver.discard_above_rtp_valid = true;
-      receiver.arm_gate_on_next_anchor = false; // already handled
+      receiver.timing.post_flush = true;
+      receiver.timing.post_flush_start_us = 0;
+      if (!gates_armed) {
+        receiver.discard_before_rtp = rtp_time;
+        receiver.discard_before_rtp_valid = true;
+        receiver.discard_above_rtp = rtp_time + gate_window;
+        receiver.discard_above_rtp_valid = true;
+      }
     }
-  }
-
-  // Forward-seek path: seek_flush empties the buffer before the anchor
-  // arrives, so the oldest_rtp check above never fires. arm_gate_on_next_anchor
-  // was set by seek_flush to ensure we still arm both gates here.
-  if (receiver.arm_gate_on_next_anchor) {
-    receiver.arm_gate_on_next_anchor = false;
-    receiver.discard_before_rtp = rtp_time;
-    receiver.discard_before_rtp_valid = true;
-    receiver.discard_above_rtp = rtp_time + gate_window;
-    receiver.discard_above_rtp_valid = true;
-    ESP_LOGI(TAG,
-             "RTP gates armed on anchor: discard_before=%lu discard_above=%lu",
-             (unsigned long)rtp_time, (unsigned long)(rtp_time + gate_window));
   }
 
   // Pin the PTP clock to the master announced by the anchor packet's
@@ -462,6 +498,7 @@ void audio_receiver_flush(void) {
   receiver.discard_before_rtp_valid = false;
   receiver.discard_above_rtp_valid = false;
   receiver.arm_gate_on_next_anchor = false;
+  receiver.discard_all_until_anchor = false;
   receiver.blocks_read_in_sequence = 1;
 }
 
@@ -479,6 +516,10 @@ void audio_receiver_seek_flush(void) {
   // the time SETRATEANCHORTIME arrives, so the seek-detection heuristic
   // (which needs oldest_rtp from the buffer) would otherwise miss arming it.
   receiver.arm_gate_on_next_anchor = true;
+  // Reject ALL incoming frames until the next anchor.  Prevents stale TCP
+  // data from filling the buffer between FLUSHBUFFERED and SETRATEANCHORTIME,
+  // which would cause a second flush and double the startup delay.
+  receiver.discard_all_until_anchor = true;
 }
 
 void audio_receiver_set_deferred_flush(uint32_t flush_until_ts) {

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -6,6 +6,7 @@
 
 #include "esp_heap_caps.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 
 #include "audio_buffer.h"
 #include "audio_decoder.h"
@@ -221,18 +222,52 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
   // PAUSE → RESUME cycle but no FLUSHBUFFERED.  The buffer may already be
   // empty (consumed during playback), so the seek-detection heuristic
   // below (which needs oldest_rtp from the buffer) would miss it.
-  // Compare the new anchor's RTP with the previous one; a delta > 5 s of
-  // samples means a different track.
+  //
+  // Compare the new anchor against the EXPECTED current playback position
+  // (old_anchor_rtp + elapsed_time × sample_rate), NOT against the raw old
+  // anchor.  The raw old anchor was set at the start of the previous play
+  // segment; comparing against it gives a delta equal to (elapsed_play_time +
+  // new_anchor_lead_time), which easily exceeds the 5-second threshold on a
+  // normal pause/resume within the same track — causing a false flush that
+  // empties valid pre-buffered frames and produces 6+ seconds of silence.
+  // Using the expected position instead, normal resume gives a delta of only
+  // the anchor's lead-time offset (< 2 s), while a real track-change or seek
+  // gives a huge delta (many minutes).
   if (!gates_armed && receiver.timing.anchor_valid) {
-    int32_t delta = (int32_t)(rtp_time - receiver.timing.anchor_rtp_time);
+    // Choose reference point for the seek-detection comparison:
+    //   - If we have a pause snapshot, use it. The snapshot was taken at the
+    //     exact moment the sender said PAUSE, so it reflects the true pause
+    //     position rather than a wall-clock estimate that keeps running during
+    //     the pause and overshoots by (pause_duration x sample_rate).
+    //   - Otherwise fall back to the elapsed-time estimate (covers the edge
+    //     case where a track changes without a prior PAUSE signal).
+    uint32_t reference_rtp;
+    if (receiver.paused_rtp_valid) {
+      reference_rtp = receiver.paused_rtp;
+      receiver.paused_rtp_valid = false; // one-shot: consume after use
+      ESP_LOGD(TAG, "Path B: using pause snapshot rtp=%lu",
+               (unsigned long)reference_rtp);
+    } else {
+      int64_t elapsed_us = esp_timer_get_time() -
+                           (receiver.timing.anchor_local_time_ns / 1000LL);
+      if (elapsed_us < 0)
+        elapsed_us = 0;
+      // Cap elapsed to prevent int64 overflow on very long pauses.
+      if (elapsed_us > 600000000LL)
+        elapsed_us = 600000000LL;
+      int32_t elapsed_samples =
+          (int32_t)((elapsed_us * (int64_t)sample_rate) / 1000000LL);
+      reference_rtp =
+          receiver.timing.anchor_rtp_time + (uint32_t)elapsed_samples;
+    }
+    int32_t delta = (int32_t)(rtp_time - reference_rtp);
     int32_t abs_delta = delta < 0 ? -delta : delta;
     if (abs_delta > seek_threshold) {
       ESP_LOGI(TAG,
-               "Anchor change detected: old_rtp=%lu new_rtp=%lu "
-               "delta=%ld samples (%.1f s) — flushing & arming gates",
-               (unsigned long)receiver.timing.anchor_rtp_time,
-               (unsigned long)rtp_time, (long)delta,
-               (float)delta / sample_rate);
+               "Anchor change detected: ref_rtp=%lu new_rtp=%lu "
+               "delta=%ld samples (%.1f s) - flushing & arming gates",
+               (unsigned long)reference_rtp, (unsigned long)rtp_time,
+               (long)delta, (float)delta / sample_rate);
       audio_buffer_flush(&receiver.buffer);
       receiver.timing.playout_started = false;
       receiver.timing.pending_valid = false;
@@ -245,6 +280,12 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.discard_above_rtp_valid = true;
       receiver.timing.quick_start = true;
       gates_armed = true;
+    } else {
+      ESP_LOGD(TAG,
+               "Anchor resume OK: ref_rtp=%lu new_rtp=%lu "
+               "delta=%ld samples (%.2f s) - same track, no flush",
+               (unsigned long)reference_rtp, (unsigned long)rtp_time,
+               (long)delta, (float)delta / (float)sample_rate);
     }
   }
 
@@ -300,6 +341,32 @@ void audio_receiver_set_playing(bool playing) {
   audio_timing_set_playing(&receiver.timing, playing);
   if (!playing) {
     receiver.blocks_read_in_sequence = 0;
+    // Snapshot the expected RTP position at the moment of pause so that
+    // Path B in audio_receiver_set_anchor_time() can compare the next
+    // resume anchor against the actual pause position.
+    //
+    // Without this, Path B uses (anchor_rtp + wall_clock_elapsed), which
+    // overshoots by the pause duration and fires a false seek flush on any
+    // pause >= seek_threshold (5 s) — causing up to 7+ s of silence when
+    // pre-buffered frames end up far ahead of the unwanted new anchor.
+    if (receiver.timing.anchor_valid && receiver.stream) {
+      int sample_rate = receiver.stream->format.sample_rate;
+      if (sample_rate <= 0)
+        sample_rate = 44100;
+      int64_t elapsed_us = esp_timer_get_time() -
+                           (receiver.timing.anchor_local_time_ns / 1000LL);
+      if (elapsed_us < 0)
+        elapsed_us = 0;
+      if (elapsed_us > 600000000LL)
+        elapsed_us = 600000000LL;
+      int32_t elapsed_samples =
+          (int32_t)((elapsed_us * (int64_t)sample_rate) / 1000000LL);
+      receiver.paused_rtp =
+          receiver.timing.anchor_rtp_time + (uint32_t)elapsed_samples;
+      receiver.paused_rtp_valid = true;
+      ESP_LOGD(TAG, "Pause: RTP snapshot=%lu (elapsed=%.2f s)",
+               (unsigned long)receiver.paused_rtp, (float)elapsed_us / 1e6f);
+    }
   }
 }
 
@@ -497,6 +564,7 @@ void audio_receiver_flush(void) {
   receiver.discard_above_rtp_valid = false;
   receiver.arm_gate_on_next_anchor = false;
   receiver.discard_all_until_anchor = false;
+  receiver.paused_rtp_valid = false;
   receiver.blocks_read_in_sequence = 1;
 }
 

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -243,8 +243,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.discard_before_rtp_valid = true;
       receiver.discard_above_rtp = rtp_time + gate_window;
       receiver.discard_above_rtp_valid = true;
-      receiver.timing.post_flush = true;
-      receiver.timing.post_flush_start_us = 0;
+      receiver.timing.quick_start = true;
       gates_armed = true;
     }
   }
@@ -273,8 +272,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
       receiver.blocks_read_in_sequence = 0;
-      receiver.timing.post_flush = true;
-      receiver.timing.post_flush_start_us = 0;
+      receiver.timing.quick_start = true;
       if (!gates_armed) {
         receiver.discard_before_rtp = rtp_time;
         receiver.discard_before_rtp_valid = true;
@@ -504,13 +502,11 @@ void audio_receiver_flush(void) {
 
 void audio_receiver_seek_flush(void) {
   // Mid-stream seek flush (FLUSH / immediate FLUSHBUFFERED).  Like
-  // audio_receiver_flush() but sets timing.post_flush so audio_timing_read
-  // plays frames immediately after the seek instead of silencing them while
-  // the anchor's pre-buffer window (several seconds) elapses.
+  // audio_receiver_flush() but sets timing.quick_start so audio_timing_read
+  // starts as soon as 1 frame is available, with normal anchor-based timing.
   // Also disarms any pending deferred flush (audio_timing_reset clears it).
   audio_receiver_flush();
-  receiver.timing.post_flush = true;
-  receiver.timing.post_flush_start_us = 0; // will be set on first frame
+  receiver.timing.quick_start = true;
   // Request that the RTP gate be armed as soon as the next anchor arrives.
   // This covers the forward-seek case where the buffer is already empty by
   // the time SETRATEANCHORTIME arrives, so the seek-detection heuristic

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -245,8 +245,19 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
     if (receiver.paused_rtp_valid) {
       reference_rtp = receiver.paused_rtp;
       receiver.paused_rtp_valid = false; // one-shot: consume after use
-      ESP_LOGD(TAG, "Path B: using pause snapshot rtp=%lu",
-               (unsigned long)reference_rtp);
+      // Compute the pause duration from the RTP snapshot so we can notify
+      // the PTP clock without tracking a separate wall-clock timestamp.
+      // anchor_local_time_ns/1000 is the µs when the anchor was set;
+      // adding the played-sample offset gives the µs when play paused.
+      int32_t played =
+          (int32_t)(reference_rtp - receiver.timing.anchor_rtp_time);
+      int64_t pause_time_us = receiver.timing.anchor_local_time_ns / 1000LL +
+                              (int64_t)played * 1000000LL / sample_rate;
+      int64_t pause_us = esp_timer_get_time() - pause_time_us;
+      ptp_clock_notify_resume((pause_us > 0) ? (uint32_t)(pause_us / 1000LL)
+                                             : 0);
+      ESP_LOGD(TAG, "Path B: pause snapshot rtp=%lu pause=%.1f s",
+               (unsigned long)reference_rtp, (float)pause_us / 1e6f);
     } else {
       int64_t elapsed_us = esp_timer_get_time() -
                            (receiver.timing.anchor_local_time_ns / 1000LL);

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -78,6 +78,12 @@ typedef struct {
   // seek: flush empties buffer before anchor arrives, so seek detection in
   // set_anchor_time would otherwise find no oldest_rtp and skip arming).
   bool arm_gate_on_next_anchor;
+  // Set by audio_receiver_seek_flush() to reject ALL incoming frames until
+  // the next SETRATEANCHORTIME provides a valid anchor.  Without this, stale
+  // TCP data (from the old track still draining the socket buffer) fills the
+  // ring buffer between FLUSHBUFFERED and the anchor, causing a second flush
+  // and doubling the startup delay.
+  bool discard_all_until_anchor;
 } audio_receiver_state_t;
 
 bool audio_stream_process_frame(audio_receiver_state_t *state,

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -84,6 +84,15 @@ typedef struct {
   // ring buffer between FLUSHBUFFERED and the anchor, causing a second flush
   // and doubling the startup delay.
   bool discard_all_until_anchor;
+
+  // Snapshot of the expected RTP position taken the moment the sender signals
+  // PAUSE (SETRATEANCHORTIME rate=0).  Path B in audio_receiver_set_anchor_time
+  // uses this as the reference when comparing the new anchor on RESUME, so
+  // that a long pause does not make the wall-clock-elapsed estimate overshoot
+  // by (pause_duration × sample_rate) and false-trigger a seek flush.
+  // Cleared on flush/reset and consumed after one use.
+  uint32_t paused_rtp;
+  bool paused_rtp_valid;
 } audio_receiver_state_t;
 
 bool audio_stream_process_frame(audio_receiver_state_t *state,

--- a/main/audio/audio_stream.c
+++ b/main/audio/audio_stream.c
@@ -33,6 +33,11 @@ bool audio_stream_process_frame(audio_receiver_state_t *state,
     return false;
   }
 
+  // Blanket gate: reject everything between seek_flush and the next anchor.
+  if (state->discard_all_until_anchor) {
+    return false;
+  }
+
   // Post-seek RTP window gate: discard frames outside [discard_before_rtp,
   // discard_above_rtp].  The TCP socket buffer can hold many seconds of
   // pre-seek audio; both gates together handle both seek directions:

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -11,26 +11,13 @@
 
 #define DEFAULT_BUFFER_LATENCY_US  200000 // 200ms startup jitter buffer
 #define HARDWARE_OUTPUT_LATENCY_US 46000  // ~46ms I2S DMA latency
-// PIPELINE_PROCESSING_LATENCY_US: combined fixed delay between a frame
-// landing on the wire at the phone and entering the sorted jitter buffer
-// on our side.  Breakdown (approximate, measured on a quiet WiFi network):
-//   ~10 ms  AAC decode (1024-sample frame, single-call)
-//   ~ 1 ms  ChaCha20 decrypt
-//   ~ 4 ms  WiFi+TCP receive jitter median
-// Reported to the phone as part of outputLatencyMicros so its scheduler
-// knows the actual end-to-end pipeline depth.  Kept independent of
-// HARDWARE_OUTPUT_LATENCY_US (DMA-side) and DEFAULT_BUFFER_LATENCY_US
-// (jitter-buffer target depth) so each can be tuned in isolation.
-#define PIPELINE_PROCESSING_LATENCY_US 15000
-#define MIN_STARTUP_FRAMES             4
-#define DRIFT_ADJUST_THRESHOLD_FRAMES  2
-#define TIMING_THRESHOLD_US            40000 // 40ms early/late threshold
-// If a frame is late by more than this, flush the whole buffer at once
-// instead of draining one frame per DMA callback (which would cause seconds
-// of silence while thousands of stale frames are individually dropped).
-// Kept independent of DEFAULT_BUFFER_LATENCY_US so reducing the startup
-// buffer doesn't also reduce the late-detection threshold.
-#define BULK_FLUSH_LATE_THRESHOLD_US 2000000 // 2 seconds
+// Additional pipeline latency to account for task scheduling, I2S write
+// blocking, and resampler processing.  Without this, frames pass the
+// timing check "on time" but actually exit the speaker several ms later.
+#define PIPELINE_LATENCY_US           10000 // ~10ms scheduling + write delay
+#define MIN_STARTUP_FRAMES            4
+#define DRIFT_ADJUST_THRESHOLD_FRAMES 2
+#define TIMING_THRESHOLD_US           40000 // 40ms early/late threshold
 // If a frame is late by more than this, flush the whole buffer at once
 // instead of draining one frame per DMA callback (which would cause seconds
 // of silence while thousands of stale frames are individually dropped).
@@ -161,7 +148,9 @@ static bool compute_early_us(const audio_timing_t *timing,
   }
 
   // Subtract hardware latency to account for I2S DMA delay
-  target_ns -= (int64_t)HARDWARE_OUTPUT_LATENCY_US * 1000LL;
+  // and pipeline latency for task scheduling and write blocking
+  target_ns -=
+      (int64_t)(HARDWARE_OUTPUT_LATENCY_US + PIPELINE_LATENCY_US) * 1000LL;
 
   int64_t now_ns = (int64_t)esp_timer_get_time() * 1000LL;
   *early_us = (target_ns - now_ns) / 1000LL;

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -18,15 +18,13 @@
 #define MIN_STARTUP_FRAMES            4
 #define DRIFT_ADJUST_THRESHOLD_FRAMES 2
 #define TIMING_THRESHOLD_US           10000 // 10ms. early/late threshold
-// MAX_CONSECUTIVE_EARLY: number of consecutive early frames before we conclude
-// the anchor is genuinely stuck/wrong.  At ~8 ms per frame this is ~6 seconds
-// of silence, which is well beyond any normal pre-buffer depth.
-#define MAX_CONSECUTIVE_EARLY 750
-// MAX_CONSECUTIVE_LATE: number of consecutive individually-late frames before
-// we conclude the whole buffer is stale and do a bulk flush.  At ~8 ms/frame
-// this is ~24 ms — just enough to distinguish a genuine stale-buffer from a
-// one-off WiFi jitter spike, without the 20-frame drain+log storm.
-#define MAX_CONSECUTIVE_LATE 3
+// MAX_CONSECUTIVE_EARLY: safety valve — counts how many consecutive calls to
+// audio_timing_read returned silence because the pending frame was still too
+// early.  Each call corresponds to one DMA period (~46 ms on I2S at 44100 Hz).
+// 50 calls × 46 ms ≈ 2.3 s: long enough that a legitimate pre-buffer of any
+// realistic depth will never hit it, short enough to detect a genuinely stuck
+// or invalid anchor in a few seconds.
+#define MAX_CONSECUTIVE_EARLY 50
 
 static const char *TAG = "audio_time";
 // consecutive_early_frames is now a field in audio_timing_t so it resets
@@ -143,7 +141,6 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->pending_frame_len = 0;
   timing->ready_time_us = 0;
   timing->consecutive_early_frames = 0;
-  timing->consecutive_late_frames = 0;
   timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
@@ -213,7 +210,6 @@ void audio_timing_set_anchor(audio_timing_t *timing,
   // Reset frame counters so pre-buffered audio after a pause/resume or
   // track skip does not accumulate into the new anchor's counts.
   timing->consecutive_early_frames = 0;
-  timing->consecutive_late_frames = 0;
 
   // Compute lead time: how far in the future this anchor's network timestamp
   // is relative to now.  Negative means the anchor is already in the past
@@ -384,7 +380,6 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         timing->playout_started = false;
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;
-        timing->consecutive_late_frames = 0;
         // quick_start so the first frame of the next track starts playing
         // as soon as 1 frame arrives, with normal anchor timing applied.
         timing->quick_start = true;
@@ -468,16 +463,12 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         } else if (early_us < -TIMING_THRESHOLD_US) {
           // Reset consecutive early counter on late/normal frames
           timing->consecutive_early_frames = 0;
-          timing->consecutive_late_frames++;
 
           // Late frame — drop it and continue draining within the SAME call.
           // The 256-attempt drain loop chews through stale frames at zero
           // wall-time cost, skipping past arbitrarily many stale frames in
           // one pass without the DMA ever idling.
-          if (timing->consecutive_late_frames == 1) {
-            ESP_LOGW(TAG, "Dropping late frame(s): %lld ms",
-                     -early_us / 1000LL);
-          }
+          ESP_LOGW(TAG, "Dropping late frame: %lld ms", -early_us / 1000LL);
           if (stats) {
             stats->late_frames++;
           }
@@ -492,9 +483,8 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       }
     }
 
-    // Frame is on time (or anchor-invalid) — reset counters.
+    // Frame is on time (or anchor-invalid) — reset counter.
     timing->consecutive_early_frames = 0;
-    timing->consecutive_late_frames = 0;
 
     // Copy PCM data to output
     memcpy(out, pcm, frame_samples * channels * sizeof(int16_t));

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -51,11 +51,12 @@
 // pre-buffer depth that normal post_flush handles (~200 ms early), but well
 // below the multi-second lateness seen on AP2 group rejoin.
 #define POST_FLUSH_LATE_DROP_US 300000LL // 300 ms
-// POST_FLUSH_TIMEOUT_US: maximum duration of the post_flush bypass.  After a
-// seek/flush the phone's pre-buffer window causes frames to appear hundreds of
-// ms early.  We play them immediately for this duration so the user hears audio
-// right away, then revert to normal timing so the anchor can enforce A/V sync.
-#define POST_FLUSH_TIMEOUT_US 500000LL // 500 ms
+// POST_FLUSH_TIMEOUT_US: safety-net timeout for the post_flush bypass.
+// Normal exit is timing-driven (exit only when early_us is within
+// ±TIMING_THRESHOLD_US).  This timeout only fires if timing never stabilises
+// (e.g. anchor permanently stuck), preventing indefinite bypass.  Set long
+// enough that it never fires during normal track skips.
+#define POST_FLUSH_TIMEOUT_US 5000000LL // 5 s (safety net only)
 
 // Closed-loop fill-depth controller.  Keeps the time-span of buffered audio
 // (newest_play_time − oldest_play_time) close to timing->output_latency_us
@@ -295,9 +296,13 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   const audio_format_t *format = &stream->format;
   int buffered_frames = audio_buffer_get_frame_count(buffer);
 
-  // Wait for enough buffer before starting
+  // Wait for enough buffer before starting.
+  // In post_flush mode (after a seek/skip), start playing as soon as 1 frame
+  // is available — the whole point is to minimise the gap between tracks.
+  // Normal startup still waits for target_buffer_frames to build jitter margin.
   if (!timing->playout_started && !timing->pending_valid) {
-    if (buffered_frames < (int)timing->target_buffer_frames) {
+    int required = timing->post_flush ? 1 : (int)timing->target_buffer_frames;
+    if (buffered_frames < required) {
       return 0;
     }
     // Wait for anchor before playing.
@@ -543,11 +548,22 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
             }
             continue;
           }
-          if ((early_us >= -TIMING_THRESHOLD_US &&
-               early_us <= TIMING_THRESHOLD_US) ||
-              flush_elapsed >= POST_FLUSH_TIMEOUT_US) {
+          if (early_us >= -TIMING_THRESHOLD_US &&
+              early_us <= TIMING_THRESHOLD_US) {
+            // Timing has stabilised — exit post_flush cleanly so normal
+            // timing takes over without a discontinuity.
             ESP_LOGI(TAG, "post_flush done: early=%lld ms, elapsed=%lld ms",
                      early_us / 1000LL, flush_elapsed / 1000LL);
+            timing->post_flush = false;
+            timing->post_flush_start_us = 0;
+          } else if (flush_elapsed >= POST_FLUSH_TIMEOUT_US) {
+            // Safety net: timing never stabilised — exit to avoid playing
+            // indefinitely out of sync.  A brief gap may follow if the next
+            // frame is still outside the normal timing window.
+            ESP_LOGW(
+                TAG,
+                "post_flush safety timeout: early=%lld ms, elapsed=%lld ms",
+                early_us / 1000LL, flush_elapsed / 1000LL);
             timing->post_flush = false;
             timing->post_flush_start_us = 0;
           }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -28,23 +28,6 @@
 // one-off WiFi jitter spike, without the 20-frame drain+log storm.
 #define MAX_CONSECUTIVE_LATE 3
 
-// Closed-loop fill-depth controller.  Keeps the time-span of buffered audio
-// (newest_play_time − oldest_play_time) close to timing->output_latency_us
-// so the system retains equal jitter margin on both sides.  Without this,
-// any small clock-rate mismatch between the source (phone) and our DAC
-// causes the fill depth to drift monotonically until something catastrophic
-// (underrun or bulk flush) resets it.
-//
-// FILL_DEPTH_DEADBAND_US: corrections only fire outside ±this band around
-// the target.  Wide enough that normal TCP-batch jitter doesn't trigger.
-//
-// MIN_CORRECTION_INTERVAL_FRAMES: at most one correction per N played
-// frames.  At ~23 ms per AAC frame and one frame's worth of skew per
-// correction, N=200 caps effective sample-rate skew at ~0.5 % — well
-// below the threshold of audibility.
-#define FILL_DEPTH_DEADBAND_US         100000 // ±100 ms hysteresis
-#define MIN_CORRECTION_INTERVAL_FRAMES 200
-
 static const char *TAG = "audio_time";
 // consecutive_early_frames is now a field in audio_timing_t so it resets
 // automatically whenever a new anchor is set.
@@ -164,7 +147,6 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
-  timing->frames_since_correction = 0;
 }
 
 void audio_timing_set_format(audio_timing_t *timing,
@@ -310,40 +292,6 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   } else if (ntp_clock_is_locked()) {
     sync_mode = SYNC_MODE_NTP;
   }
-
-  // ---------- Fill-depth diagnostic (no correction) ----------
-  //
-  // Earlier revisions of this code dropped or padded frames here to keep the
-  // buffer time-span near timing->output_latency_us.  That was misguided:
-  // the buffer time-span reflects the phone's PUSH pattern (TCP bursts and
-  // end-of-track pre-buffer routinely send 1–4 s ahead), not playout drift.
-  // Frames have correct RTP-anchored play times; dropping them just causes
-  // audible skips of legitimately-future audio.  PTP keeps us synced and
-  // the per-frame early-pending / late-drop paths handle transients, so no
-  // depth-based correction is needed.  Memory pressure is handled by the
-  // overflow path in audio_buffer_queue_chunk.
-  //
-  // We still expose the depth as a diagnostic so anomalies (e.g. depth
-  // staying above a couple of seconds for a long stretch, indicating a
-  // sender bug) remain visible in logs without forcing corrective action.
-  if (timing->anchor_valid && timing->playout_started &&
-      format->sample_rate > 0 && timing->nominal_frame_samples > 0 &&
-      buffered_frames >= 2 &&
-      timing->frames_since_correction >= MIN_CORRECTION_INTERVAL_FRAMES) {
-    int64_t depth_us = ((int64_t)buffered_frames *
-                        (int64_t)timing->nominal_frame_samples * 1000000LL) /
-                       (int64_t)format->sample_rate;
-    int64_t target_us = (int64_t)timing->output_latency_us;
-    int64_t excess = depth_us - target_us;
-    if (excess < 0)
-      excess = -excess;
-    if (excess > FILL_DEPTH_DEADBAND_US) {
-      ESP_LOGD(TAG, "fill_depth=%lldms (target=%lldms, frames=%d) — no action",
-               depth_us / 1000LL, target_us / 1000LL, buffered_frames);
-      timing->frames_since_correction = 0;
-    }
-  }
-  // -----------------------------------------------------------
 
   // Drain up to MAX_DRAIN_ATTEMPTS late/invalid frames within a SINGLE
   // DMA callback.  The previous limit of 8 was the root cause of run-away
@@ -565,11 +513,6 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       timing->quick_start = false;
       ESP_LOGI(TAG, "Playout started%s: rtp=%" PRIu32,
                was_quick ? " (quick_start)" : "", hdr->rtp_timestamp);
-    }
-
-    // Tick the fill-depth controller's rate limiter once per played frame.
-    if (timing->frames_since_correction < UINT32_MAX) {
-      timing->frames_since_correction++;
     }
 
     return frame_samples;

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -4,13 +4,13 @@
 
 #include "audio_timing.h"
 
+#include "audio_output.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "ntp_clock.h"
 #include "ptp_clock.h"
 
-#define DEFAULT_BUFFER_LATENCY_US  200   // 200µs startup jitter buffer
-#define HARDWARE_OUTPUT_LATENCY_US 40000 // ~40ms I2S DMA latency
+#define DEFAULT_BUFFER_LATENCY_US 200 // 200µs startup jitter buffer
 // Additional pipeline latency to account for task scheduling, I2S write
 // blocking, and resampler processing.  Without this, frames pass the
 // timing check "on time" but actually exit the speaker several ms later.
@@ -148,9 +148,12 @@ static bool compute_early_us(const audio_timing_t *timing,
   }
 
   // Subtract hardware latency to account for I2S DMA delay
-  // and pipeline latency for task scheduling and write blocking
+  // and pipeline latency for task scheduling and write blocking.
+  // The hardware latency is computed from the DMA descriptor/frame
+  // configuration rather than being hard-coded.
   target_ns -=
-      (int64_t)(HARDWARE_OUTPUT_LATENCY_US + PIPELINE_LATENCY_US) * 1000LL;
+      (int64_t)(audio_output_get_hardware_latency_us() + PIPELINE_LATENCY_US) *
+      1000LL;
 
   int64_t now_ns = (int64_t)esp_timer_get_time() * 1000LL;
   *early_us = (target_ns - now_ns) / 1000LL;
@@ -223,7 +226,7 @@ uint32_t audio_timing_get_output_latency(const audio_timing_t *timing) {
 }
 
 uint32_t audio_timing_get_hardware_latency(void) {
-  return HARDWARE_OUTPUT_LATENCY_US;
+  return audio_output_get_hardware_latency_us();
 }
 
 uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing) {
@@ -236,7 +239,7 @@ uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing) {
   // + PIPELINE_PROCESSING_LATENCY_US — decrypt + decode + net jitter constant
   uint32_t base =
       timing ? timing->output_latency_us : DEFAULT_BUFFER_LATENCY_US;
-  return base + HARDWARE_OUTPUT_LATENCY_US + PIPELINE_LATENCY_US;
+  return base + audio_output_get_hardware_latency_us() + PIPELINE_LATENCY_US;
 }
 
 void audio_timing_set_anchor(audio_timing_t *timing,

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -18,12 +18,6 @@
 #define MIN_STARTUP_FRAMES            4
 #define DRIFT_ADJUST_THRESHOLD_FRAMES 2
 #define TIMING_THRESHOLD_US           40000 // 40ms early/late threshold
-// If a frame is late by more than this, flush the whole buffer at once
-// instead of draining one frame per DMA callback (which would cause seconds
-// of silence while thousands of stale frames are individually dropped).
-// Kept independent of DEFAULT_BUFFER_LATENCY_US so reducing the startup
-// buffer doesn't also reduce the late-detection threshold.
-#define BULK_FLUSH_LATE_THRESHOLD_US 2000000 // 2 seconds
 // MAX_CONSECUTIVE_EARLY: number of consecutive early frames before we conclude
 // the anchor is genuinely stuck/wrong.  At ~8 ms per frame this is ~6 seconds
 // of silence, which is well beyond any normal pre-buffer depth.
@@ -33,30 +27,6 @@
 // this is ~24 ms — just enough to distinguish a genuine stale-buffer from a
 // one-off WiFi jitter spike, without the 20-frame drain+log storm.
 #define MAX_CONSECUTIVE_LATE 3
-// MAX_CONSECUTIVE_LATE: number of consecutive individually-late frames before
-// we conclude the whole buffer is stale and do a bulk flush.  At ~8 ms/frame
-// this is ~24 ms — just enough to distinguish a genuine stale-buffer from a
-// one-off WiFi jitter spike, without the 20-frame drain+log storm.
-#define MAX_CONSECUTIVE_LATE 3
-
-// POST_FLUSH_STALE_THRESHOLD_US: in post_flush mode the bypass plays frames
-// unconditionally to avoid silence during the phone's pre-buffer window
-// (typically 2–4 s).  Frames that are MORE than this many µs early are from
-// the wrong seek position (old audio still draining through the TCP pipeline)
-// and must be discarded rather than played.  10 s is well above the deepest
-// observed AirPlay 2 pre-buffer depth and well below any real seek delta.
-#define POST_FLUSH_STALE_THRESHOLD_US 10000000LL // 10 seconds
-// POST_FLUSH_LATE_DROP_US: in post_flush, frames whose play time is more
-// than this far in the past are dropped rather than played.  Set above the
-// pre-buffer depth that normal post_flush handles (~200 ms early), but well
-// below the multi-second lateness seen on AP2 group rejoin.
-#define POST_FLUSH_LATE_DROP_US 300000LL // 300 ms
-// POST_FLUSH_TIMEOUT_US: safety-net timeout for the post_flush bypass.
-// Normal exit is timing-driven (exit only when early_us is within
-// ±TIMING_THRESHOLD_US).  This timeout only fires if timing never stabilises
-// (e.g. anchor permanently stuck), preventing indefinite bypass.  Set long
-// enough that it never fires during normal track skips.
-#define POST_FLUSH_TIMEOUT_US 5000000LL // 5 s (safety net only)
 
 // Closed-loop fill-depth controller.  Keeps the time-span of buffered audio
 // (newest_play_time − oldest_play_time) close to timing->output_latency_us
@@ -191,8 +161,7 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->ready_time_us = 0;
   timing->consecutive_early_frames = 0;
   timing->consecutive_late_frames = 0;
-  timing->post_flush = false;
-  timing->post_flush_start_us = 0;
+  timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
   timing->frames_since_correction = 0;
@@ -236,8 +205,8 @@ uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing) {
   // schedules sends to land in our sorted buffer at the right time.
   //
   //   output_latency_us         — controller target (jitter-buffer depth)
-  // + HARDWARE_OUTPUT_LATENCY_US — I2S DMA delay (fixed)
-  // + PIPELINE_PROCESSING_LATENCY_US — decrypt + decode + net jitter constant
+  // + audio_output_get_hardware_latency_us() — I2S DMA delay (dynamic)
+  // + PIPELINE_LATENCY_US — scheduling + write delay constant
   uint32_t base =
       timing ? timing->output_latency_us : DEFAULT_BUFFER_LATENCY_US;
   return base + audio_output_get_hardware_latency_us() + PIPELINE_LATENCY_US;
@@ -297,11 +266,13 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   int buffered_frames = audio_buffer_get_frame_count(buffer);
 
   // Wait for enough buffer before starting.
-  // In post_flush mode (after a seek/skip), start playing as soon as 1 frame
-  // is available — the whole point is to minimise the gap between tracks.
-  // Normal startup still waits for target_buffer_frames to build jitter margin.
+  // In quick_start mode (after a seek/skip), start as soon as 1 frame is
+  // available to minimise the gap between tracks.  Anchor-based timing
+  // still applies — if the frame is early, silence is output until its
+  // scheduled play time, just like shairport-sync.
+  // Normal startup waits for target_buffer_frames to build jitter margin.
   if (!timing->playout_started && !timing->pending_valid) {
-    int required = timing->post_flush ? 1 : (int)timing->target_buffer_frames;
+    int required = timing->quick_start ? 1 : (int)timing->target_buffer_frames;
     if (buffered_frames < required) {
       return 0;
     }
@@ -454,123 +425,26 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;
         timing->consecutive_late_frames = 0;
-        // post_flush = true so the first frame of the next track plays
-        // immediately rather than waiting out the phone's pre-buffer window.
-        timing->post_flush = true;
-        timing->post_flush_start_us = 0;
+        // quick_start so the first frame of the next track starts playing
+        // as soon as 1 frame arrives, with normal anchor timing applied.
+        timing->quick_start = true;
         return 0;
       }
     }
 
     // Handle early/late frames based on anchor timing.
     //
-    // post_flush bypasses ALL timing checks (early and late) and plays every
-    // frame unconditionally.  This mirrors shairport-sync's
-    // first_packet_timestamp==0 path: after a seek or flush, the phone's anchor
-    // may be stale by hundreds of ms (startup buffer fill delay + pre-buffer
-    // depth), so frames appear early or late through no fault of the stream.
-    // Enforcing timing here causes silence or cascading re-flushes.
-    // post_flush clears only when a frame is genuinely on-time, at which point
-    // the anchor has settled and normal timing can re-engage.
+    // After a seek/flush, anchor-based timing is applied immediately from the
+    // first frame — no bypass.  With a stable PTP clock the anchor is
+    // accurate, so early frames are held as pending (silence output) until
+    // their scheduled play time, and late frames are dropped.  This mirrors
+    // shairport-sync's approach and guarantees the first audible sample is
+    // correctly synchronised.
     if (timing->anchor_valid && format->sample_rate > 0) {
       int64_t early_us = 0;
       if (compute_early_us(timing, format, hdr->rtp_timestamp, sync_mode,
                            &early_us)) {
-        if (timing->post_flush) {
-          // Bypass: play regardless of early/late — the phone pre-buffers
-          // several seconds ahead of the anchor's current position after a
-          // seek, so frames appear early through no fault of the stream.
-          //
-          // Track the start time so we can exit post_flush after a timeout
-          // rather than requiring early to reach ±TIMING_THRESHOLD_US (which
-          // may never happen if the pre-buffer depth exceeds the threshold).
-          if (timing->post_flush_start_us == 0) {
-            timing->post_flush_start_us = esp_timer_get_time();
-          }
-          int64_t flush_elapsed =
-              esp_timer_get_time() - timing->post_flush_start_us;
-          // Exception: frames that are MORE than POST_FLUSH_STALE_THRESHOLD_US
-          // early are old-position data still draining from the TCP kernel
-          // buffer (e.g. frames from 2:30 after a seek back to 0:00).  Discard
-          // those so the user never hears audio from the wrong position.
-          if (early_us > POST_FLUSH_STALE_THRESHOLD_US) {
-            // This frame is from the wrong seek position — still draining the
-            // TCP kernel buffer from before the flush.  Bulk-flush the entire
-            // ring buffer so all remaining stale (and any already-queued new)
-            // frames are cleared in one shot.  Draining one-by-one takes
-            // hundreds of DMA callbacks (8 frames/callback × hundreds of stale
-            // frames) causing seconds of silent lag that compounds each seek.
-            ESP_LOGW(
-                TAG, "post_flush: bulk flush %d stale frames (%lld s early)",
-                audio_buffer_get_frame_count(buffer), early_us / 1000000LL);
-            if (from_pending) {
-              timing->pending_valid = false;
-              timing->pending_frame_len = 0;
-            } else {
-              audio_buffer_return(buffer, item);
-            }
-            audio_buffer_flush(buffer);
-            timing->playout_started = false;
-            timing->ready_time_us = 0;
-            timing->consecutive_early_frames = 0;
-            timing->consecutive_late_frames = 0;
-            // Keep post_flush=true so new-position frames that refill the
-            // buffer will play immediately rather than waiting out the anchor.
-            return 0;
-          }
-          // Within pre-buffer depth — play and check if we should exit.
-          // Exit post_flush when either:
-          //  1. early is within ±TIMING_THRESHOLD_US (anchor is on-time), or
-          //  2. POST_FLUSH_TIMEOUT_US has elapsed (pre-buffer depth exceeds
-          //     threshold but anchor is stable — let normal timing take over
-          //     so frames are held until their scheduled play point).
-          //
-          // Exception: a frame that is more than POST_FLUSH_LATE_DROP_US in
-          // the past is from a previous play position (typical of an AP2
-          // group-rejoin where the source replays the group's continuous
-          // timeline into our buffer).  Playing it would emit audibly stale
-          // audio; instead drop it and continue draining within post_flush
-          // so we burn through the backlog and reach the live edge.
-          if (early_us < -POST_FLUSH_LATE_DROP_US) {
-            if (timing->consecutive_late_frames == 0) {
-              ESP_LOGW(TAG, "post_flush: dropping stale frame %lld ms late",
-                       -early_us / 1000LL);
-            }
-            timing->consecutive_late_frames++;
-            if (stats) {
-              stats->late_frames++;
-            }
-            if (from_pending) {
-              timing->pending_valid = false;
-              timing->pending_frame_len = 0;
-            } else {
-              audio_buffer_return(buffer, item);
-            }
-            continue;
-          }
-          if (early_us >= -TIMING_THRESHOLD_US &&
-              early_us <= TIMING_THRESHOLD_US) {
-            // Timing has stabilised — exit post_flush cleanly so normal
-            // timing takes over without a discontinuity.
-            ESP_LOGI(TAG, "post_flush done: early=%lld ms, elapsed=%lld ms",
-                     early_us / 1000LL, flush_elapsed / 1000LL);
-            timing->post_flush = false;
-            timing->post_flush_start_us = 0;
-          } else if (flush_elapsed >= POST_FLUSH_TIMEOUT_US) {
-            // Safety net: timing never stabilised — exit to avoid playing
-            // indefinitely out of sync.  A brief gap may follow if the next
-            // frame is still outside the normal timing window.
-            ESP_LOGW(
-                TAG,
-                "post_flush safety timeout: early=%lld ms, elapsed=%lld ms",
-                early_us / 1000LL, flush_elapsed / 1000LL);
-            timing->post_flush = false;
-            timing->post_flush_start_us = 0;
-          }
-          timing->consecutive_early_frames = 0;
-          timing->consecutive_late_frames = 0;
-          // Fall through to play the frame.
-        } else if (early_us > TIMING_THRESHOLD_US) {
+        if (early_us > TIMING_THRESHOLD_US) {
           timing->consecutive_early_frames++;
 
           // If we have had an implausibly long run of early frames the anchor
@@ -614,17 +488,8 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
           // Late frame — drop it and continue draining within the SAME call.
           // The 256-attempt drain loop chews through stale frames at zero
-          // wall-time cost.  We used to bulk-flush the whole buffer on
-          // >2 s late frames as a shortcut, but that path:
-          //  - re-armed post_flush, which then played the very next stale
-          //    frame unconditionally (producing audible jitter), and
-          //  - returned silence to the DMA, burning ~23 ms of wall time
-          //    while RTP didn't advance — each cycle made us more late and
-          //    we could never catch up (observed in AirPlay 2 group rejoin,
-          //    where the source's anchor is set in the past relative to
-          //    current PTP time and frames pour in 1.5–2 s late).
-          // Dropping & continuing lets the drain loop skip past arbitrarily
-          // many stale frames in one call.
+          // wall-time cost, skipping past arbitrarily many stale frames in
+          // one pass without the DMA ever idling.
           if (timing->consecutive_late_frames == 1) {
             ESP_LOGW(TAG, "Dropping late frame(s): %lld ms",
                      -early_us / 1000LL);
@@ -660,6 +525,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
     if (!timing->playout_started) {
       timing->playout_started = true;
+      timing->quick_start = false;
     }
 
     // Tick the fill-depth controller's rate limiter once per played frame.

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -9,12 +9,12 @@
 #include "ntp_clock.h"
 #include "ptp_clock.h"
 
-#define DEFAULT_BUFFER_LATENCY_US  200000 // 200ms startup jitter buffer
-#define HARDWARE_OUTPUT_LATENCY_US 46000  // ~46ms I2S DMA latency
+#define DEFAULT_BUFFER_LATENCY_US  200   // 200µs startup jitter buffer
+#define HARDWARE_OUTPUT_LATENCY_US 40000 // ~40ms I2S DMA latency
 // Additional pipeline latency to account for task scheduling, I2S write
 // blocking, and resampler processing.  Without this, frames pass the
 // timing check "on time" but actually exit the speaker several ms later.
-#define PIPELINE_LATENCY_US           10000 // ~10ms scheduling + write delay
+#define PIPELINE_LATENCY_US           1000 // ~1ms scheduling + write delay
 #define MIN_STARTUP_FRAMES            4
 #define DRIFT_ADJUST_THRESHOLD_FRAMES 2
 #define TIMING_THRESHOLD_US           40000 // 40ms early/late threshold

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -10,14 +10,14 @@
 #include "ntp_clock.h"
 #include "ptp_clock.h"
 
-#define DEFAULT_BUFFER_LATENCY_US 200 // 200µs startup jitter buffer
+#define DEFAULT_BUFFER_LATENCY_US 2000 // 2ms startup jitter buffer
 // Additional pipeline latency to account for task scheduling, I2S write
 // blocking, and resampler processing.  Without this, frames pass the
 // timing check "on time" but actually exit the speaker several ms later.
-#define PIPELINE_LATENCY_US           1000 // ~1ms scheduling + write delay
+#define PIPELINE_LATENCY_US           5000 // ~5ms scheduling + write delay
 #define MIN_STARTUP_FRAMES            4
 #define DRIFT_ADJUST_THRESHOLD_FRAMES 2
-#define TIMING_THRESHOLD_US           40000 // 40ms early/late threshold
+#define TIMING_THRESHOLD_US           10000 // 10ms. early/late threshold
 // MAX_CONSECUTIVE_EARLY: number of consecutive early frames before we conclude
 // the anchor is genuinely stuck/wrong.  At ~8 ms per frame this is ~6 seconds
 // of silence, which is well beyond any normal pre-buffer depth.

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -236,7 +236,7 @@ uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing) {
   // + PIPELINE_PROCESSING_LATENCY_US — decrypt + decode + net jitter constant
   uint32_t base =
       timing ? timing->output_latency_us : DEFAULT_BUFFER_LATENCY_US;
-  return base + HARDWARE_OUTPUT_LATENCY_US + PIPELINE_PROCESSING_LATENCY_US;
+  return base + HARDWARE_OUTPUT_LATENCY_US + PIPELINE_LATENCY_US;
 }
 
 void audio_timing_set_anchor(audio_timing_t *timing,

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -232,6 +232,18 @@ void audio_timing_set_anchor(audio_timing_t *timing,
   // track skip does not accumulate into the new anchor's counts.
   timing->consecutive_early_frames = 0;
   timing->consecutive_late_frames = 0;
+
+  // Compute lead time: how far in the future this anchor's network timestamp
+  // is relative to now.  Negative means the anchor is already in the past
+  // (normal: the phone pre-buffers and the anchor is 200–800 ms old by the
+  // time we receive it).
+  int64_t lead_ms = ((int64_t)network_time_ns -
+                     (int64_t)(ptp_clock_get_offset_ns() + now_ns)) /
+                    1000000LL;
+  ESP_LOGI(
+      TAG,
+      "Anchor set: rtp=%" PRIu32 " lead=%lld ms ptp_locked=%d quick_start=%d",
+      rtp_time, (long long)lead_ms, timing->ptp_locked, timing->quick_start);
 }
 
 void audio_timing_set_playing(audio_timing_t *timing, bool playing) {
@@ -445,12 +457,36 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       if (compute_early_us(timing, format, hdr->rtp_timestamp, sync_mode,
                            &early_us)) {
         if (early_us > TIMING_THRESHOLD_US) {
-          timing->consecutive_early_frames++;
+          // Only advance the stuck-anchor counter for NEW frames taken from
+          // the buffer — not for pending re-checks of the same early frame.
+          // A pending frame is re-examined every DMA callback (~8 ms) while
+          // we wait for wall-clock to reach its scheduled play time.  Counting
+          // those re-checks would fire the stuck-anchor detector in
+          // (MAX_CONSECUTIVE_EARLY × 8 ms) = 6 s even for a legitimately
+          // early frame that just needs to wait its pre-buffer depth (~1.5 s).
+          if (!from_pending) {
+            timing->consecutive_early_frames++;
+            // Log the first early frame after each anchor set (shows lead
+            // time before audio starts) and every 50 new frames after that
+            // (confirms the counter only counts real buffer reads, not
+            // pending re-checks).
+            if (timing->consecutive_early_frames == 1) {
+              ESP_LOGI(TAG,
+                       "First early frame: rtp=%" PRIu32 " early=%.1f ms"
+                       " quick_start=%d buffered=%d",
+                       hdr->rtp_timestamp, (float)early_us / 1000.0f,
+                       timing->quick_start, buffered_frames);
+            } else if (timing->consecutive_early_frames % 50 == 0) {
+              ESP_LOGD(TAG, "Early counter: %d/%d early=%.1f ms rtp=%" PRIu32,
+                       timing->consecutive_early_frames, MAX_CONSECUTIVE_EARLY,
+                       (float)early_us / 1000.0f, hdr->rtp_timestamp);
+            }
+          }
 
           // If we have had an implausibly long run of early frames the anchor
           // is probably stuck or wrong — give up on it so playback can
-          // continue.  This threshold is high enough (~6 s) that it never
-          // fires during normal pre-buffered-audio scenarios.
+          // continue.  This threshold is high enough (~17 s at 23 ms/frame)
+          // that it never fires during normal pre-buffered-audio scenarios.
           if (timing->consecutive_early_frames > MAX_CONSECUTIVE_EARLY) {
             ESP_LOGW(TAG,
                      "Invalidating stuck anchor: consecutive=%d, early=%lld ms",
@@ -525,7 +561,10 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
     if (!timing->playout_started) {
       timing->playout_started = true;
+      bool was_quick = timing->quick_start;
       timing->quick_start = false;
+      ESP_LOGI(TAG, "Playout started%s: rtp=%" PRIu32,
+               was_quick ? " (quick_start)" : "", hdr->rtp_timestamp);
     }
 
     // Tick the fill-depth controller's rate limiter once per played frame.

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -47,11 +47,6 @@ typedef struct {
   // mutex (write flush_until_ts first, arm bool second; read bool first).
   bool deferred_flush_pending;
   uint32_t flush_until_ts;
-  // Closed-loop fill-depth controller state.  Counts how many audio_timing_read
-  // calls have played a real frame since the last drop/pad correction.  Used
-  // to rate-limit corrections so the effective sample-rate skew stays below
-  // the threshold of audibility.
-  uint32_t frames_since_correction;
 } audio_timing_t;
 
 void audio_timing_init(audio_timing_t *timing, size_t pending_capacity);

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -29,10 +29,6 @@ typedef struct {
   // played.
   int consecutive_early_frames;
   // Late-frame guard: counts consecutive individually-late frames.  When this
-  // exceeds MAX_CONSECUTIVE_LATE the whole buffer is considered stale (e.g.
-  // after a track skip where the anchor network_time has already passed) and a
-  // bulk flush is triggered instead of draining frame-by-frame.
-  int consecutive_late_frames;
   // Quick-start flag: set after a seek/flush/track-change so that
   // audio_timing_read starts playback with just 1 buffered frame instead of
   // waiting for target_buffer_frames.  Anchor-based timing is used from the

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -33,14 +33,13 @@ typedef struct {
   // after a track skip where the anchor network_time has already passed) and a
   // bulk flush is triggered instead of draining frame-by-frame.
   int consecutive_late_frames;
-  // Post-seek/skip flag: set by audio_receiver_seek_flush() via
-  // audio_timing_t so that audio_timing_read plays frames immediately rather
-  // than silencing them during the phone's pre-buffer window (which can be
-  // several seconds).  Cleared automatically after POST_FLUSH_TIMEOUT_US of
-  // real-time playback so normal timing re-engages and frames are held until
-  // their scheduled play point.
-  bool post_flush;
-  int64_t post_flush_start_us; // esp_timer_get_time() when post_flush began
+  // Quick-start flag: set after a seek/flush/track-change so that
+  // audio_timing_read starts playback with just 1 buffered frame instead of
+  // waiting for target_buffer_frames.  Anchor-based timing is used from the
+  // very first frame (no bypass) — early frames are held as pending and
+  // silence is output until their scheduled play time, exactly like
+  // shairport-sync.  Cleared once playout_started becomes true.
+  bool quick_start;
   // Deferred flush (AirPlay 2 FLUSHBUFFERED with flushFromSeq present):
   // keep playing until a frame with rtp_timestamp >= flush_until_ts arrives,
   // then bulk-flush and start fresh.  Written by the RTSP task, read by the

--- a/main/network/ptp_clock.c
+++ b/main/network/ptp_clock.c
@@ -49,8 +49,20 @@ static const char *TAG = "ptp_clock";
 #define MIN_SAMPLES_FOR_LOCK 4
 #define LOCK_STABLE_TIME_MS  250 // 250ms of stable readings to declare lock
 #define LOCK_TIMEOUT_MS      5000
-#define SAMPLE_BUFFER_SIZE   16         // Ring buffer for median filtering
-#define OUTLIER_THRESHOLD_NS 75000000LL // 75ms - reject samples beyond this
+#define OUTLIER_THRESHOLD_NS 50000000LL // 50ms - reject samples beyond this
+// Asymmetric filter parameters (modeled after nqptp):
+// Network delays only ADD positive bias to the measured offset, so
+//   offset_measured = true_offset - one_way_delay
+// The LARGEST measured offsets correspond to the SHORTEST delays and are
+// therefore the most accurate.  We accept positive jitter (= shorter delay)
+// quickly and dampen negative jitter (= longer delay) heavily.  This causes
+// the filter to converge to the minimum-delay offset, matching the behaviour
+// of nqptp used by shairport-sync and ensuring tight multi-room sync.
+#define SMOOTH_POS_STARTUP_DIV 1   // accept positive jitter fully at start
+#define SMOOTH_POS_STEADY_DIV  16  // later, apply 1/16 of positive jitter
+#define SMOOTH_NEG_DIV         256 // always apply only 1/256 of negative jitter
+#define SMOOTH_NEG_CLAMP_NS    (-2500000LL) // clamp negative jitter at -2.5ms
+#define STARTUP_DURATION_MS    1000 // first second: aggressive positive tracking
 
 // PTP state
 static struct {
@@ -68,10 +80,10 @@ static struct {
   int64_t filtered_offset_ns; // PTP_time = local_time + offset
   uint32_t sample_count;
 
-  // Sample ring buffer for median filtering
-  int64_t samples[SAMPLE_BUFFER_SIZE];
-  int sample_index;
-  int sample_fill;
+  // Asymmetric smoothing state (replaces median ring buffer)
+  int64_t previous_offset;
+  uint32_t previous_offset_time_ms; // 0 = no previous sample yet
+  uint32_t mastership_start_ms;     // when continuous tracking began
 
   // Two-step sync tracking
   uint16_t last_sync_seq;
@@ -119,40 +131,30 @@ static inline int64_t get_local_time_ns(void) {
   return (int64_t)esp_timer_get_time() * 1000LL;
 }
 
-// Compare function for qsort
-static int compare_int64(const void *a, const void *b) {
-  int64_t va = *(const int64_t *)a;
-  int64_t vb = *(const int64_t *)b;
-  if (va < vb) {
-    return -1;
-  }
-  if (va > vb) {
-    return 1;
-  }
-  return 0;
-}
-
-// Compute median of samples
-static int64_t compute_median(void) {
-  if (ptp.sample_fill == 0) {
-    return 0;
-  }
-
-  int64_t sorted[SAMPLE_BUFFER_SIZE];
-  memcpy(sorted, ptp.samples, ptp.sample_fill * sizeof(int64_t));
-  qsort(sorted, ptp.sample_fill, sizeof(int64_t), compare_int64);
-
-  return sorted[ptp.sample_fill / 2];
-}
-
-// Update offset with new sample using median filtering
+// Update offset with new sample using asymmetric smoothing (nqptp-style).
+//
+// The key insight from nqptp: since we are a passive PTP listener (no
+// DELAY_REQ/DELAY_RESP), every measured offset contains a one-way network
+// delay bias:  offset_measured = true_offset - delay.
+// LARGER offsets come from SHORTER delays and are MORE accurate.
+//
+// By accepting positive jitter (larger offset = shorter delay) quickly and
+// dampening negative jitter (smaller offset = longer delay) slowly, the
+// filter converges to the offset corresponding to the minimum network
+// delay — the best available approximation of the true clock offset.
 static void update_offset(int64_t new_offset_ns) {
   uint32_t now_ms = xTaskGetTickCount() * portTICK_PERIOD_MS;
   ptp.last_sync_ms = now_ms;
   ptp.sample_count++;
 
-  // Reject obvious outliers (more than 50ms from current estimate)
-  if (ptp.sample_fill > 0) {
+  int64_t smoothed_offset;
+
+  if (ptp.previous_offset_time_ms == 0) {
+    // First sample (or after reset): accept unconditionally
+    smoothed_offset = new_offset_ns;
+    ptp.mastership_start_ms = now_ms;
+  } else {
+    // Reject obvious outliers (more than 50ms from current estimate)
     int64_t diff = new_offset_ns - ptp.filtered_offset_ns;
     if (diff < 0) {
       diff = -diff;
@@ -161,33 +163,43 @@ static void update_offset(int64_t new_offset_ns) {
       ptp.outlier_count++;
       return;
     }
+
+    int64_t jitter = new_offset_ns - ptp.previous_offset;
+    uint32_t mastership_time_ms = now_ms - ptp.mastership_start_ms;
+
+    if (jitter >= 0) {
+      // Positive jitter: offset increased → shorter network delay → more
+      // accurate.  Accept quickly, especially during startup.
+      if (mastership_time_ms < STARTUP_DURATION_MS) {
+        smoothed_offset = ptp.previous_offset + jitter / SMOOTH_POS_STARTUP_DIV;
+      } else {
+        smoothed_offset = ptp.previous_offset + jitter / SMOOTH_POS_STEADY_DIV;
+      }
+    } else {
+      // Negative jitter: offset decreased → longer network delay → less
+      // reliable.  Clamp and apply only a tiny fraction.
+      int64_t clamped_jitter = jitter;
+      if (clamped_jitter < SMOOTH_NEG_CLAMP_NS) {
+        clamped_jitter = SMOOTH_NEG_CLAMP_NS;
+      }
+      smoothed_offset = ptp.previous_offset + clamped_jitter / SMOOTH_NEG_DIV;
+    }
   }
 
-  // Add to ring buffer
-  ptp.samples[ptp.sample_index] = new_offset_ns;
-  ptp.sample_index = (ptp.sample_index + 1) % SAMPLE_BUFFER_SIZE;
-  if (ptp.sample_fill < SAMPLE_BUFFER_SIZE) {
-    ptp.sample_fill++;
-  }
+  ptp.previous_offset = smoothed_offset;
+  ptp.previous_offset_time_ms = now_ms;
+  ptp.filtered_offset_ns = smoothed_offset;
 
-  // Use median for filtered offset (robust to outliers)
-  ptp.filtered_offset_ns = compute_median();
-
-  // Check lock status based on sample variance
-  if (ptp.sample_fill >= MIN_SAMPLES_FOR_LOCK) {
-    // Compute max deviation from median
-    int64_t max_dev = 0;
-    for (int i = 0; i < ptp.sample_fill; i++) {
-      int64_t dev = ptp.samples[i] - ptp.filtered_offset_ns;
-      if (dev < 0) {
-        dev = -dev;
-      }
-      if (dev > max_dev) {
-        max_dev = dev;
-      }
+  // Check lock status: once we have enough samples and the offset is stable,
+  // declare lock.  Use the deviation between the raw sample and the smoothed
+  // value as a stability indicator.
+  if (ptp.sample_count >= MIN_SAMPLES_FOR_LOCK) {
+    int64_t dev = new_offset_ns - smoothed_offset;
+    if (dev < 0) {
+      dev = -dev;
     }
 
-    if (max_dev < LOCK_THRESHOLD_NS) {
+    if (dev < LOCK_THRESHOLD_NS) {
       if (!ptp.locked) {
         if (ptp.lock_candidate_start_ms == 0) {
           ptp.lock_candidate_start_ms = now_ms;
@@ -206,7 +218,7 @@ static void update_offset(int64_t new_offset_ns) {
       }
     } else {
       ptp.lock_candidate_start_ms = 0;
-      if (ptp.locked && max_dev > LOCK_THRESHOLD_NS * 4) {
+      if (ptp.locked && dev > LOCK_THRESHOLD_NS * 4) {
         ptp.locked = false;
         ptp.lock_start_ms = 0;
         ESP_LOGW(TAG, "LOST LOCK: max_dev=%lldns (threshold=%lldns)",
@@ -231,6 +243,16 @@ static void process_sync(const uint8_t *data, size_t len, uint16_t seq) {
   if (!two_step && len >= PTP_HEADER_SIZE + PTP_TIMESTAMP_SIZE) {
     // One-step sync - timestamp is in the SYNC message
     uint64_t ptp_time_ns = parse_ptp_timestamp_ns(data + PTP_TIMESTAMP_OFFSET);
+    // Apply correctionField for one-step sync as well
+    if (len >= 16) {
+      int64_t correction_field =
+          ((int64_t)data[8] << 56) | ((int64_t)data[9] << 48) |
+          ((int64_t)data[10] << 40) | ((int64_t)data[11] << 32) |
+          ((int64_t)data[12] << 24) | ((int64_t)data[13] << 16) |
+          ((int64_t)data[14] << 8) | (int64_t)data[15];
+      correction_field /= 65536; // convert from 2^-16 ns to ns
+      ptp_time_ns = (uint64_t)((int64_t)ptp_time_ns + correction_field);
+    }
     int64_t offset = (int64_t)ptp_time_ns - ptp.last_sync_local_ns;
     update_offset(offset);
     ptp.awaiting_followup = false;
@@ -253,6 +275,20 @@ static void process_followup(const uint8_t *data, size_t len, uint16_t seq) {
 
   if (len >= PTP_HEADER_SIZE + PTP_TIMESTAMP_SIZE) {
     uint64_t ptp_time_ns = parse_ptp_timestamp_ns(data + PTP_TIMESTAMP_OFFSET);
+
+    // Apply correctionField (IEEE 1588 §11.4.4.2.1):
+    // The correctionField accumulates residence time and path delay
+    // corrections from PTP-aware network elements.  It is a signed
+    // 64-bit value in units of 2^-16 nanoseconds.
+    if (len >= 16) {
+      int64_t correction_field =
+          ((int64_t)data[8] << 56) | ((int64_t)data[9] << 48) |
+          ((int64_t)data[10] << 40) | ((int64_t)data[11] << 32) |
+          ((int64_t)data[12] << 24) | ((int64_t)data[13] << 16) |
+          ((int64_t)data[14] << 8) | (int64_t)data[15];
+      correction_field /= 65536; // convert from 2^-16 ns to ns
+      ptp_time_ns = (uint64_t)((int64_t)ptp_time_ns + correction_field);
+    }
 
     // offset = PTP_time - local_time_at_sync_receipt
     int64_t offset = (int64_t)ptp_time_ns - ptp.last_sync_local_ns;
@@ -496,8 +532,9 @@ void ptp_clock_clear(void) {
   ptp.last_sync_ms = 0;
   ptp.filtered_offset_ns = 0;
   ptp.sample_count = 0;
-  ptp.sample_index = 0;
-  ptp.sample_fill = 0;
+  ptp.previous_offset = 0;
+  ptp.previous_offset_time_ms = 0;
+  ptp.mastership_start_ms = 0;
 
   ptp.last_sync_seq = 0;
   ptp.last_sync_local_ns = 0;
@@ -560,11 +597,7 @@ uint64_t ptp_clock_get_master_clock_id(void) {
 void ptp_clock_get_stats(ptp_stats_t *stats) {
   stats->sync_count = ptp.sync_count;
   stats->followup_count = ptp.followup_count;
-  stats->last_offset_ns =
-      ptp.sample_fill > 0
-          ? ptp.samples[(ptp.sample_index + SAMPLE_BUFFER_SIZE - 1) %
-                        SAMPLE_BUFFER_SIZE]
-          : 0;
+  stats->last_offset_ns = ptp.previous_offset;
   stats->filtered_offset_ns = ptp.filtered_offset_ns;
 
   if (ptp.locked && ptp.lock_start_ms > 0) {

--- a/main/network/ptp_clock.c
+++ b/main/network/ptp_clock.c
@@ -64,6 +64,12 @@ static const char *TAG = "ptp_clock";
 #define SMOOTH_NEG_CLAMP_NS    (-2500000LL) // clamp negative jitter at -2.5ms
 #define STARTUP_DURATION_MS    1000 // first second: aggressive positive tracking
 
+// Threshold above which we reset the PTP smoothing filter on resume.
+// E.g. at 50 ppm crystal accuracy, 30 s of pause accumulates ~1.5 ms of drift —
+// large enough to be audible in multi-room but well within the 50 ms outlier
+// window.  Below this threshold the drift is negligible (<0.25 ms at 5 s).
+#define PTP_LONG_PAUSE_THRESHOLD_MS 30000
+
 // PTP state
 static struct {
   bool running;
@@ -547,6 +553,29 @@ void ptp_clock_clear(void) {
   // Drop the master filter so the next session can lock to whatever master
   // its anchor packet names (which may differ from the previous session).
   ptp.expected_clock_id = 0;
+}
+
+void ptp_clock_notify_resume(uint32_t pause_duration_ms) {
+  if (pause_duration_ms < PTP_LONG_PAUSE_THRESHOLD_MS) {
+    return; // drift too small to matter
+  }
+  // Reset the "previous sample" pointer so the very next PTP FOLLOW_UP is
+  // accepted unconditionally (the first-sample path in update_offset()).
+  // This mirrors what nqptp does on its "B" (begin) signal:
+  //   "when the clock goes from inactive to active, NQPTP resets clock
+  //    smoothing to the new offset" -- nqptp-shm-structures.h
+  //
+  // We keep filtered_offset_ns so that audio_timing can continue to use the
+  // last-known offset until the first new sample arrives (~125 ms away).
+  // We also reset mastership_start_ms so the STARTUP_DURATION_MS aggressive-
+  // positive window kicks in again for a faster upward catch-up.
+  ptp.previous_offset_time_ms = 0;
+  ptp.mastership_start_ms = 0;
+  ESP_LOGI(TAG,
+           "notify_resume: pause=%lu ms, resetting PTP smoothing "
+           "(est. drift %.1f ms @ 50ppm)",
+           (unsigned long)pause_duration_ms,
+           (float)pause_duration_ms * 50.0f / 1000000.0f);
 }
 
 bool ptp_clock_is_locked(void) {

--- a/main/network/ptp_clock.c
+++ b/main/network/ptp_clock.c
@@ -209,10 +209,11 @@ static void update_offset(int64_t new_offset_ns) {
           ptp.lock_start_ms = now_ms;
           ptp.lock_candidate_start_ms = 0;
           ESP_LOGI(TAG,
-                   "LOCKED: offset=%+lldns max_dev=%lldns samples=%d "
+                   "LOCKED: offset=%+lldns dev=%lldns samples=%lu "
                    "sync=%lu followup=%lu",
-                   (long long)ptp.filtered_offset_ns, (long long)max_dev,
-                   ptp.sample_fill, (unsigned long)ptp.sync_count,
+                   (long long)ptp.filtered_offset_ns, (long long)dev,
+                   (unsigned long)ptp.sample_count,
+                   (unsigned long)ptp.sync_count,
                    (unsigned long)ptp.followup_count);
         }
       }
@@ -221,8 +222,8 @@ static void update_offset(int64_t new_offset_ns) {
       if (ptp.locked && dev > LOCK_THRESHOLD_NS * 4) {
         ptp.locked = false;
         ptp.lock_start_ms = 0;
-        ESP_LOGW(TAG, "LOST LOCK: max_dev=%lldns (threshold=%lldns)",
-                 (long long)max_dev, (long long)(LOCK_THRESHOLD_NS * 4));
+        ESP_LOGW(TAG, "LOST LOCK: dev=%lldns (threshold=%lldns)",
+                 (long long)dev, (long long)(LOCK_THRESHOLD_NS * 4));
       }
     }
   }
@@ -585,8 +586,9 @@ void ptp_clock_set_master_clock_id(uint64_t clock_id) {
   ptp.lock_start_ms = 0;
   ptp.lock_candidate_start_ms = 0;
   ptp.filtered_offset_ns = 0;
-  ptp.sample_index = 0;
-  ptp.sample_fill = 0;
+  ptp.sample_count = 0;
+  ptp.previous_offset = 0;
+  ptp.previous_offset_time_ms = 0;
   ptp.awaiting_followup = false;
 }
 

--- a/main/network/ptp_clock.h
+++ b/main/network/ptp_clock.h
@@ -47,6 +47,22 @@ uint64_t ptp_clock_get_time_ns(void);
 int64_t ptp_clock_get_offset_ns(void);
 
 /**
+ * Notify the PTP clock that playback is resuming after a pause.
+ *
+ * If the pause lasted longer than PTP_LONG_PAUSE_THRESHOLD_MS, this
+ * resets the asymmetric smoothing filter so the next received PTP sample is
+ * accepted unconditionally — mirroring the nqptp "B" (begin) signal behaviour
+ * described in nqptp-shm-structures.h.
+ *
+ * Without this, after a pause long enough for the local crystal to drift,
+ * the 1/256-negative-jitter damping would take several minutes to re-converge,
+ * causing audible multi-room sync loss on resume.
+ *
+ * @param pause_duration_ms  Wall-clock length of the pause in milliseconds.
+ */
+void ptp_clock_notify_resume(uint32_t pause_duration_ms);
+
+/**
  * Get synchronization statistics.
  */
 typedef struct {

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -498,11 +498,12 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
     plist_array_end(&p);
 
     // Audio latencies array
-    // Type 96 (realtime/UDP): PTP sync + internal hardware compensation
-    // means audio exits the speaker at the correct wall-clock time;
-    // reporting additional latency would cause the sender to over-delay video.
-    // Type 103 (buffered/TCP): no timestamp-based scheduling, so the full
-    // jitter-buffer depth + hardware pipeline delay applies.
+    // Both type 96 (realtime/UDP) and type 103 (buffered/TCP) use PTP-based
+    // anchor timing with internal hardware-latency compensation in
+    // compute_early_us().  Report 0 so the sender does NOT also adjust its
+    // anchor — otherwise the hardware pipeline delay is subtracted twice and
+    // the ESP plays ahead of other speakers.  shairport-sync likewise
+    // reports no audioLatencies at all.
     plist_dict_array_begin(&p, "audioLatencies");
     plist_dict_begin(&p);
     plist_dict_int(&p, "type", 96);
@@ -514,8 +515,7 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
     plist_dict_int(&p, "type", 103);
     plist_dict_int(&p, "audioType", 0x64);
     plist_dict_int(&p, "inputLatencyMicros", 0);
-    plist_dict_int(&p, "outputLatencyMicros",
-                   audio_receiver_get_advertised_latency_us());
+    plist_dict_int(&p, "outputLatencyMicros", 0);
     plist_dict_end(&p);
     plist_array_end(&p);
 


### PR DESCRIPTION
### Motivation
The previous PTP implementation used a 16-sample ring buffer with median filtering to compute the clock offset. While robust against outliers, the median approach treats positive and negative jitter symmetrically — which is wrong for a passive PTP listener.
Samples with larger offset are from packets that took a shorter path through the network and are therefore more accurate. The median filter discards exactly these useful samples in favor of average-quality ones, causing the offset to converge too low and introducing systematic sync error — especially noticeable during multi-room playback.
This PR introduces a asymmetric smoothing (nqptp-style).

Additionally, HARDWARE_OUTPUT_LATENCY_US is no longer a compile-time constant. audio_output_get_hardware_latency_us() is used instead, which computes it as (dma_desc_num × dma_frame_num × 1 000 000) / sample_rate so it stays correct if the DMA config or output rate ever changes.

### Tests

I tested this with my s2 (custom board definition that will PR separately), ans the multiroom sync works like a charm. There are still some other possible improvements and it might be that the hard coded latency parameters will need fine tuning in other boards.