### PR TITLE
Improve buffered audio recovery and drop stale RTP frames earlier

### DIFF
--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -106,31 +106,39 @@ static void playback_task(void *arg) {
       i2s_channel_enable(tx_handle);
     }
     size_t samples = audio_receiver_read(pcm, FRAME_SAMPLES + 1);
-    if (samples > 0) {
- //     ESP_LOGD(TAG, "Read %u samples from receiver", (unsigned int)samples);
-      int16_t *play_buf = pcm;
-      size_t play_samples = samples;
-      /*
-      if (audio_resample_is_active()) {
-        play_samples = audio_resample_process(pcm, samples, resample_buf,
-                                              MAX_RESAMPLE_FRAMES);
+   if (samples > 0) {
+    int16_t *play_buf = pcm;
+    size_t play_samples = samples;
+
+    if (audio_resample_is_active()) {
+        play_samples = audio_resample_process(
+            pcm,
+            samples,
+            resample_buf,
+            MAX_RESAMPLE_FRAMES
+        );
         play_buf = resample_buf;
-      }
-      */
- //     ESP_LOGD(TAG, "Resampled to %u samples", (unsigned int)play_samples);
-      apply_volume(play_buf, play_samples * 2);
-      apply_channel_mode(play_buf, play_samples);
-      led_audio_feed(play_buf, play_samples);
-      i2s_channel_write(tx_handle, play_buf, play_samples * 4, &written,
-                        portMAX_DELAY);
-//      ESP_LOGD(TAG, "I2S write: %u bytes written", (unsigned int)written);
-  //    taskYIELD();
-    } else {
+    }
+
+    apply_volume(play_buf, play_samples * 2);
+    apply_channel_mode(play_buf, play_samples);
+
+    led_audio_feed(play_buf, play_samples);
+
+    i2s_channel_write(
+        tx_handle,
+        play_buf,
+        play_samples * 2 * sizeof(int16_t),
+        &written,
+        portMAX_DELAY
+    );
+	}else {
       // ESP_LOGW(TAG, "Receiver underflow - playing silence");
       led_audio_feed(silence, FRAME_SAMPLES);
       i2s_channel_write(tx_handle, silence, (size_t)FRAME_SAMPLES * 4, &written,
                         portMAX_DELAY);
-     // vTaskDelay(1);
+    //  vTaskDelay(1);
+  
     }
   }
 

--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -107,28 +107,30 @@ static void playback_task(void *arg) {
     }
     size_t samples = audio_receiver_read(pcm, FRAME_SAMPLES + 1);
     if (samples > 0) {
-      ESP_LOGD(TAG, "Read %u samples from receiver", (unsigned int)samples);
+ //     ESP_LOGD(TAG, "Read %u samples from receiver", (unsigned int)samples);
       int16_t *play_buf = pcm;
       size_t play_samples = samples;
+      /*
       if (audio_resample_is_active()) {
         play_samples = audio_resample_process(pcm, samples, resample_buf,
                                               MAX_RESAMPLE_FRAMES);
         play_buf = resample_buf;
       }
-      ESP_LOGD(TAG, "Resampled to %u samples", (unsigned int)play_samples);
+      */
+ //     ESP_LOGD(TAG, "Resampled to %u samples", (unsigned int)play_samples);
       apply_volume(play_buf, play_samples * 2);
       apply_channel_mode(play_buf, play_samples);
       led_audio_feed(play_buf, play_samples);
       i2s_channel_write(tx_handle, play_buf, play_samples * 4, &written,
                         portMAX_DELAY);
-      ESP_LOGD(TAG, "I2S write: %u bytes written", (unsigned int)written);
-      taskYIELD();
+//      ESP_LOGD(TAG, "I2S write: %u bytes written", (unsigned int)written);
+  //    taskYIELD();
     } else {
       // ESP_LOGW(TAG, "Receiver underflow - playing silence");
       led_audio_feed(silence, FRAME_SAMPLES);
       i2s_channel_write(tx_handle, silence, (size_t)FRAME_SAMPLES * 4, &written,
-                        pdMS_TO_TICKS(10));
-      vTaskDelay(1);
+                        portMAX_DELAY);
+     // vTaskDelay(1);
     }
   }
 

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -97,6 +97,18 @@ typedef struct {
   bool paused_rtp_valid;
 } audio_receiver_state_t;
 
+// Lightweight RTP gate used by the buffered TCP task before decrypt/decode.
+// Returns false for frames that belong to the pre-seek/old-track backlog.
+bool audio_stream_accept_timestamp(audio_receiver_state_t *state,
+                                   uint32_t timestamp);
+
+// Decode and queue a frame whose timestamp has already passed the RTP gate.
+bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
+                                         uint32_t timestamp,
+                                         const uint8_t *audio_data,
+                                         size_t audio_len);
+
+// Convenience entry point for realtime paths: gate, decode and queue.
 bool audio_stream_process_frame(audio_receiver_state_t *state,
                                 uint32_t timestamp, const uint8_t *audio_data,
                                 size_t audio_len);

--- a/main/audio/audio_stream.c
+++ b/main/audio/audio_stream.c
@@ -26,36 +26,45 @@ static bool apply_aac_transient_mute(audio_receiver_state_t *state,
   return false;
 }
 
