### PR TITLE
Emit RTSP_EVENT_PAUSED on stream-level TEARDOWN

### DIFF
--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1756,7 +1756,10 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
   conn->stream_paused =
       has_streams; // Keep session ready if only streams torn down
 
-  if (!has_streams) {
+  if (has_streams) {
+    // Stream-level teardown — session still open, iOS considers this paused
+    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
+  } else {
     // Full teardown — server cleanup will emit RTSP_EVENT_DISCONNECTED
     // when the TCP connection closes.
     // For v1 sessions, keep the DACP session alive across teardown so the


### PR DESCRIPTION
## Problem

When iOS pauses AirPlay it sends a `TEARDOWN` with `has_streams=1` — a stream-level teardown where the RTSP session stays alive. The handler correctly stopped audio and set `conn->stream_paused = true`, but never emitted `RTSP_EVENT_PAUSED`.

This meant any listener that tracks playback state (LED subsystem, Bluetooth switching logic) stayed in `STATE_PLAYING` indefinitely after a pause. The LED stayed solid; BT switching listeners saw no pause event.

## Fix

Emit `RTSP_EVENT_PAUSED` when `has_streams=true` (stream-level teardown, session still open). The existing `RTSP_EVENT_DISCONNECTED` path for full teardowns is unchanged.

## Testing

Tested on XIAO ESP32-S3 with AirPlay 2 (AAC). Pausing from iOS Control Centre triggers the event immediately; resuming and re-pausing works correctly across multiple cycles. LED transitions from solid → medium blink on pause and back to solid on resume as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small event-emission change on an existing teardown path; no auth or data handling impact.
> 
> **Overview**
> When iOS pauses AirPlay it often sends **TEARDOWN** with streams still listed (`has_streams=true`), keeping the RTSP session open while tearing down audio. `handle_teardown` already stopped playback and set `stream_paused`, but it never notified subscribers, so LED and Bluetooth logic could stay in **playing** state.
> 
> The handler now branches on `has_streams`: stream-level teardown calls **`rtsp_events_emit(RTSP_EVENT_PAUSED, NULL)`**; full session teardown behavior (DACP cleanup, NTP stop, disconnect handling) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633e964a3a0ae17e9e548b20debf17c51eec4990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->