### PR TITLE
Fix Music Assistant /info compatibility

### DIFF
--- a/main/plist/bplist_builder.c
+++ b/main/plist/bplist_builder.c
@@ -3,6 +3,142 @@
 #include "audio_stream.h"
 #include "plist.h"
 
+static bool bplist_has_room(size_t pos, size_t need, size_t capacity) {
+  return pos <= capacity && need <= capacity - pos;
+}
+
+static bool bplist_write_u64(uint8_t *out, size_t capacity, size_t *pos,
+                             uint64_t value) {
+  if (!bplist_has_room(*pos, 8, capacity)) {
+    return false;
+  }
+  for (int i = 7; i >= 0; i--) {
+    out[(*pos)++] = (uint8_t)(value >> (i * 8));
+  }
+  return true;
+}
+
+static bool bplist_write_length(uint8_t *out, size_t capacity, size_t *pos,
+                                uint8_t marker_base, size_t length) {
+  if (length < 15) {
+    if (!bplist_has_room(*pos, 1, capacity)) {
+      return false;
+    }
+    out[(*pos)++] = marker_base | (uint8_t)length;
+    return true;
+  }
+  if (length > UINT8_MAX || !bplist_has_room(*pos, 3, capacity)) {
+    return false;
+  }
+  out[(*pos)++] = marker_base | 0x0F;
+  out[(*pos)++] = 0x10;
+  out[(*pos)++] = (uint8_t)length;
+  return true;
+}
+
+static bool bplist_write_ascii_string(uint8_t *out, size_t capacity,
+                                      size_t *pos, const char *value) {
+  size_t len = strlen(value);
+  if (!bplist_write_length(out, capacity, pos, 0x50, len) ||
+      !bplist_has_room(*pos, len, capacity)) {
+    return false;
+  }
+  memcpy(out + *pos, value, len);
+  *pos += len;
+  return true;
+}
+
+static bool bplist_write_data(uint8_t *out, size_t capacity, size_t *pos,
+                              const uint8_t *data, size_t len) {
+  if (!bplist_write_length(out, capacity, pos, 0x40, len) ||
+      !bplist_has_room(*pos, len, capacity)) {
+    return false;
+  }
+  memcpy(out + *pos, data, len);
+  *pos += len;
+  return true;
+}
+
+static bool bplist_write_int(uint8_t *out, size_t capacity, size_t *pos,
+                             uint64_t value) {
+  uint8_t marker;
+  size_t bytes;
+  if (value <= UINT8_MAX) {
+    marker = 0x10;
+    bytes = 1;
+  } else if (value <= UINT16_MAX) {
+    marker = 0x11;
+    bytes = 2;
+  } else if (value <= UINT32_MAX) {
+    marker = 0x12;
+    bytes = 4;
+  } else {
+    marker = 0x13;
+    bytes = 8;
+  }
+
+  if (!bplist_has_room(*pos, 1 + bytes, capacity)) {
+    return false;
+  }
+  out[(*pos)++] = marker;
+  for (int i = (int)bytes - 1; i >= 0; i--) {
+    out[(*pos)++] = (uint8_t)(value >> (i * 8));
+  }
+  return true;
+}
+
+static bool bplist_write_refs(uint8_t *out, size_t capacity, size_t *pos,
+                              const uint8_t *refs, size_t count) {
+  if (!bplist_has_room(*pos, count, capacity)) {
+    return false;
+  }
+  memcpy(out + *pos, refs, count);
+  *pos += count;
+  return true;
+}
+
+static bool bplist_write_array(uint8_t *out, size_t capacity, size_t *pos,
+                               const uint8_t *refs, size_t count) {
+  return bplist_write_length(out, capacity, pos, 0xA0, count) &&
+         bplist_write_refs(out, capacity, pos, refs, count);
+}
+
+static bool bplist_write_dict(uint8_t *out, size_t capacity, size_t *pos,
+                              const uint8_t *keys, const uint8_t *values,
+                              size_t count) {
+  return bplist_write_length(out, capacity, pos, 0xD0, count) &&
+         bplist_write_refs(out, capacity, pos, keys, count) &&
+         bplist_write_refs(out, capacity, pos, values, count);
+}
+
+static bool bplist_finish(uint8_t *out, size_t capacity, size_t *pos,
+                          const size_t *offsets, size_t object_count,
+                          size_t top_object) {
+  size_t offset_table_offset = *pos;
+  for (size_t i = 0; i < object_count; i++) {
+    if (offsets[i] > UINT16_MAX || !bplist_has_room(*pos, 2, capacity)) {
+      return false;
+    }
+    out[(*pos)++] = (uint8_t)(offsets[i] >> 8);
+    out[(*pos)++] = (uint8_t)offsets[i];
+  }
+
+  if (!bplist_has_room(*pos, 32, capacity)) {
+    return false;
+  }
+  memset(out + *pos, 0, 6);
+  *pos += 6;
+  out[(*pos)++] = 2; // offset size
+  out[(*pos)++] = 1; // object ref size
+
+  if (!bplist_write_u64(out, capacity, pos, object_count) ||
+      !bplist_write_u64(out, capacity, pos, top_object) ||
+      !bplist_write_u64(out, capacity, pos, offset_table_offset)) {
+    return false;
+  }
+  return true;
+}
+
 size_t bplist_build_initial_setup(uint8_t *out, size_t capacity,
                                   uint16_t event_port) {
   if (capacity < 100) {
@@ -302,6 +438,225 @@ size_t bplist_build_feedback_response(uint8_t *out, size_t capacity,
     out[pos++] = 0;
   }
   out[pos++] = (uint8_t)offset_table_offset;
+
+  return pos;
+}
+
+size_t bplist_build_info_response(uint8_t *out, size_t capacity,
+                                  const char *device_id,
+                                  const char *device_name,
+                                  const uint8_t *public_key,
+                                  size_t public_key_len, uint64_t features,
+                                  int64_t protocol_version) {
+  if (!out || !device_id || !device_name || !public_key ||
+      public_key_len == 0 || capacity < 512) {
+    return 0;
+  }
+
+  size_t pos = 0;
+  size_t offsets[39];
+  size_t obj = 0;
+
+#define ADD_OFFSET()                                   \
+  do {                                                 \
+    if (obj >= sizeof(offsets) / sizeof(offsets[0])) { \
+      return 0;                                        \
+    }                                                  \
+    offsets[obj++] = pos;                              \
+  } while (0)
+
+  if (!bplist_has_room(pos, 8, capacity)) {
+    return 0;
+  }
+  memcpy(out + pos, "bplist00", 8);
+  pos += 8;
+
+  ADD_OFFSET(); // 0: "deviceid"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "deviceid")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 1: device id
+  if (!bplist_write_ascii_string(out, capacity, &pos, device_id)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 2: "features"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "features")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 3: features
+  if (!bplist_write_int(out, capacity, &pos, features)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 4: "model"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "model")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 5: model
+  if (!bplist_write_ascii_string(out, capacity, &pos, "AudioAccessory5,1")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 6: "protovers"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "protovers")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 7: protocol version string
+  if (!bplist_write_ascii_string(out, capacity, &pos, "1.1")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 8: "srcvers"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "srcvers")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 9: source version string
+  if (!bplist_write_ascii_string(out, capacity, &pos, "377.40.00")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 10: "vv"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "vv")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 11: vv value
+  if (!bplist_write_int(out, capacity, &pos, (uint64_t)protocol_version)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 12: "statusFlags"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "statusFlags")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 13: statusFlags value
+  if (!bplist_write_int(out, capacity, &pos, 4)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 14: "pk"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "pk")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 15: public key
+  if (!bplist_write_data(out, capacity, &pos, public_key, public_key_len)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 16: "pi"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "pi")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 17: pairing identifier
+  if (!bplist_write_ascii_string(out, capacity, &pos,
+                                 "00000000-0000-0000-0000-000000000000")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 18: "name"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "name")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 19: device name
+  if (!bplist_write_ascii_string(out, capacity, &pos, device_name)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 20: "audioFormats"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "audioFormats")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 21: "type"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "type")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 22: "audioInputFormats"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "audioInputFormats")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 23: "audioOutputFormats"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "audioOutputFormats")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 24: stream type 96
+  if (!bplist_write_int(out, capacity, &pos, 96)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 25: format mask
+  if (!bplist_write_int(out, capacity, &pos, 0x01000000)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 26: audio format dict
+  {
+    const uint8_t keys[] = {21, 22, 23};
+    const uint8_t values[] = {24, 25, 25};
+    if (!bplist_write_dict(out, capacity, &pos, keys, values, 3)) {
+      return 0;
+    }
+  }
+  ADD_OFFSET(); // 27: audioFormats array
+  {
+    const uint8_t refs[] = {26};
+    if (!bplist_write_array(out, capacity, &pos, refs, 1)) {
+      return 0;
+    }
+  }
+  ADD_OFFSET(); // 28: "audioLatencies"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "audioLatencies")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 29: "audioType"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "audioType")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 30: "inputLatencyMicros"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "inputLatencyMicros")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 31: "outputLatencyMicros"
+  if (!bplist_write_ascii_string(out, capacity, &pos, "outputLatencyMicros")) {
+    return 0;
+  }
+  ADD_OFFSET(); // 32: stream type 103
+  if (!bplist_write_int(out, capacity, &pos, 103)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 33: audio type
+  if (!bplist_write_int(out, capacity, &pos, 0x64)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 34: zero latency
+  if (!bplist_write_int(out, capacity, &pos, 0)) {
+    return 0;
+  }
+  ADD_OFFSET(); // 35: latency dict for realtime stream
+  {
+    const uint8_t keys[] = {21, 29, 30, 31};
+    const uint8_t values[] = {24, 33, 34, 34};
+    if (!bplist_write_dict(out, capacity, &pos, keys, values, 4)) {
+      return 0;
+    }
+  }
+  ADD_OFFSET(); // 36: latency dict for buffered stream
+  {
+    const uint8_t keys[] = {21, 29, 30, 31};
+    const uint8_t values[] = {32, 33, 34, 34};
+    if (!bplist_write_dict(out, capacity, &pos, keys, values, 4)) {
+      return 0;
+    }
+  }
+  ADD_OFFSET(); // 37: audioLatencies array
+  {
+    const uint8_t refs[] = {35, 36};
+    if (!bplist_write_array(out, capacity, &pos, refs, 2)) {
+      return 0;
+    }
+  }
+  ADD_OFFSET(); // 38: top-level info dict
+  {
+    const uint8_t keys[] = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 28};
+    const uint8_t values[] = {1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 27, 37};
+    if (!bplist_write_dict(out, capacity, &pos, keys, values, 12)) {
+      return 0;
+    }
+  }
+
+#undef ADD_OFFSET
+
+  if (obj != sizeof(offsets) / sizeof(offsets[0]) ||
+      !bplist_finish(out, capacity, &pos, offsets, obj, 38)) {
+    return 0;
+  }
 
   return pos;
 }

--- a/main/plist/plist.h
+++ b/main/plist/plist.h
@@ -282,3 +282,23 @@ size_t bplist_build_stream_setup(uint8_t *out, size_t capacity,
  */
 size_t bplist_build_feedback_response(uint8_t *out, size_t capacity,
                                       int64_t stream_type, double sample_rate);
+
+/**
+ * Build /info response bplist.
+ * Mirrors the XML /info response for RTSP clients that require binary plists.
+ * @param out Output buffer
+ * @param capacity Buffer capacity
+ * @param device_id Device MAC string
+ * @param device_name User-visible AirPlay device name
+ * @param public_key HAP Ed25519 public key
+ * @param public_key_len Public key length
+ * @param features AirPlay feature bitmask
+ * @param protocol_version AirPlay protocol version value ("vv")
+ * @return Length of generated bplist, or 0 on error
+ */
+size_t bplist_build_info_response(uint8_t *out, size_t capacity,
+                                  const char *device_id,
+                                  const char *device_name,
+                                  const uint8_t *public_key,
+                                  size_t public_key_len, uint64_t features,
+                                  int64_t protocol_version);

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -431,6 +431,10 @@ static const char *parse_raw_header(const uint8_t *raw, size_t raw_len,
   return NULL;
 }
 
+static bool request_uses_rtsp(const rtsp_request_t *req) {
+  return req && strncasecmp(req->protocol, "RTSP/", 5) == 0;
+}
+
 int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
                   size_t raw_len) {
   rtsp_request_t req;
@@ -471,8 +475,13 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
   }
 
   ESP_LOGW(TAG, "Unknown method: %s", req.method);
-  rtsp_send_http_response(socket, conn, 501, "Not Implemented", "text/plain",
-                          "Not Implemented", 15);
+  if (request_uses_rtsp(&req)) {
+    rtsp_send_response(socket, conn, 501, "Not Implemented", req.cseq,
+                       "Content-Type: text/plain\r\n", "Not Implemented", 15);
+  } else {
+    rtsp_send_http_response(socket, conn, 501, "Not Implemented", "text/plain",
+                            "Not Implemented", 15);
+  }
   return 0;
 }
 
@@ -528,14 +537,38 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
     // Build info response
     char device_id[18];
     char device_name[65];
-    static char body[4096];
-    plist_t p;
 
     rtsp_get_device_id(device_id, sizeof(device_id));
     settings_get_device_name(device_name, sizeof(device_name));
     const uint8_t *pk = hap_get_public_key();
     uint64_t features =
         ((uint64_t)AIRPLAY_FEATURES_HI << 32) | AIRPLAY_FEATURES_LO;
+
+#ifdef CONFIG_AIRPLAY_FORCE_V1
+    int64_t protocol_version = 1;
+#else
+    int64_t protocol_version = 2;
+#endif
+
+    if (request_uses_rtsp(req)) {
+      static uint8_t body[1024];
+      size_t body_len =
+          bplist_build_info_response(body, sizeof(body), device_id, device_name,
+                                     pk, 32, features, protocol_version);
+      if (body_len == 0) {
+        ESP_LOGE(TAG, "Failed to build binary /info response");
+        rtsp_send_response(socket, conn, 500, "Internal Error", req->cseq, NULL,
+                           NULL, 0);
+        return;
+      }
+      rtsp_send_response(socket, conn, 200, "OK", req->cseq,
+                         "Content-Type: application/x-apple-binary-plist\r\n",
+                         (const char *)body, body_len);
+      return;
+    }
+
+    static char body[4096];
+    plist_t p;
 
     plist_init(&p, body, sizeof(body));
     plist_begin(&p);
@@ -546,11 +579,7 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
     plist_dict_string(&p, "model", "AudioAccessory5,1");
     plist_dict_string(&p, "protovers", "1.1");
     plist_dict_string(&p, "srcvers", "377.40.00");
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-    plist_dict_int(&p, "vv", 1);
-#else
-    plist_dict_int(&p, "vv", 2);
-#endif
+    plist_dict_int(&p, "vv", protocol_version);
     plist_dict_int(&p, "statusFlags", 4);
     plist_dict_data(&p, "pk", pk, 32);
     plist_dict_string(&p, "pi", "00000000-0000-0000-0000-000000000000");
@@ -594,8 +623,13 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
                             body, body_len);
   } else {
     ESP_LOGW(TAG, "Unknown GET path: %s", req->path);
-    rtsp_send_http_response(socket, conn, 404, "Not Found", "text/plain",
-                            "Not Found", 9);
+    if (request_uses_rtsp(req)) {
+      rtsp_send_response(socket, conn, 404, "Not Found", req->cseq,
+                         "Content-Type: text/plain\r\n", "Not Found", 9);
+    } else {
+      rtsp_send_http_response(socket, conn, 404, "Not Found", "text/plain",
+                              "Not Found", 9);
+    }
   }
 }
 

