### PR TITLE
fix(timing): reset deferred flush state & align socket receive buffer

### DIFF
--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -284,6 +284,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_valid = false;
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
+      receiver.timing.deferred_flush_pending = false;
       receiver.blocks_read_in_sequence = 0;
       receiver.discard_before_rtp = rtp_time;
       receiver.discard_before_rtp_valid = true;
@@ -323,6 +324,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_valid = false;
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
+      receiver.timing.deferred_flush_pending = false;
       receiver.blocks_read_in_sequence = 0;
       receiver.timing.quick_start = true;
       if (!gates_armed) {

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -79,13 +79,13 @@ static void buffered_audio_task(void *pvParameters) {
     struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
     setsockopt(client_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
-    // Match SO_RCVBUF to lwIP's TCP receive window (set via
-    // CONFIG_LWIP_TCP_WND_DEFAULT, currently 32 KB on dma80).  This is the
-    // socket-level kernel buffer; the in-flight window itself comes from
-    // LWIP_TCP_WND_DEFAULT.  Default LWIP value of 2880 B (= 2*MSS) caps
-    // the iPhone's catchup-backfill rate to ~1.5x realtime on group rejoin
-    // — raise the LWIP window in sdkconfig to actually fix that.
-    int rcvbuf = 65536;
+    // Socket receive buffer: match lwIP's TCP receive window so the kernel
+    // buffer can hold exactly what the TCP window allows in flight.  A larger
+    // SO_RCVBUF (e.g. the old 65536) accumulates stale audio data that must
+    // drain through the RTP gates on every track skip, adding transition
+    // latency.  Keeping it at TCP_WND ties both knobs to a single sdkconfig
+    // value (CONFIG_LWIP_TCP_WND_DEFAULT).
+    int rcvbuf = CONFIG_LWIP_TCP_WND_DEFAULT;
     setsockopt(client_sock, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
 
     uint8_t *packet = state->buffered_recv_buffer;


### PR DESCRIPTION
## Summary

Two related fixes that reduce transition latency when a track skip or group
rejoin occurs.

## Changes

### `main/audio/audio_receiver.c`

`audio_receiver_set_anchor_time` resets the timing state whenever a new anchor
is established.  `deferred_flush_pending` was not cleared in either branch of
that reset, so a stale flush request from a previous session could fire during
the next playback window.

**Fix:** Reset `receiver.timing.deferred_flush_pending = false` in both reset
paths inside `audio_receiver_set_anchor_time`.

### `main/audio/audio_stream_buffered.c`

The socket receive buffer was hardcoded to 65 536 bytes, which is larger than
the lwIP TCP receive window.
The excess buffer space accumulates stale audio data that must drain through
the RTP gates on every track skip, adding audible transition latency.

**Fix:** Set `SO_RCVBUF` to `CONFIG_LWIP_TCP_WND_DEFAULT` so both knobs are
controlled by a single sdkconfig value and the kernel buffer never exceeds
what the TCP window can deliver.

## Testing

- [x] Track skip on single device — lower stale audio burst at start of new track
- [x] Group rejoin (multi-room) — transition latency reduced
- [x] Long playback session — audio pipeline stable

## Related

- `CONFIG_LWIP_TCP_WND_DEFAULT` in `sdkconfig.defaults`