### PR TITLE
Fix up metadata missing on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Advanced timing and metadata options under **AirPlay Receiver → AirPlay Protoc
 
 ### Cover Art / Artwork
 
-Album cover art is **disabled by default**. Most receivers have no screen (or only a small OLED), and receiving artwork images over the RTSP connection can stall the audio pipeline and cause drop-outs — especially on unbuffered AirPlay 1 / realtime streams. When disabled, the receiver removes the artwork type (`0`) from its advertised `md` txt record so senders don't transmit cover art, and ignores any artwork sent anyway. Track title, artist, album and progress metadata are always received.
+Album cover art is **disabled by default**. Most receivers have no screen (or only a small OLED), and receiving artwork images over the RTSP connection can stall the audio pipeline and cause drop-outs — especially on unbuffered AirPlay 1 / realtime streams. When disabled, the receiver removes the artwork type (`1`) from its advertised `md` txt record so senders don't transmit cover art, and ignores any artwork sent anyway. Track title, artist, album and progress metadata are always received.
 
 To enable cover art (e.g. if you have a TFT display):
 

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -26,13 +26,15 @@ static const char *TAG = "mdns_airplay";
 #define AIRPLAY_FLAGS "0x4"
 
 // Metadata types advertised in the "md" txt record:
-//   0 = artwork (cover art images), 1 = progress, 2 = text (track info).
-// When artwork is disabled, drop "0" so senders do not transmit cover art,
-// which can stall the audio pipeline and cause drop-outs on realtime streams.
+//   0 = text (track title/artist/album), 1 = artwork (cover art images),
+//   2 = progress.
+// When artwork is disabled, drop "1" so senders do not transmit cover art
+// (which can stall the audio pipeline and cause drop-outs on realtime
+// streams) while still sending text and progress metadata.
 #ifdef CONFIG_ENABLE_AIRPLAY_ARTWORK
 #define AIRPLAY_METADATA_TYPES "0,1,2"
 #else
-#define AIRPLAY_METADATA_TYPES "1,2"
+#define AIRPLAY_METADATA_TYPES "0,2"
 #endif
 
 // Model identifier - AudioAccessory for speaker appearance


### PR DESCRIPTION
Bug fix for the optionalization of artwork.
Track metadata is back for the screens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mDNS advertisement fix for metadata flags; no auth or audio pipeline logic changes beyond restoring text metadata negotiation.
> 
> **Overview**
> Fixes **missing track text on displays** after artwork was made optional: the RAOP **`md`** mDNS values used the wrong type indices.
> 
> **`mdns_airplay.c`** now matches Apple’s mapping (**`0`** = text, **`1`** = artwork, **`2`** = progress). With **`CONFIG_ENABLE_AIRPLAY_ARTWORK`** off, the advertised types change from **`1,2`** to **`0,2`** so senders still get title/artist/album and progress while **`1`** (artwork) stays out of the txt record. Comments are updated to match.
> 
> **`README.md`** documents the same artwork type **`1`** wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2a3b08c6584215109c8bf416c215a918adefa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->