--- a/main/rtsp/rtsp_message.c
+++ b/main/rtsp/rtsp_message.c
@@ -103,8 +103,24 @@ int rtsp_request_parse(const uint8_t *data, size_t len, rtsp_request_t *req) {
     return -1;
   }
 
-  // Parse first line: METHOD PATH PROTOCOL
-  if (sscanf((const char *)data, "%31s %255s", req->method, req->path) < 1) {
+  // Parse first line: METHOD PATH PROTOCOL.  The socket buffer is not
+  // guaranteed to be NUL-terminated, so copy only the request line.
+  const uint8_t *line_end = memchr(data, '\n', (size_t)(header_end - data));
+  if (!line_end) {
+    return -1;
+  }
+  size_t line_len = (size_t)(line_end - data);
+  if (line_len > 0 && data[line_len - 1] == '\r') {
+    line_len--;
+  }
+  char first_line[320];
+  if (line_len >= sizeof(first_line)) {
+    return -1;
+  }
+  memcpy(first_line, data, line_len);
+  first_line[line_len] = '\0';
+  if (sscanf(first_line, "%31s %255s %15s", req->method, req->path,
+             req->protocol) < 2) {
     return -1;
   }
 

--- a/main/rtsp/rtsp_message.h
+++ b/main/rtsp/rtsp_message.h
@@ -15,6 +15,7 @@
 typedef struct {
   char method[32];
   char path[256];
+  char protocol[16];
   int cseq;
   char content_type[64];
   size_t content_length;


### PR DESCRIPTION
## Summary
- Parse and preserve the RTSP/HTTP protocol token from incoming request lines.
- Return RTSP-framed responses for RTSP requests, including unknown methods and GET /info errors.
- Add a binary plist /info response for RTSP clients while keeping the existing XML HTTP /info path intact.

## Test plan
- `clang-format -i main/plist/bplist_builder.c main/plist/plist.h main/rtsp/rtsp_handlers.c main/rtsp/rtsp_message.c main/rtsp/rtsp_message.h`
- `git diff --check`
- `pio run -e esp32s3 -t build` (PlatformIO reported success; local env first needed missing ESP-IDF Python helpers installed in the PlatformIO venv, and configure printed a non-fatal x509_crt_bundle message.)
- Pre-commit hook ran clang-tidy on staged files during commit.

Closes #12
Refs #62

Made with [Cursor](https://cursor.com)