-bool audio_stream_process_frame(audio_receiver_state_t *state,
-                                uint32_t timestamp, const uint8_t *audio_data,
-                                size_t audio_len) {
-  if (!state || !state->decoder) {
+bool audio_stream_accept_timestamp(audio_receiver_state_t *state,
+                                   uint32_t timestamp) {
+  if (!state) {
     return false;
   }
 
-  // Blanket gate: reject everything between seek_flush and the next anchor.
+  // Reject everything between a seek/track flush and the next anchor.  This
+  // check deliberately happens before decrypt/decode in the buffered TCP task.
   if (state->discard_all_until_anchor) {
     return false;
   }
 
-  // Post-seek RTP window gate: discard frames outside [discard_before_rtp,
-  // discard_above_rtp].  The TCP socket buffer can hold many seconds of
-  // pre-seek audio; both gates together handle both seek directions:
-  //   discard_before_rtp — forward seek: stale frames have lower RTP
-  //   discard_above_rtp  — backward seek: stale frames have much higher RTP
-  // Each self-disarms on the first frame that passes it.
+  // Post-seek RTP window gate.  TCP preserves order, so stale packets drain
+  // first and each gate can self-disarm on the first timestamp that passes.
   if (state->discard_before_rtp_valid) {
     if ((int32_t)(timestamp - state->discard_before_rtp) < 0) {
-      return false; // below lower bound — forward-seek stale frame
+      return false;
     }
     state->discard_before_rtp_valid = false;
   }
+
   if (state->discard_above_rtp_valid) {
     if ((int32_t)(timestamp - state->discard_above_rtp) > 0) {
-      return false; // above upper bound — backward-seek stale frame
+      return false;
     }
     state->discard_above_rtp_valid = false;
   }
+
+  return true;
+}
+
+bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
+                                         uint32_t timestamp,
+                                         const uint8_t *audio_data,
+                                         size_t audio_len) {
+  if (!state || !state->decoder) {
+    return false;
+  }
+
   size_t capacity_samples = 0;
   int16_t *decode_buffer =
       audio_buffer_get_decode_buffer(&state->buffer, &capacity_samples);
@@ -83,6 +92,16 @@ bool audio_stream_process_frame(audio_receiver_state_t *state,
   return audio_buffer_queue_decoded(&state->buffer, &state->stats, timestamp,
                                     decode_buffer, (size_t)decoded_samples,
                                     channels);
+}
+
+bool audio_stream_process_frame(audio_receiver_state_t *state,
+                                uint32_t timestamp, const uint8_t *audio_data,
+                                size_t audio_len) {
+  if (!audio_stream_accept_timestamp(state, timestamp)) {
+    return false;
+  }
+  return audio_stream_process_accepted_frame(state, timestamp, audio_data,
+                                             audio_len);
 }
 
 audio_stream_t *audio_stream_create_realtime(void) {

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -132,6 +132,14 @@ static void buffered_audio_task(void *pvParameters) {
       uint32_t timestamp =
           (packet[4] << 24) | (packet[5] << 16) | (packet[6] << 8) | packet[7];
 
+      // Drop stale pre-seek/old-track packets before AES and AAC work.  The
+      // bytes still have to be drained from TCP, but they no longer consume
+      // decoder time or enter the PCM ring buffer.
+      if (!audio_stream_accept_timestamp(state, timestamp)) {
+        state->stats.packets_dropped++;
+        continue;
+      }
+
       uint8_t *decrypted = state->decrypt_buffer;
       size_t decrypt_capacity = state->decrypt_buffer_size;
       if (!decrypted) {
@@ -153,8 +161,8 @@ static void buffered_audio_task(void *pvParameters) {
       state->blocks_read++;
       state->blocks_read_in_sequence++;
 
-      if (!audio_stream_process_frame(state, timestamp, decrypted,
-                                      (size_t)decrypted_len)) {
+      if (!audio_stream_process_accepted_frame(state, timestamp, decrypted,
+                                               (size_t)decrypted_len)) {
         state->stats.packets_dropped++;
       }
     }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -162,6 +162,9 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
+
+  timing->late_drop_count = 0;
+  timing->late_drop_active = false;
 }
 
 void audio_timing_set_format(audio_timing_t *timing,
@@ -273,73 +276,67 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   const audio_format_t *format = &stream->format;
   int buffered_frames = audio_buffer_get_frame_count(buffer);
 
-  size_t dropped_frames = 0;
-  int64_t first_late_us = 0;
-  int64_t last_late_us = 0;
   // Unbuffered realtime streams (ALAC/UDP) get a looser early/late threshold
   // than buffered AirPlay 2 streams, because they have little jitter buffer to
-  // absorb scheduling hiccups and would otherwise drop frames (audible
-  // drop-outs) whenever the pipeline stalls — e.g. while artwork/metadata is
-  // received on the RTSP connection.
-  const int64_t timing_threshold_us = audio_stream_uses_buffer(stream->type)
-                                          ? TIMING_THRESHOLD_US
-                                          : RT_TIMING_THRESHOLD_US;
+  // absorb scheduling hiccups and would otherwise drop frames.
+  const int64_t timing_threshold_us =
+      audio_stream_uses_buffer(stream->type)
+          ? TIMING_THRESHOLD_US
+          : RT_TIMING_THRESHOLD_US;
 
   // Wait for enough buffer before starting.
   // In quick_start mode (after a seek/skip), start as soon as 1 frame is
-  // available to minimise the gap between tracks.  Anchor-based timing
-  // still applies — if the frame is early, silence is output until its
-  // scheduled play time, just like shairport-sync.
-  // Normal startup waits for target_buffer_frames to build jitter margin.
+  // available to minimise the gap between tracks.
   if (!timing->playout_started && !timing->pending_valid) {
-    int required = timing->quick_start ? 1 : (int)timing->target_buffer_frames;
+    int required =
+        timing->quick_start ? 1 : (int)timing->target_buffer_frames;
+
     if (buffered_frames < required) {
       return 0;
     }
+
     // Wait for anchor before playing.
-    // Normal startup: allow a 1-second fallback so a stream with no anchor
-    // (e.g. AirPlay 1 without NTP) can still start.
+    // Allow a 1-second fallback if no anchor arrives.
     if (!timing->anchor_valid) {
       int64_t now_us = esp_timer_get_time();
+
       if (timing->ready_time_us == 0) {
         timing->ready_time_us = now_us;
       }
+
       if (now_us - timing->ready_time_us < 1000000) {
-        return 0; // Still waiting for anchor
+        return 0;
       }
-      // Waited 1 second, no anchor - proceed without sync
     }
   }
 
-  // Determine sync mode: PTP (AirPlay 2), NTP (AirPlay 1), or local fallback
+  // Determine sync mode: PTP, NTP or local fallback.
   sync_mode_t sync_mode = SYNC_MODE_NONE;
+
   if (ptp_clock_is_locked()) {
     sync_mode = SYNC_MODE_PTP;
   } else if (ntp_clock_is_locked()) {
     sync_mode = SYNC_MODE_NTP;
   }
 
-  // Drain up to MAX_DRAIN_ATTEMPTS late/invalid frames within a SINGLE
-  // DMA callback.  The previous limit of 8 was the root cause of run-away
-  // lateness: each call that returned silence (instead of playing a frame)
-  // forfeited ~23 ms of RTP advancement while wall time kept moving, so
-  // every late frame we dropped MADE us more late.  Draining many frames
-  // in one pass advances RTP at zero wall-time cost and lets the buffer
-  // skip past stale data without the DMA ever idling.
+  // Drain many stale frames within one call.
   enum { MAX_DRAIN_ATTEMPTS = 256 };
+
   for (int attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
     size_t item_size = 0;
     void *item = NULL;
     bool from_pending = false;
 
-    // Get frame from pending or buffer
+    // Get frame from pending storage or from the sorted audio buffer.
     if (timing->pending_valid) {
       item_size = timing->pending_frame_len;
+
       if (item_size < sizeof(audio_frame_header_t)) {
         timing->pending_valid = false;
         timing->pending_frame_len = 0;
         continue;
       }
+
       item = timing->pending_frame;
       from_pending = true;
     } else {
@@ -347,8 +344,12 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         if (stats) {
           stats->buffer_underruns++;
         }
+
+        // Не принтираме тук. Изхвърлянето може да продължи
+        // при следващото извикване на функцията.
         return 0;
       }
+
       buffered_frames = audio_buffer_get_frame_count(buffer);
 
       if (item_size < sizeof(audio_frame_header_t)) {
@@ -358,11 +359,14 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     }
 
     audio_frame_header_t *hdr = (audio_frame_header_t *)item;
+
     size_t frame_samples = hdr->samples_per_channel;
-    size_t channels = hdr->channels ? hdr->channels : format->channels;
+    size_t channels =
+        hdr->channels ? hdr->channels : format->channels;
+
     int16_t *pcm = (int16_t *)(hdr + 1);
 
-    // Validate frame
+    // Validate frame.
     if (frame_samples == 0 || channels == 0) {
       if (from_pending) {
         timing->pending_valid = false;
@@ -370,11 +374,14 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       } else {
         audio_buffer_return(buffer, item);
       }
+
       continue;
     }
 
     size_t expected_bytes =
-        sizeof(*hdr) + frame_samples * channels * sizeof(int16_t);
+        sizeof(*hdr) +
+        frame_samples * channels * sizeof(int16_t);
+
     if (item_size < expected_bytes) {
       if (from_pending) {
         timing->pending_valid = false;
@@ -382,6 +389,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       } else {
         audio_buffer_return(buffer, item);
       }
+
       continue;
     }
 
@@ -389,174 +397,196 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       frame_samples = samples;
     }
 
-    // Deferred flush check (AirPlay 2 FLUSHBUFFERED with flushFromSeq):
-    // keep playing until the frame whose RTP timestamp reaches flush_until_ts,
-    // then bulk-flush the remainder of the buffer and start fresh.
-    // Signed 32-bit subtraction handles RTP wraparound correctly.
+    // Deferred flush check.
     if (timing->deferred_flush_pending) {
-      if ((int32_t)(hdr->rtp_timestamp - timing->flush_until_ts) >= 0) {
+      if ((int32_t)(hdr->rtp_timestamp -
+                    timing->flush_until_ts) >= 0) {
         ESP_LOGI(TAG,
-                 "Deferred flush triggered at ts=%" PRIu32 " (until_ts=%" PRIu32
-                 ")",
-                 hdr->rtp_timestamp, timing->flush_until_ts);
+                 "Deferred flush triggered at ts=%" PRIu32
+                 " (until_ts=%" PRIu32 ")",
+                 hdr->rtp_timestamp,
+                 timing->flush_until_ts);
+
         if (from_pending) {
           timing->pending_valid = false;
           timing->pending_frame_len = 0;
         } else {
           audio_buffer_return(buffer, item);
         }
+
         audio_buffer_flush(buffer);
+
         timing->deferred_flush_pending = false;
         timing->playout_started = false;
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;
-        // quick_start so the first frame of the next track starts playing
-        // as soon as 1 frame arrives, with normal anchor timing applied.
+
+        // Запазваме брояча на изхвърлените late кадри.
+        // Той ще бъде принтиран, когато започне реално възпроизвеждане.
         timing->quick_start = true;
+
         return 0;
       }
     }
 
     // Handle early/late frames based on anchor timing.
-    //
-    // After a seek/flush, anchor-based timing is applied immediately from the
-    // first frame — no bypass.  With a stable PTP clock the anchor is
-    // accurate, so early frames are held as pending (silence output) until
-    // their scheduled play time, and late frames are dropped.  This mirrors
-    // shairport-sync's approach and guarantees the first audible sample is
-    // correctly synchronised.
     if (timing->anchor_valid && format->sample_rate > 0) {
       int64_t early_us = 0;
-      if (compute_early_us(timing, format, hdr->rtp_timestamp, sync_mode,
+
+      if (compute_early_us(timing,
+                           format,
+                           hdr->rtp_timestamp,
+                           sync_mode,
                            &early_us)) {
+
         if (early_us > timing_threshold_us) {
-          // Only advance the stuck-anchor counter for NEW frames taken from
-          // the buffer — not for pending re-checks of the same early frame.
-          // A pending frame is re-examined every DMA callback (~8 ms) while
-          // we wait for wall-clock to reach its scheduled play time.  Counting
-          // those re-checks would fire the stuck-anchor detector in
-          // (MAX_CONSECUTIVE_EARLY × 8 ms) = 6 s even for a legitimately
-          // early frame that just needs to wait its pre-buffer depth (~1.5 s).
+          // Count only new early frames, not repeated checks of pending frame.
           if (!from_pending) {
             timing->consecutive_early_frames++;
-            // Log the first early frame after each anchor set (shows lead
-            // time before audio starts) and every 50 new frames after that
-            // (confirms the counter only counts real buffer reads, not
-            // pending re-checks).
+
             if (timing->consecutive_early_frames == 1) {
               ESP_LOGI(TAG,
-                       "First early frame: rtp=%" PRIu32 " early=%.1f ms"
-                       " quick_start=%d buffered=%d",
-                       hdr->rtp_timestamp, (float)early_us / 1000.0f,
-                       timing->quick_start, buffered_frames);
-            } else if (timing->consecutive_early_frames % 50 == 0) {
-              ESP_LOGD(TAG, "Early counter: %d/%d early=%.1f ms rtp=%" PRIu32,
-                       timing->consecutive_early_frames, MAX_CONSECUTIVE_EARLY,
-                       (float)early_us / 1000.0f, hdr->rtp_timestamp);
+                       "First early frame: rtp=%" PRIu32
+                       " early=%.1f ms quick_start=%d buffered=%d",
+                       hdr->rtp_timestamp,
+                       (float)early_us / 1000.0f,
+                       timing->quick_start,
+                       buffered_frames);
+            } else if (
+                timing->consecutive_early_frames % 50 == 0) {
+              ESP_LOGD(TAG,
+                       "Early counter: %d/%d early=%.1f ms "
+                       "rtp=%" PRIu32,
+                       timing->consecutive_early_frames,
+                       MAX_CONSECUTIVE_EARLY,
+                       (float)early_us / 1000.0f,
+                       hdr->rtp_timestamp);
             }
           }
 
-          // If we have had an implausibly long run of early frames the anchor
-          // is probably stuck or wrong — give up on it so playback can
-          // continue.  This threshold is high enough (~17 s at 23 ms/frame)
-          // that it never fires during normal pre-buffered-audio scenarios.
-          if (timing->consecutive_early_frames > MAX_CONSECUTIVE_EARLY) {
+          if (timing->consecutive_early_frames >
+              MAX_CONSECUTIVE_EARLY) {
             ESP_LOGW(TAG,
-                     "Invalidating stuck anchor: consecutive=%d, early=%lld ms",
-                     timing->consecutive_early_frames, early_us / 1000LL);
+                     "Invalidating stuck anchor: "
+                     "consecutive=%d, early=%lld ms",
+                     timing->consecutive_early_frames,
+                     early_us / 1000LL);
+
             timing->anchor_valid = false;
             timing->consecutive_early_frames = 0;
-            // Fall through to play the frame normally
+
+            // Continue below and play the frame normally.
           } else {
-            // Frame is early — store it as pending and output silence.
-            // The pending frame is re-checked on every subsequent call;
-            // once wall-clock catches up it will be played on time.
-            // This is the normal path for pre-buffered audio after a pause.
+            // Store early frame as pending and output silence.
             static int early_count = 0;
             early_count++;
+
             if (early_count % 100 == 1) {
               ESP_LOGD(TAG,
-                       "Frame too early #%d: %lld ms, buffered=%d, pending=%d",
-                       early_count, early_us / 1000LL, buffered_frames,
+                       "Frame too early #%d: %lld ms, "
+                       "buffered=%d, pending=%d",
+                       early_count,
+                       early_us / 1000LL,
+                       buffered_frames,
                        timing->pending_valid ? 1 : 0);
             }
-            if (!from_pending && timing->pending_frame &&
-                item_size <= timing->pending_frame_capacity) {
-              memcpy(timing->pending_frame, item, item_size);
+
+            if (!from_pending &&
+                timing->pending_frame &&
+                item_size <=
+                    timing->pending_frame_capacity) {
+
+              memcpy(timing->pending_frame,
+                     item,
+                     item_size);
+
               timing->pending_frame_len = item_size;
               timing->pending_valid = true;
+
               audio_buffer_return(buffer, item);
             }
-            memset(out, 0, samples * channels * sizeof(int16_t));
+
+            memset(out,
+                   0,
+                   samples * channels * sizeof(int16_t));
+
+            // Не принтираме late брояча тук.
+            // Все още не е намерен нормален кадър.
             return samples;
           }
+
         } else if (early_us < -timing_threshold_us) {
-          // Reset consecutive early counter on late/normal frames
           timing->consecutive_early_frames = 0;
 
-          // Late frame — drop it and continue draining within the SAME call.
-          // The 256-attempt drain loop chews through stale frames at zero
-          // wall-time cost, skipping past arbitrarily many stale frames in
-          // one pass without the DMA ever idling.
-          if (dropped_frames == 0) {
-            first_late_us = -early_us;
-          }
-
-          last_late_us = -early_us;
-          dropped_frames++;
+          // Само натрупваме броя.
+          // Няма лог за всеки кадър и няма лог при всяко извикване.
+          timing->late_drop_count++;
+          timing->late_drop_active = true;
 
           if (stats) {
             stats->late_frames++;
           }
+
           if (from_pending) {
             timing->pending_valid = false;
             timing->pending_frame_len = 0;
           } else {
             audio_buffer_return(buffer, item);
           }
+
           continue;
         }
       }
     }
 
-    // Frame is on time (or anchor-invalid) — reset counter.
+    // Frame is on time or anchor is invalid.
     timing->consecutive_early_frames = 0;
 
-    // Copy PCM data to output
-    memcpy(out, pcm, frame_samples * channels * sizeof(int16_t));
+    // Запазваме RTP timestamp, преди да върнем item в буфера.
+    uint32_t played_rtp_timestamp =
+        hdr->rtp_timestamp;
 
-    // Cleanup
+    // Copy PCM data to output.
+    memcpy(out,
+           pcm,
+           frame_samples * channels * sizeof(int16_t));
+
+    // Cleanup.
     if (from_pending) {
       timing->pending_valid = false;
       timing->pending_frame_len = 0;
     } else {
       audio_buffer_return(buffer, item);
     }
-    if (dropped_frames) {
-    ESP_LOGW(TAG,
-             "Dropped %u late frames (%lld -> %lld ms), buffer=%d",
-             (unsigned)dropped_frames,
-             first_late_us / 1000LL,
-             last_late_us / 1000LL,
-             audio_buffer_get_frame_count(buffer));
-    }
+
     if (!timing->playout_started) {
       timing->playout_started = true;
+
       bool was_quick = timing->quick_start;
       timing->quick_start = false;
-      ESP_LOGI(TAG, "Playout started%s: rtp=%" PRIu32,
-               was_quick ? " (quick_start)" : "", hdr->rtp_timestamp);
+
+      ESP_LOGI(TAG,
+               "Playout started%s: rtp=%" PRIu32,
+               was_quick ? " (quick_start)" : "",
+               played_rtp_timestamp);
+    }
+
+    // Принтира се само веднъж, когато след всички late кадри
+    // най-накрая бъде намерен кадър за възпроизвеждане.
+    if (timing->late_drop_active) {
+      ESP_LOGW(TAG,
+               "Total dropped late frames: %" PRIu32,
+               timing->late_drop_count);
+
+      timing->late_drop_count = 0;
+      timing->late_drop_active = false;
     }
 
     return frame_samples;
   }
-  if (dropped_frames) {
-    ESP_LOGW(TAG,
-             "Dropped %u late frames (%lld -> %lld ms), buffer=%d",
-             (unsigned)dropped_frames,
-             first_late_us / 1000LL,
-             last_late_us / 1000LL,
-             audio_buffer_get_frame_count(buffer));
-  }
+
+  // Достигнат е лимитът от 256 опита.
+  // Не принтираме нищо, защото изхвърлянето ще продължи
+  // при следващото извикване.
   return 0;
 }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -273,6 +273,9 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   const audio_format_t *format = &stream->format;
   int buffered_frames = audio_buffer_get_frame_count(buffer);
 
+  size_t dropped_frames = 0;
+  int64_t first_late_us = 0;
+  int64_t last_late_us = 0;
   // Unbuffered realtime streams (ALAC/UDP) get a looser early/late threshold
   // than buffered AirPlay 2 streams, because they have little jitter buffer to
   // absorb scheduling hiccups and would otherwise drop frames (audible
@@ -495,7 +498,13 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
           // The 256-attempt drain loop chews through stale frames at zero
           // wall-time cost, skipping past arbitrarily many stale frames in
           // one pass without the DMA ever idling.
-          ESP_LOGW(TAG, "Dropping late frame: %lld ms", -early_us / 1000LL);
+          if (dropped_frames == 0) {
+            first_late_us = -early_us;
+          }
+
+          last_late_us = -early_us;
+          dropped_frames++;
+
           if (stats) {
             stats->late_frames++;
           }
@@ -523,7 +532,14 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     } else {
       audio_buffer_return(buffer, item);
     }
-
+    if (dropped_frames) {
+    ESP_LOGW(TAG,
+             "Dropped %u late frames (%lld -> %lld ms), buffer=%d",
+             (unsigned)dropped_frames,
+             first_late_us / 1000LL,
+             last_late_us / 1000LL,
+             audio_buffer_get_frame_count(buffer));
+    }
     if (!timing->playout_started) {
       timing->playout_started = true;
       bool was_quick = timing->quick_start;
@@ -534,6 +550,13 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
     return frame_samples;
   }
-
+  if (dropped_frames) {
+    ESP_LOGW(TAG,
+             "Dropped %u late frames (%lld -> %lld ms), buffer=%d",
+             (unsigned)dropped_frames,
+             first_late_us / 1000LL,
+             last_late_us / 1000LL,
+             audio_buffer_get_frame_count(buffer));
+  }
   return 0;
 }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -162,7 +162,6 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
-
   timing->late_drop_count = 0;
   timing->late_drop_active = false;
 }
@@ -278,65 +277,71 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
   // Unbuffered realtime streams (ALAC/UDP) get a looser early/late threshold
   // than buffered AirPlay 2 streams, because they have little jitter buffer to
-  // absorb scheduling hiccups and would otherwise drop frames.
-  const int64_t timing_threshold_us =
-      audio_stream_uses_buffer(stream->type)
-          ? TIMING_THRESHOLD_US
-          : RT_TIMING_THRESHOLD_US;
+  // absorb scheduling hiccups and would otherwise drop frames (audible
+  // drop-outs) whenever the pipeline stalls — e.g. while artwork/metadata is
+  // received on the RTSP connection.
+  const int64_t timing_threshold_us = audio_stream_uses_buffer(stream->type)
+                                          ? TIMING_THRESHOLD_US
+                                          : RT_TIMING_THRESHOLD_US;
 
   // Wait for enough buffer before starting.
   // In quick_start mode (after a seek/skip), start as soon as 1 frame is
-  // available to minimise the gap between tracks.
+  // available to minimise the gap between tracks.  Anchor-based timing
+  // still applies — if the frame is early, silence is output until its
+  // scheduled play time, just like shairport-sync.
+  // Normal startup waits for target_buffer_frames to build jitter margin.
   if (!timing->playout_started && !timing->pending_valid) {
-    int required =
-        timing->quick_start ? 1 : (int)timing->target_buffer_frames;
-
+    int required = timing->quick_start ? 1 : (int)timing->target_buffer_frames;
     if (buffered_frames < required) {
       return 0;
     }
-
     // Wait for anchor before playing.
-    // Allow a 1-second fallback if no anchor arrives.
+    // Normal startup: allow a 1-second fallback so a stream with no anchor
+    // (e.g. AirPlay 1 without NTP) can still start.
     if (!timing->anchor_valid) {
       int64_t now_us = esp_timer_get_time();
-
       if (timing->ready_time_us == 0) {
         timing->ready_time_us = now_us;
       }
-
       if (now_us - timing->ready_time_us < 1000000) {
-        return 0;
+        return 0; // Still waiting for anchor
       }
+      // Waited 1 second, no anchor - proceed without sync
     }
   }
 
-  // Determine sync mode: PTP, NTP or local fallback.
+  // Determine sync mode: PTP (AirPlay 2), NTP (AirPlay 1), or local fallback
   sync_mode_t sync_mode = SYNC_MODE_NONE;
-
   if (ptp_clock_is_locked()) {
     sync_mode = SYNC_MODE_PTP;
   } else if (ntp_clock_is_locked()) {
     sync_mode = SYNC_MODE_NTP;
   }
 
-  // Drain many stale frames within one call.
-  enum { MAX_DRAIN_ATTEMPTS = 256 };
-
+  // Keep the DMA/I2S task bounded.  Stale frames are still drained in
+  // batches, but a single callback may spend at most ~1.5 ms here.  The RTP
+  // gate in the buffered receiver prevents new old-track frames from being
+  // decoded, so this loop normally only clears a small residual PCM backlog.
+  enum { MAX_DRAIN_ATTEMPTS = 64 };
+  const int64_t drain_deadline_us = esp_timer_get_time() + 1500;
   for (int attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
+    // Checking every eight iterations reduces esp_timer overhead.
+    if ((attempt & 7) == 0 && attempt != 0 &&
+        esp_timer_get_time() >= drain_deadline_us) {
+      break;
+    }
     size_t item_size = 0;
     void *item = NULL;
     bool from_pending = false;
 
-    // Get frame from pending storage or from the sorted audio buffer.
+    // Get frame from pending or buffer
     if (timing->pending_valid) {
       item_size = timing->pending_frame_len;
-
       if (item_size < sizeof(audio_frame_header_t)) {
         timing->pending_valid = false;
         timing->pending_frame_len = 0;
         continue;
       }
-
       item = timing->pending_frame;
       from_pending = true;
     } else {
@@ -344,12 +349,8 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         if (stats) {
           stats->buffer_underruns++;
         }
-
-        // Не принтираме тук. Изхвърлянето може да продължи
-        // при следващото извикване на функцията.
         return 0;
       }
-
       buffered_frames = audio_buffer_get_frame_count(buffer);
 
       if (item_size < sizeof(audio_frame_header_t)) {
@@ -359,14 +360,11 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     }
 
     audio_frame_header_t *hdr = (audio_frame_header_t *)item;
-
     size_t frame_samples = hdr->samples_per_channel;
-    size_t channels =
-        hdr->channels ? hdr->channels : format->channels;
-
+    size_t channels = hdr->channels ? hdr->channels : format->channels;
     int16_t *pcm = (int16_t *)(hdr + 1);
 
-    // Validate frame.
+    // Validate frame
     if (frame_samples == 0 || channels == 0) {
       if (from_pending) {
         timing->pending_valid = false;
@@ -374,14 +372,11 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       } else {
         audio_buffer_return(buffer, item);
       }
-
       continue;
     }
 
     size_t expected_bytes =
-        sizeof(*hdr) +
-        frame_samples * channels * sizeof(int16_t);
-
+        sizeof(*hdr) + frame_samples * channels * sizeof(int16_t);
     if (item_size < expected_bytes) {
       if (from_pending) {
         timing->pending_valid = false;
@@ -389,7 +384,6 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       } else {
         audio_buffer_return(buffer, item);
       }
-
       continue;
     }
 
@@ -397,161 +391,139 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       frame_samples = samples;
     }
 
-    // Deferred flush check.
+    // Deferred flush check (AirPlay 2 FLUSHBUFFERED with flushFromSeq):
+    // keep playing until the frame whose RTP timestamp reaches flush_until_ts,
+    // then bulk-flush the remainder of the buffer and start fresh.
+    // Signed 32-bit subtraction handles RTP wraparound correctly.
     if (timing->deferred_flush_pending) {
-      if ((int32_t)(hdr->rtp_timestamp -
-                    timing->flush_until_ts) >= 0) {
+      if ((int32_t)(hdr->rtp_timestamp - timing->flush_until_ts) >= 0) {
         ESP_LOGI(TAG,
-                 "Deferred flush triggered at ts=%" PRIu32
-                 " (until_ts=%" PRIu32 ")",
-                 hdr->rtp_timestamp,
-                 timing->flush_until_ts);
-
+                 "Deferred flush triggered at ts=%" PRIu32 " (until_ts=%" PRIu32
+                 ")",
+                 hdr->rtp_timestamp, timing->flush_until_ts);
         if (from_pending) {
           timing->pending_valid = false;
           timing->pending_frame_len = 0;
         } else {
           audio_buffer_return(buffer, item);
         }
-
         audio_buffer_flush(buffer);
-
         timing->deferred_flush_pending = false;
         timing->playout_started = false;
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;
-
-        // Запазваме брояча на изхвърлените late кадри.
-        // Той ще бъде принтиран, когато започне реално възпроизвеждане.
+        // quick_start so the first frame of the next track starts playing
+        // as soon as 1 frame arrives, with normal anchor timing applied.
         timing->quick_start = true;
-
         return 0;
       }
     }
 
     // Handle early/late frames based on anchor timing.
+    //
+    // After a seek/flush, anchor-based timing is applied immediately from the
+    // first frame — no bypass.  With a stable PTP clock the anchor is
+    // accurate, so early frames are held as pending (silence output) until
+    // their scheduled play time, and late frames are dropped.  This mirrors
+    // shairport-sync's approach and guarantees the first audible sample is
+    // correctly synchronised.
     if (timing->anchor_valid && format->sample_rate > 0) {
       int64_t early_us = 0;
-
-      if (compute_early_us(timing,
-                           format,
-                           hdr->rtp_timestamp,
-                           sync_mode,
+      if (compute_early_us(timing, format, hdr->rtp_timestamp, sync_mode,
                            &early_us)) {
-
         if (early_us > timing_threshold_us) {
-          // Count only new early frames, not repeated checks of pending frame.
+          // Only advance the stuck-anchor counter for NEW frames taken from
+          // the buffer — not for pending re-checks of the same early frame.
+          // A pending frame is re-examined every DMA callback (~8 ms) while
+          // we wait for wall-clock to reach its scheduled play time.  Counting
+          // those re-checks would fire the stuck-anchor detector in
+          // (MAX_CONSECUTIVE_EARLY × 8 ms) = 6 s even for a legitimately
+          // early frame that just needs to wait its pre-buffer depth (~1.5 s).
           if (!from_pending) {
             timing->consecutive_early_frames++;
-
+            // Log the first early frame after each anchor set (shows lead
+            // time before audio starts) and every 50 new frames after that
+            // (confirms the counter only counts real buffer reads, not
+            // pending re-checks).
             if (timing->consecutive_early_frames == 1) {
               ESP_LOGI(TAG,
-                       "First early frame: rtp=%" PRIu32
-                       " early=%.1f ms quick_start=%d buffered=%d",
-                       hdr->rtp_timestamp,
-                       (float)early_us / 1000.0f,
-                       timing->quick_start,
-                       buffered_frames);
-            } else if (
-                timing->consecutive_early_frames % 50 == 0) {
-              ESP_LOGD(TAG,
-                       "Early counter: %d/%d early=%.1f ms "
-                       "rtp=%" PRIu32,
-                       timing->consecutive_early_frames,
-                       MAX_CONSECUTIVE_EARLY,
-                       (float)early_us / 1000.0f,
-                       hdr->rtp_timestamp);
+                       "First early frame: rtp=%" PRIu32 " early=%.1f ms"
+                       " quick_start=%d buffered=%d",
+                       hdr->rtp_timestamp, (float)early_us / 1000.0f,
+                       timing->quick_start, buffered_frames);
+            } else if (timing->consecutive_early_frames % 50 == 0) {
+              ESP_LOGD(TAG, "Early counter: %d/%d early=%.1f ms rtp=%" PRIu32,
+                       timing->consecutive_early_frames, MAX_CONSECUTIVE_EARLY,
+                       (float)early_us / 1000.0f, hdr->rtp_timestamp);
             }
           }
 
-          if (timing->consecutive_early_frames >
-              MAX_CONSECUTIVE_EARLY) {
+          // If we have had an implausibly long run of early frames the anchor
+          // is probably stuck or wrong — give up on it so playback can
+          // continue.  This threshold is high enough (~17 s at 23 ms/frame)
+          // that it never fires during normal pre-buffered-audio scenarios.
+          if (timing->consecutive_early_frames > MAX_CONSECUTIVE_EARLY) {
             ESP_LOGW(TAG,
-                     "Invalidating stuck anchor: "
-                     "consecutive=%d, early=%lld ms",
-                     timing->consecutive_early_frames,
-                     early_us / 1000LL);
-
+                     "Invalidating stuck anchor: consecutive=%d, early=%lld ms",
+                     timing->consecutive_early_frames, early_us / 1000LL);
             timing->anchor_valid = false;
             timing->consecutive_early_frames = 0;
-
-            // Continue below and play the frame normally.
+            // Fall through to play the frame normally
           } else {
-            // Store early frame as pending and output silence.
+            // Frame is early — store it as pending and output silence.
+            // The pending frame is re-checked on every subsequent call;
+            // once wall-clock catches up it will be played on time.
+            // This is the normal path for pre-buffered audio after a pause.
             static int early_count = 0;
             early_count++;
-
             if (early_count % 100 == 1) {
               ESP_LOGD(TAG,
-                       "Frame too early #%d: %lld ms, "
-                       "buffered=%d, pending=%d",
-                       early_count,
-                       early_us / 1000LL,
-                       buffered_frames,
+                       "Frame too early #%d: %lld ms, buffered=%d, pending=%d",
+                       early_count, early_us / 1000LL, buffered_frames,
                        timing->pending_valid ? 1 : 0);
             }
-
-            if (!from_pending &&
-                timing->pending_frame &&
-                item_size <=
-                    timing->pending_frame_capacity) {
-
-              memcpy(timing->pending_frame,
-                     item,
-                     item_size);
-
+            if (!from_pending && timing->pending_frame &&
+                item_size <= timing->pending_frame_capacity) {
+              memcpy(timing->pending_frame, item, item_size);
               timing->pending_frame_len = item_size;
               timing->pending_valid = true;
-
               audio_buffer_return(buffer, item);
             }
-
-            memset(out,
-                   0,
-                   samples * channels * sizeof(int16_t));
-
-            // Не принтираме late брояча тук.
-            // Все още не е намерен нормален кадър.
+            memset(out, 0, samples * channels * sizeof(int16_t));
             return samples;
           }
-
         } else if (early_us < -timing_threshold_us) {
+          // Reset consecutive early counter on late/normal frames
           timing->consecutive_early_frames = 0;
 
-          // Само натрупваме броя.
-          // Няма лог за всеки кадър и няма лог при всяко извикване.
+          // Late frame: count it and continue within the bounded drain budget.
+          // Do not log here; UART logging in the playback task is expensive.
           timing->late_drop_count++;
           timing->late_drop_active = true;
-
           if (stats) {
             stats->late_frames++;
           }
-
           if (from_pending) {
             timing->pending_valid = false;
             timing->pending_frame_len = 0;
           } else {
             audio_buffer_return(buffer, item);
           }
-
           continue;
         }
       }
     }
 
-    // Frame is on time or anchor is invalid.
+    // Frame is on time (or anchor-invalid) — reset counter.
     timing->consecutive_early_frames = 0;
 
-    // Запазваме RTP timestamp, преди да върнем item в буфера.
-    uint32_t played_rtp_timestamp =
-        hdr->rtp_timestamp;
+    // Save metadata before returning the pool slot.
+    uint32_t played_rtp_timestamp = hdr->rtp_timestamp;
 
-    // Copy PCM data to output.
-    memcpy(out,
-           pcm,
-           frame_samples * channels * sizeof(int16_t));
+    // Copy PCM data to output
+    memcpy(out, pcm, frame_samples * channels * sizeof(int16_t));
 
-    // Cleanup.
+    // Cleanup
     if (from_pending) {
       timing->pending_valid = false;
       timing->pending_frame_len = 0;
@@ -561,23 +533,15 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
 
     if (!timing->playout_started) {
       timing->playout_started = true;
-
       bool was_quick = timing->quick_start;
       timing->quick_start = false;
-
-      ESP_LOGI(TAG,
-               "Playout started%s: rtp=%" PRIu32,
-               was_quick ? " (quick_start)" : "",
-               played_rtp_timestamp);
+      ESP_LOGI(TAG, "Playout started%s: rtp=%" PRIu32,
+               was_quick ? " (quick_start)" : "", played_rtp_timestamp);
     }
 
-    // Принтира се само веднъж, когато след всички late кадри
-    // най-накрая бъде намерен кадър за възпроизвеждане.
     if (timing->late_drop_active) {
-      ESP_LOGW(TAG,
-               "Total dropped late frames: %" PRIu32,
+      ESP_LOGW(TAG, "Late-frame drain complete: dropped=%" PRIu32,
                timing->late_drop_count);
-
       timing->late_drop_count = 0;
       timing->late_drop_active = false;
     }
@@ -585,8 +549,5 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     return frame_samples;
   }
 
-  // Достигнат е лимитът от 256 опита.
-  // Не принтираме нищо, защото изхвърлянето ще продължи
-  // при следващото извикване.
   return 0;
 }

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -24,6 +24,8 @@ typedef struct {
   size_t pending_frame_len;
   size_t pending_frame_capacity;
   bool pending_valid;
+  uint32_t late_drop_count;
+  bool late_drop_active;
   // Early-frame guard: counts consecutive early frames to detect a stuck
   // anchor. Reset whenever a new anchor is set or a late/on-time frame is
   // played.

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -24,8 +24,6 @@ typedef struct {
   size_t pending_frame_len;
   size_t pending_frame_capacity;
   bool pending_valid;
-  uint32_t late_drop_count;
-  bool late_drop_active;
   // Early-frame guard: counts consecutive early frames to detect a stuck
   // anchor. Reset whenever a new anchor is set or a late/on-time frame is
   // played.
@@ -45,6 +43,12 @@ typedef struct {
   // mutex (write flush_until_ts first, arm bool second; read bool first).
   bool deferred_flush_pending;
   uint32_t flush_until_ts;
+
+  // Persistent statistics for a late-frame drain episode.  Kept in the
+  // timing state so repeated DMA callbacks produce one summary log instead
+  // of one UART write per dropped frame.
+  uint32_t late_drop_count;
+  bool late_drop_active;
 } audio_timing_t;
 
 void audio_timing_init(audio_timing_t *timing, size_t pending_capacity);


### PR DESCRIPTION
## Summary

This PR improves the buffered AirPlay audio pipeline on ESP32.

### Changes
- Drop stale RTP packets before AES decryption and AAC decoding.
- Reduce the amount of late-frame draining per playback iteration.
- Replace repeated late-frame log messages with a single summary.
- Fix RTP timestamp handling after frame release.

### Motivation

While testing on ESP32-S3 I was observing 7–8 second delays during track changes and occasional AAC decoder errors. These changes significantly reduce recovery time after buffered playback falls behind while also lowering unnecessary CPU usage.

I'm still performing long-term testing, but the initial results have been very positive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time playback, seek gating, and I2S timing on the ESP32 audio path; behavior changes are intentional but could affect edge cases around underflow blocking and partial late-frame drains.
> 
> **Overview**
> Improves **buffered AirPlay recovery** after seeks/track changes by rejecting stale RTP **before** AES decrypt and AAC decode, and by tightening how much work the playback path does when catching up.
> 
> The stream layer splits timestamp gating from decode/queue: **`audio_stream_accept_timestamp`** applies the existing post-seek / until-anchor RTP rules, and the buffered TCP task calls it immediately after parsing the header so old-track backlog is drained from the socket without decoder CPU or PCM ring use. Realtime paths keep **`audio_stream_process_frame`** as gate-then-decode.
> 
> **`audio_timing_read`** no longer tries to drop hundreds of late PCM frames in one DMA tick (256 → **64** attempts plus a **~1.5 ms** deadline). Per-frame late **UART logs** are replaced with **`late_drop_count`** / a single summary when playout resumes. RTP for the “Playout started” log is copied before the buffer slot is returned.
> 
> **`audio_output`** removes hot-path debug logging, uses an explicit stereo byte count for I2S writes, and on underflow blocks on **`portMAX_DELAY`** instead of a short timeout + **`vTaskDelay(1)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebf6358c8fd24de7bdf88a0871e04eab7af1b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->