### PR TITLE
Buffering, Bluetooth, and AirPlay UDP timing improvements

### DIFF
--- a/data/www/logs.html
+++ b/data/www/logs.html
@@ -4,7 +4,7 @@
 <title>System Logs</title>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;min-height:100vh;display:flex;flex-direction:column}
+body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;height:100vh;display:flex;flex-direction:column;overflow:hidden}
 .toolbar{background:#161b22;padding:10px 16px;display:flex;align-items:center;gap:12px;border-bottom:1px solid #30363d}
 .toolbar h1{font-size:16px;font-weight:600;flex:1}
 .toolbar a{color:#58a6ff;text-decoration:none;font-size:13px}
@@ -12,7 +12,7 @@ body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9
 .dot.ok{background:#3fb950}
 .btn-sm{padding:6px 12px;border:1px solid #30363d;border-radius:6px;background:#21262d;color:#c9d1d9;font-size:12px;cursor:pointer}
 .btn-sm:hover{background:#30363d}
-#log{flex:1;overflow-y:auto;padding:12px 16px;font-family:'SF Mono',Consolas,monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-all}
+#log{flex:1;min-height:0;overflow-y:auto;padding:12px 16px;font-family:'SF Mono',Consolas,monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-all}
 .a30{color:#484f58}.a31{color:#f85149}.a32{color:#3fb950}.a33{color:#d29922}.a34{color:#58a6ff}.a35{color:#bc8cff}.a36{color:#39c5cf}.a37{color:#c9d1d9}
 .a90{color:#6e7681}.a91{color:#ff7b72}.a92{color:#56d364}.a93{color:#e3b341}.a94{color:#79c0ff}.a95{color:#d2a8ff}.a96{color:#56d4dd}.a97{color:#f0f6fc}
 </style></head><body>
@@ -26,7 +26,15 @@ body{font-family:-apple-system,system-ui,sans-serif;background:#0d1117;color:#c9
 <div id='log'><div id='anchor'></div></div>
 <script>
 var log=document.getElementById('log'),dot=document.getElementById('dot'),anchor=document.getElementById('anchor'),autoScroll=true,maxLines=2000;
-function toggle_scroll(){autoScroll=!autoScroll;document.getElementById('scroll-btn').textContent='Auto-scroll: '+(autoScroll?'ON':'OFF');}
+function set_auto(v){autoScroll=v;document.getElementById('scroll-btn').textContent='Auto-scroll: '+(v?'ON':'OFF');}
+function toggle_scroll(){set_auto(!autoScroll);if(autoScroll)log.scrollTop=log.scrollHeight;}
+function at_bottom(){return log.scrollHeight-log.scrollTop-log.clientHeight<40;}
+// Auto-scroll must yield to the reader: scrolling up pauses it so new lines
+// never yank the view back down; scrolling to the bottom resumes it.
+log.addEventListener('scroll',function(){
+  if(autoScroll&&!at_bottom())set_auto(false);
+  else if(!autoScroll&&at_bottom())set_auto(true);
+});
 function clear_log(){log.innerHTML='';anchor=document.createElement('div');anchor.id='anchor';log.appendChild(anchor);}
 var ansiRe=/\x1b\[([0-9;]*)m/g;
 var ansiCls={'30':1,'31':1,'32':1,'33':1,'34':1,'35':1,'36':1,'37':1,'90':1,'91':1,'92':1,'93':1,'94':1,'95':1,'96':1,'97':1};
@@ -65,9 +73,15 @@ function colorize(text){
     wrap.appendChild(document.createTextNode('\n'));
     frag.appendChild(wrap);
   });
+  var follow=autoScroll&&at_bottom();
   log.insertBefore(frag,anchor);
-  while(log.childNodes.length>maxLines+1)log.removeChild(log.firstChild);
-  if(autoScroll)anchor.scrollIntoView();
+  var trimmed=0;
+  while(log.childNodes.length>maxLines+1){
+    trimmed+=log.firstChild.offsetHeight||0;
+    log.removeChild(log.firstChild);
+  }
+  if(follow)log.scrollTop=log.scrollHeight;
+  else if(trimmed)log.scrollTop=Math.max(0,log.scrollTop-trimmed);
 }
 function connect(){
   var ws=new WebSocket('ws://'+location.host+'/ws/logs');

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 # Bluetooth A2DP sink (only available on ESP32 with Classic BT)
 if(CONFIG_BT_A2DP_ENABLE)
     list(APPEND SRC_FILES "audio/a2dp_sink.c")
+    list(APPEND SRC_FILES "bt_coex.c")
 endif()
 
 # W5500 SPI Ethernet

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -430,7 +430,7 @@ menu "Airplay ESP Configuration"
 
         config AIRPLAY_TIMING_THRESHOLD_MS
             int "Early/late timing threshold for buffered streams (ms)"
-            default 10
+            default 25
             range 2 200
             help
                 Maximum amount a frame may be early or late (in milliseconds)
@@ -438,6 +438,15 @@ menu "Airplay ESP Configuration"
                 it (late). Buffered AirPlay 2 streams (AAC, type 103) have a
                 deep jitter buffer, so a tight threshold keeps tight sync
                 without causing drop-outs.
+
+                This must stay comfortably above the I2S DMA ring's own
+                jitter (about +/-3 ms with the default 8x256 descriptor
+                config) plus PTP filter excursions, otherwise normal
+                scheduling noise crosses the threshold and good audio is
+                discarded. Steady-state accuracy is maintained by the
+                one-sample drift servo rather than by a tight threshold, so
+                lowering this does not improve sync — it only increases the
+                chance of dropouts.
 
         config AIRPLAY_RT_TIMING_THRESHOLD_MS
             int "Early/late timing threshold for unbuffered streams (ms)"

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -919,9 +919,8 @@ esp_err_t bt_a2dp_sink_suspend(void) {
       bt_register_profiles();
       bt_apply_scan_mode();
     } else {
-      ESP_LOGE(TAG,
-               "bluedroid re-enable failed during rollback — "
-               "BT unavailable until reboot");
+      ESP_LOGE(TAG, "bluedroid re-enable failed during rollback — "
+                    "BT unavailable until reboot");
     }
     return err;
   }

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -38,6 +38,7 @@
 #include "freertos/task.h"
 
 #include <inttypes.h>
+#include <stdio.h>
 #include <string.h>
 
 static const char *TAG = "bt_a2dp";
@@ -98,6 +99,11 @@ static volatile bool s_audio_started = false;
 static volatile bool s_avrc_playing = false; /* AVRCP play state (instant) */
 static volatile bool s_i2s_task_running = false;
 static bool s_bt_discoverable = true;
+// Radio suspended (controller+bluedroid disabled) to free WiFi airtime while
+// AirPlay is streaming.  Reversible without a reboot: memory is retained.
+static bool s_bt_suspended = false;
+// Advertised BT device name, saved so it can be re-applied after a resume.
+static char s_device_name[64] = {0};
 static uint8_t s_avrc_volume = 64; /* 0-127, AVRCP absolute volume */
 static volatile bool s_vol_ntf_pending =
     false; /* phone registered for volume change */
@@ -678,17 +684,18 @@ static void bt_gap_cb(esp_bt_gap_cb_event_t event,
 /* Stack-up handler — called when Bluedroid is (re-)enabled                   */
 /* ========================================================================== */
 
-static void bt_stack_evt_handler(uint16_t event, void *param) {
-  (void)param;
-
-  if (event != BT_APP_EVT_STACK_UP) {
-    return;
-  }
-
-  ESP_LOGI(TAG, "BT stack up, initializing profiles");
-
+// Register the GAP/AVRC/A2DP profiles.  Shared by the initial stack-up path
+// and bt_a2dp_sink_resume(), so a suspend/resume cycle re-registers the L2CAP
+// PSMs cleanly instead of relying on them surviving esp_bluedroid_disable().
+static void bt_register_profiles(void) {
   // GAP
   esp_bt_gap_register_callback(bt_gap_cb);
+
+  // (Re-)apply the advertised device name.  Required after a resume because
+  // the name does not survive esp_bluedroid_disable().
+  if (s_device_name[0] != '\0') {
+    esp_bt_gap_set_device_name(s_device_name);
+  }
 
 #ifdef CONFIG_BT_SSP_ENABLED
   // Secure Simple Pairing — numeric comparison for BT 2.1+ devices
@@ -724,6 +731,28 @@ static void bt_stack_evt_handler(uint16_t event, void *param) {
   esp_a2d_register_callback(bt_a2dp_cb);
   esp_a2d_sink_register_data_callback(bt_a2dp_data_cb);
   esp_a2d_sink_init();
+}
+
+// Deregister the profiles before suspending so their L2CAP PSMs (0x0019 AVDTP,
+// 0x0017 AVCTP) are torn down cleanly rather than during bluedroid disable.
+// Order matters: Bluedroid requires AVRC (TG then CT) to be deinited *before*
+// A2DP, otherwise it logs "AVRC should deinit in advance of A2DP".
+static void bt_deinit_profiles(void) {
+  esp_avrc_tg_deinit();
+  esp_avrc_ct_deinit();
+  esp_a2d_sink_deinit();
+}
+
+static void bt_stack_evt_handler(uint16_t event, void *param) {
+  (void)param;
+
+  if (event != BT_APP_EVT_STACK_UP) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "BT stack up, initializing profiles");
+
+  bt_register_profiles();
 
   // Apply saved discoverable state
   if (s_bt_discoverable) {
@@ -791,7 +820,9 @@ esp_err_t bt_a2dp_sink_init(const char *device_name,
     return err;
   }
 
-  // Set device name
+  // Save the device name so it can be re-applied after a suspend/resume; the
+  // stack-up profile registration (bt_register_profiles) applies it.
+  snprintf(s_device_name, sizeof(s_device_name), "%s", device_name);
   esp_bt_gap_set_device_name(device_name);
 
   // Create the BT app task and event queue
@@ -821,7 +852,9 @@ bool bt_a2dp_sink_is_connected(void) {
 
 void bt_a2dp_sink_set_discoverable(bool discoverable) {
   s_bt_discoverable = discoverable;
-  if (s_connected) {
+  if (s_connected || s_bt_suspended) {
+    // Suspended: only the saved preference is updated; the scan mode is
+    // re-applied by bt_a2dp_sink_resume().
     return;
   }
   if (discoverable) {
@@ -831,6 +864,75 @@ void bt_a2dp_sink_set_discoverable(bool discoverable) {
     ESP_LOGI(TAG, "BT discoverable disabled");
     esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
   }
+}
+
+bool bt_a2dp_sink_is_suspended(void) {
+  return s_bt_suspended;
+}
+
+esp_err_t bt_a2dp_sink_suspend(void) {
+  if (s_bt_suspended) {
+    return ESP_OK;
+  }
+  if (s_connected) {
+    // A phone is actively streaming over BT — don't pull the radio out from
+    // under it.  (Shouldn't happen while AirPlay is the active source.)
+    ESP_LOGW(TAG, "Not suspending BT: A2DP device connected");
+    return ESP_ERR_INVALID_STATE;
+  }
+
+  ESP_LOGI(TAG, "Suspending Bluetooth radio (freeing airtime for WiFi)");
+  // Stop accepting connections before tearing the radio down.
+  esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+
+  // Deregister profiles first so their L2CAP PSMs are removed cleanly (avoids
+  // the "PSM not found for deregistration" warnings during bluedroid disable).
+  bt_deinit_profiles();
+
+  esp_err_t err = esp_bluedroid_disable();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "bluedroid disable failed: %s", esp_err_to_name(err));
+    return err;
+  }
+  err = esp_bt_controller_disable();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "controller disable failed: %s", esp_err_to_name(err));
+    esp_bluedroid_enable(); // best-effort rollback
+    return err;
+  }
+
+  s_bt_suspended = true;
+  return ESP_OK;
+}
+
+esp_err_t bt_a2dp_sink_resume(void) {
+  if (!s_bt_suspended) {
+    return ESP_OK;
+  }
+
+  ESP_LOGI(TAG, "Resuming Bluetooth radio");
+  esp_err_t err = esp_bt_controller_enable(ESP_BT_MODE_CLASSIC_BT);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "controller enable failed: %s", esp_err_to_name(err));
+    return err;
+  }
+  err = esp_bluedroid_enable();
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "bluedroid enable failed: %s", esp_err_to_name(err));
+    esp_bt_controller_disable(); // roll back to a consistent suspended state
+    return err;
+  }
+
+  s_bt_suspended = false;
+  // Re-register the profiles torn down in suspend, then restore the
+  // connectable/discoverable state saved before suspend.
+  bt_register_profiles();
+  if (s_bt_discoverable) {
+    esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
+  } else {
+    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+  }
+  return ESP_OK;
 }
 
 // ============================================================================

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -886,7 +886,7 @@ bool bt_a2dp_sink_is_suspended(void) {
   return s_bt_suspended;
 }
 
-esp_err_t bt_a2dp_sink_suspend(void) {
+static esp_err_t bt_suspend_locked(void) {
   if (s_bt_suspended) {
     return ESP_OK;
   }
@@ -947,7 +947,7 @@ esp_err_t bt_a2dp_sink_suspend(void) {
   return ESP_OK;
 }
 
-esp_err_t bt_a2dp_sink_resume(void) {
+static esp_err_t bt_resume_locked(void) {
   if (!s_bt_suspended) {
     return ESP_OK;
   }
@@ -973,6 +973,65 @@ esp_err_t bt_a2dp_sink_resume(void) {
   bt_apply_scan_mode();
   bt_restore_saved_volume();
   return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------
+// Suspend/resume mutate the Bluedroid stack (profile deinit/init, controller
+// enable/disable).  They must not run directly on the caller's (coex) task
+// because bt_app_task keeps dispatching A2DP/AVRC handlers — tearing the stack
+// down or rebuilding it under an in-flight callback races them.  Instead run
+// the operation on bt_app_task itself (the same serialised queue that stack-up
+// uses) and block the caller until it finishes, returning its result.
+// ---------------------------------------------------------------------------
+typedef struct {
+  esp_err_t (*fn)(void);
+  esp_err_t result;
+  SemaphoreHandle_t done;
+} bt_sync_op_t;
+
+// Only ever one op is in flight: bt_run_on_app_task blocks until it completes,
+// and its sole caller (the coex task) issues them serially.
+static bt_sync_op_t *s_pending_op;
+
+static void bt_sync_op_runner(uint16_t event, void *param) {
+  (void)event;
+  (void)param;
+  bt_sync_op_t *op = s_pending_op;
+  op->result = op->fn();
+  xSemaphoreGive(op->done);
+}
+
+static esp_err_t bt_run_on_app_task(esp_err_t (*fn)(void)) {
+  if (!s_bt_task_queue) {
+    return ESP_ERR_INVALID_STATE;
+  }
+  // If somehow invoked from bt_app_task itself, run inline — dispatching to our
+  // own queue and then blocking on it would dead-lock.
+  if (xTaskGetCurrentTaskHandle() == s_bt_task_handle) {
+    return fn();
+  }
+
+  bt_sync_op_t op = {.fn = fn, .result = ESP_FAIL, .done = NULL};
+  op.done = xSemaphoreCreateBinary();
+  if (!op.done) {
+    return ESP_ERR_NO_MEM;
+  }
+  s_pending_op = &op;
+  if (!bt_app_work_dispatch(bt_sync_op_runner, 0, NULL, 0)) {
+    vSemaphoreDelete(op.done);
+    return ESP_FAIL;
+  }
+  xSemaphoreTake(op.done, portMAX_DELAY);
+  vSemaphoreDelete(op.done);
+  return op.result;
+}
+
+esp_err_t bt_a2dp_sink_suspend(void) {
+  return bt_run_on_app_task(bt_suspend_locked);
+}
+
+esp_err_t bt_a2dp_sink_resume(void) {
+  return bt_run_on_app_task(bt_resume_locked);
 }
 
 // ============================================================================

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -743,6 +743,16 @@ static void bt_deinit_profiles(void) {
   esp_a2d_sink_deinit();
 }
 
+// Apply the saved connectable/discoverable preference.  Assumes bluedroid is
+// enabled and the profiles are registered.
+static void bt_apply_scan_mode(void) {
+  if (s_bt_discoverable) {
+    esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
+  } else {
+    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
+  }
+}
+
 static void bt_stack_evt_handler(uint16_t event, void *param) {
   (void)param;
 
@@ -891,13 +901,28 @@ esp_err_t bt_a2dp_sink_suspend(void) {
 
   esp_err_t err = esp_bluedroid_disable();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "bluedroid disable failed: %s", esp_err_to_name(err));
+    // Bluedroid is still enabled; re-register the profiles we just tore down
+    // so BT stays functional rather than being left half-dismantled.
+    ESP_LOGE(TAG, "bluedroid disable failed: %s — restoring profiles",
+             esp_err_to_name(err));
+    bt_register_profiles();
+    bt_apply_scan_mode();
     return err;
   }
   err = esp_bt_controller_disable();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "controller disable failed: %s", esp_err_to_name(err));
-    esp_bluedroid_enable(); // best-effort rollback
+    // Roll bluedroid back up and re-register the profiles so BT is restored to
+    // a working, non-suspended state instead of being bricked until reboot.
+    ESP_LOGE(TAG, "controller disable failed: %s — rolling back",
+             esp_err_to_name(err));
+    if (esp_bluedroid_enable() == ESP_OK) {
+      bt_register_profiles();
+      bt_apply_scan_mode();
+    } else {
+      ESP_LOGE(TAG,
+               "bluedroid re-enable failed during rollback — "
+               "BT unavailable until reboot");
+    }
     return err;
   }
 
@@ -927,11 +952,7 @@ esp_err_t bt_a2dp_sink_resume(void) {
   // Re-register the profiles torn down in suspend, then restore the
   // connectable/discoverable state saved before suspend.
   bt_register_profiles();
-  if (s_bt_discoverable) {
-    esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
-  } else {
-    esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
-  }
+  bt_apply_scan_mode();
   return ESP_OK;
 }
 

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -905,6 +905,18 @@ esp_err_t bt_a2dp_sink_suspend(void) {
   // the "PSM not found for deregistration" warnings during bluedroid disable).
   bt_deinit_profiles();
 
+  // Re-check after tearing down the A2DP/AVRC profiles: a device may have
+  // completed its connection during the scan-mode/deinit window (between the
+  // initial s_connected check and here).  Now that the profiles are gone no
+  // new connection can complete, so if one did, abort the suspend and restore
+  // the profiles rather than disabling the radio out from under a live link.
+  if (s_connected) {
+    ESP_LOGW(TAG, "BT connected mid-suspend — aborting, restoring profiles");
+    bt_register_profiles();
+    bt_apply_scan_mode();
+    return ESP_ERR_INVALID_STATE;
+  }
+
   esp_err_t err = esp_bluedroid_disable();
   if (err != ESP_OK) {
     // Bluedroid is still enabled; re-register the profiles we just tore down

--- a/main/audio/a2dp_sink.c
+++ b/main/audio/a2dp_sink.c
@@ -753,6 +753,21 @@ static void bt_apply_scan_mode(void) {
   }
 }
 
+// Push the saved BT volume to the DAC (falls back to 64 / -15 dB if none
+// stored).  Applied on stack-up and on resume, so the first A2DP playback
+// after a suspend/resume cycle starts at the correct level instead of whatever
+// AirPlay last set, without waiting for an AVRCP volume update.
+static void bt_restore_saved_volume(void) {
+  uint8_t saved_vol;
+  if (settings_get_bt_volume(&saved_vol) == ESP_OK) {
+    s_avrc_volume = saved_vol;
+  }
+  float volume_db = ((float)s_avrc_volume / 127.0f) * 30.0f - 30.0f;
+  dac_set_volume(volume_db);
+  ESP_LOGI(TAG, "BT volume restored: %d/127 (%.1f dB)", s_avrc_volume,
+           volume_db);
+}
+
 static void bt_stack_evt_handler(uint16_t event, void *param) {
   (void)param;
 
@@ -772,16 +787,7 @@ static void bt_stack_evt_handler(uint16_t event, void *param) {
   }
 
   // Restore saved BT volume (falls back to 64 / -15 dB if none stored)
-  {
-    uint8_t saved_vol;
-    if (settings_get_bt_volume(&saved_vol) == ESP_OK) {
-      s_avrc_volume = saved_vol;
-    }
-    float volume_db = ((float)s_avrc_volume / 127.0f) * 30.0f - 30.0f;
-    dac_set_volume(volume_db);
-    ESP_LOGI(TAG, "BT volume restored: %d/127 (%.1f dB)", s_avrc_volume,
-             volume_db);
-  }
+  bt_restore_saved_volume();
 
   ESP_LOGI(TAG, "BT A2DP sink ready, waiting for connections");
 }
@@ -948,10 +954,12 @@ esp_err_t bt_a2dp_sink_resume(void) {
   }
 
   s_bt_suspended = false;
-  // Re-register the profiles torn down in suspend, then restore the
-  // connectable/discoverable state saved before suspend.
+  // Re-register the profiles torn down in suspend, restore the connectable/
+  // discoverable state, and re-apply the saved BT volume to the DAC (AirPlay
+  // may have changed it) so post-resume A2DP starts at the right level.
   bt_register_profiles();
   bt_apply_scan_mode();
+  bt_restore_saved_volume();
   return ESP_OK;
 }
 

--- a/main/audio/a2dp_sink.h
+++ b/main/audio/a2dp_sink.h
@@ -47,6 +47,26 @@ bool bt_a2dp_sink_is_connected(void);
 void bt_a2dp_sink_set_discoverable(bool discoverable);
 
 /**
+ * Suspend the Bluetooth radio: disables Bluedroid and the BT controller so the
+ * WiFi/BT coexistence arbiter hands all radio airtime to WiFi.  Memory is
+ * retained, so bt_a2dp_sink_resume() restores BT without a reboot.  Used to
+ * free the radio for WiFi while AirPlay is the active source.
+ * No-op if already suspended; refuses if a BT device is currently connected.
+ */
+esp_err_t bt_a2dp_sink_suspend(void);
+
+/**
+ * Resume the Bluetooth radio after bt_a2dp_sink_suspend(), restoring the
+ * previously saved discoverable/connectable state.  No-op if not suspended.
+ */
+esp_err_t bt_a2dp_sink_resume(void);
+
+/**
+ * @return true while the BT radio is suspended (see bt_a2dp_sink_suspend()).
+ */
+bool bt_a2dp_sink_is_suspended(void);
+
+/**
  * AVRCP passthrough commands for hardware button control.
  * These send commands to the connected BT source device.
  */

--- a/main/audio/audio_buffer.c
+++ b/main/audio/audio_buffer.c
@@ -239,6 +239,64 @@ int audio_buffer_get_frame_count(audio_buffer_t *buffer) {
   return frames;
 }
 
+/* ---------- newest queued timestamp (diagnostics) ---------- */
+
+bool audio_buffer_peek_newest_rtp(audio_buffer_t *buffer, uint32_t *rtp_out) {
+  if (!buffer || !rtp_out || !buffer->pool || !buffer->sorted) {
+    return false;
+  }
+
+  bool found = false;
+  portENTER_CRITICAL(&buffer->lock);
+  if (buffer->count > 0) {
+    /* sorted[] is ordered by RTP timestamp, so the last entry is newest. */
+    uint16_t slot = buffer->sorted[buffer->count - 1];
+    const audio_frame_header_t *hdr =
+        (const audio_frame_header_t *)(buffer->pool +
+                                       (size_t)slot * buffer->slot_size);
+    *rtp_out = hdr->rtp_timestamp;
+    found = true;
+  }
+  portEXIT_CRITICAL(&buffer->lock);
+  return found;
+}
+
+/* ---------- start of the contiguous tail run (diagnostics/startup) ----- */
+
+bool audio_buffer_bulk_start_rtp(audio_buffer_t *buffer, uint32_t *rtp_out) {
+  if (!buffer || !rtp_out || !buffer->pool || !buffer->sorted) {
+    return false;
+  }
+
+  bool found = false;
+  portENTER_CRITICAL(&buffer->lock);
+  if (buffer->count > 0) {
+    /* Walk backward from the newest frame until the run breaks.  The
+     * result is the first frame of the contiguous region that includes
+     * the newest data — the "real" stream head, as opposed to stale
+     * islands (e.g. late pre-flush retransmissions) stranded below it. */
+    uint16_t slot = buffer->sorted[buffer->count - 1];
+    const audio_frame_header_t *cur =
+        (const audio_frame_header_t *)(buffer->pool +
+                                       (size_t)slot * buffer->slot_size);
+    uint32_t bulk = cur->rtp_timestamp;
+    for (int i = buffer->count - 1; i > 0; i--) {
+      uint16_t pslot = buffer->sorted[i - 1];
+      const audio_frame_header_t *prev =
+          (const audio_frame_header_t *)(buffer->pool +
+                                         (size_t)pslot * buffer->slot_size);
+      if (prev->rtp_timestamp + prev->samples_per_channel != bulk) {
+        break;
+      }
+      bulk = prev->rtp_timestamp;
+    }
+    *rtp_out = bulk;
+    found = true;
+  }
+  portEXIT_CRITICAL(&buffer->lock);
+  return found;
+}
+
 /* ---------- nearly full check (for back-pressure) ---------- */
 
 bool audio_buffer_is_nearly_full(audio_buffer_t *buffer) {

--- a/main/audio/audio_buffer.h
+++ b/main/audio/audio_buffer.h
@@ -50,6 +50,12 @@ void audio_buffer_deinit(audio_buffer_t *buffer);
 void audio_buffer_flush(audio_buffer_t *buffer);
 int audio_buffer_get_frame_count(audio_buffer_t *buffer);
 bool audio_buffer_is_nearly_full(audio_buffer_t *buffer);
+/* Newest (highest-RTP) frame currently queued.  Diagnostics only: used to
+ * report how far behind the head of the buffer playout is running. */
+bool audio_buffer_peek_newest_rtp(audio_buffer_t *buffer, uint32_t *rtp_out);
+/* First frame of the contiguous run that ends at the newest frame.  Used at
+ * playout start to skip stale islands stranded below the real stream. */
+bool audio_buffer_bulk_start_rtp(audio_buffer_t *buffer, uint32_t *rtp_out);
 bool audio_buffer_take(audio_buffer_t *buffer, void **item, size_t *item_size,
                        TickType_t ticks);
 void audio_buffer_return(audio_buffer_t *buffer, void *item);

--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -268,9 +268,24 @@ void audio_output_set_source_rate(int rate) {
 }
 
 uint32_t audio_output_get_hardware_latency_us(void) {
-  return (
-      uint32_t)(((uint64_t)I2S_DMA_DESC_NUM * I2S_DMA_FRAME_NUM * 1000000ULL) /
-                OUTPUT_RATE);
+  // Delay between i2s_channel_write() accepting a sample and that sample
+  // leaving the DAC.  This is the DMA ring occupancy AHEAD of the newly
+  // written data, which is NOT the full ring: i2s_channel_write() blocks
+  // only until space frees, so the writer refills as soon as a descriptor
+  // completes and steady-state occupancy oscillates between
+  // (DESC_NUM - 1) and DESC_NUM descriptors.
+  //
+  // Using the full ring (DESC_NUM) overstates the delay by half a
+  // descriptor on average — 2.9 ms at 44.1 kHz with the config below — and
+  // that bias lands directly in compute_early_us(), pushing every frame
+  // toward the "late" side of the threshold.  Model the midpoint instead:
+  //   (DESC_NUM - 0.5) x FRAME_NUM == (2*DESC_NUM - 1) x FRAME_NUM / 2
+  // The residual +/-2.9 ms swing is real jitter that the drift servo in
+  // audio_timing.c absorbs; only the constant bias is removed here.
+  return (uint32_t)((((uint64_t)(2 * I2S_DMA_DESC_NUM - 1) * I2S_DMA_FRAME_NUM *
+                      1000000ULL) /
+                     2) /
+                    OUTPUT_RATE);
 }
 
 audio_channel_mode_t audio_output_cycle_channel_mode(void) {

--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -56,9 +56,29 @@ static volatile audio_channel_mode_t channel_mode = AUDIO_CHANNEL_STEREO;
 
 static void apply_volume(int16_t *buf, size_t n) {
 #ifndef CONFIG_DAC_CONTROLS_VOLUME
-  int32_t vol = airplay_get_volume_q15();
+  // Ramp toward the target gain instead of applying volume changes
+  // instantly.  An abrupt gain step mid-waveform is a discontinuity scaled
+  // by the signal's current amplitude — the classic volume "zipper" click,
+  // audible on every step of the sender's volume slider.  Approach the
+  // target exponentially, stepping once per stereo frame (even indices) so
+  // both channels always carry the same gain; the /256 divisor gives a
+  // ~3 ms time constant and a worst-case per-frame gain step of ~0.4%,
+  // with a minimum step of 1 so the ramp always completes.
+  static int32_t cur_q15 = -1;
+  int32_t target = airplay_get_volume_q15();
+  if (cur_q15 < 0) {
+    cur_q15 = target; // first call: no audio has played yet, jump silently
+  }
   for (size_t i = 0; i < n; i++) {
-    buf[i] = (int16_t)(((int32_t)buf[i] * vol) >> 15);
+    if ((i & 1) == 0 && cur_q15 != target) {
+      int32_t diff = target - cur_q15;
+      int32_t step = diff / 256;
+      if (step == 0) {
+        step = diff > 0 ? 1 : -1;
+      }
+      cur_q15 += step;
+    }
+    buf[i] = (int16_t)(((int32_t)buf[i] * cur_q15) >> 15);
   }
 #endif
 }
@@ -142,6 +162,13 @@ esp_err_t audio_output_init(void) {
       I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
   chan_cfg.dma_desc_num = I2S_DMA_DESC_NUM;
   chan_cfg.dma_frame_num = I2S_DMA_FRAME_NUM;
+  // Zero each DMA descriptor after it is sent.  Without this, a writer
+  // stall longer than the DMA ring (~46 ms — e.g. an NVS/flash write
+  // disabling the cache, or a CPU burst from the web server) makes the
+  // hardware REPLAY the stale ring contents in a loop: a loud stutter, then
+  // a second discontinuity on recovery.  With auto_clear an underrun
+  // degrades to plain silence.
+  chan_cfg.auto_clear = true;
 
   ESP_RETURN_ON_ERROR(i2s_new_channel(&chan_cfg, &tx_handle, NULL), TAG,
                       "channel create failed");

--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -107,7 +107,6 @@ static void playback_task(void *arg) {
     }
     size_t samples = audio_receiver_read(pcm, FRAME_SAMPLES + 1);
     if (samples > 0) {
-      ESP_LOGD(TAG, "Read %u samples from receiver", (unsigned int)samples);
       int16_t *play_buf = pcm;
       size_t play_samples = samples;
       if (audio_resample_is_active()) {
@@ -115,20 +114,20 @@ static void playback_task(void *arg) {
                                               MAX_RESAMPLE_FRAMES);
         play_buf = resample_buf;
       }
-      ESP_LOGD(TAG, "Resampled to %u samples", (unsigned int)play_samples);
       apply_volume(play_buf, play_samples * 2);
       apply_channel_mode(play_buf, play_samples);
       led_audio_feed(play_buf, play_samples);
-      i2s_channel_write(tx_handle, play_buf, play_samples * 4, &written,
-                        portMAX_DELAY);
-      ESP_LOGD(TAG, "I2S write: %u bytes written", (unsigned int)written);
+      i2s_channel_write(tx_handle, play_buf, play_samples * 2 * sizeof(int16_t),
+                        &written, portMAX_DELAY);
       taskYIELD();
     } else {
-      // ESP_LOGW(TAG, "Receiver underflow - playing silence");
+      // Receiver underflow — output a frame of silence.  Block on the DMA
+      // write (portMAX_DELAY) so the write itself paces the loop, instead of a
+      // short timeout plus vTaskDelay(1) which produced jittery silence.
       led_audio_feed(silence, FRAME_SAMPLES);
-      i2s_channel_write(tx_handle, silence, (size_t)FRAME_SAMPLES * 4, &written,
-                        pdMS_TO_TICKS(10));
-      vTaskDelay(1);
+      i2s_channel_write(tx_handle, silence,
+                        (size_t)FRAME_SAMPLES * 2 * sizeof(int16_t), &written,
+                        portMAX_DELAY);
     }
   }
 

--- a/main/audio/audio_output_spdif.c
+++ b/main/audio/audio_output_spdif.c
@@ -138,9 +138,29 @@ static uint32_t *spdif_ptr;
 
 static void apply_volume(int16_t *buf, size_t n) {
 #ifndef CONFIG_DAC_CONTROLS_VOLUME
-  int32_t vol = airplay_get_volume_q15();
+  // Ramp toward the target gain instead of applying volume changes
+  // instantly.  An abrupt gain step mid-waveform is a discontinuity scaled
+  // by the signal's current amplitude — the classic volume "zipper" click,
+  // audible on every step of the sender's volume slider.  Approach the
+  // target exponentially, stepping once per stereo frame (even indices) so
+  // both channels always carry the same gain; the /256 divisor gives a
+  // ~3 ms time constant and a worst-case per-frame gain step of ~0.4%,
+  // with a minimum step of 1 so the ramp always completes.
+  static int32_t cur_q15 = -1;
+  int32_t target = airplay_get_volume_q15();
+  if (cur_q15 < 0) {
+    cur_q15 = target; // first call: no audio has played yet, jump silently
+  }
   for (size_t i = 0; i < n; i++) {
-    buf[i] = (int16_t)(((int32_t)buf[i] * vol) >> 15);
+    if ((i & 1) == 0 && cur_q15 != target) {
+      int32_t diff = target - cur_q15;
+      int32_t step = diff / 256;
+      if (step == 0) {
+        step = diff > 0 ? 1 : -1;
+      }
+      cur_q15 += step;
+    }
+    buf[i] = (int16_t)(((int32_t)buf[i] * cur_q15) >> 15);
   }
 #endif
 }

--- a/main/audio/audio_output_usb.c
+++ b/main/audio/audio_output_usb.c
@@ -77,9 +77,29 @@ static esp_err_t usb_input_cb(uint8_t *buf, size_t len, size_t *bytes_read,
 
 static void apply_volume(int16_t *buf, size_t n) {
 #ifndef CONFIG_DAC_CONTROLS_VOLUME
-  int32_t vol = airplay_get_volume_q15();
+  // Ramp toward the target gain instead of applying volume changes
+  // instantly.  An abrupt gain step mid-waveform is a discontinuity scaled
+  // by the signal's current amplitude — the classic volume "zipper" click,
+  // audible on every step of the sender's volume slider.  Approach the
+  // target exponentially, stepping once per stereo frame (even indices) so
+  // both channels always carry the same gain; the /256 divisor gives a
+  // ~3 ms time constant and a worst-case per-frame gain step of ~0.4%,
+  // with a minimum step of 1 so the ramp always completes.
+  static int32_t cur_q15 = -1;
+  int32_t target = airplay_get_volume_q15();
+  if (cur_q15 < 0) {
+    cur_q15 = target; // first call: no audio has played yet, jump silently
+  }
   for (size_t i = 0; i < n; i++) {
-    buf[i] = (int16_t)(((int32_t)buf[i] * vol) >> 15);
+    if ((i & 1) == 0 && cur_q15 != target) {
+      int32_t diff = target - cur_q15;
+      int32_t step = diff / 256;
+      if (step == 0) {
+        step = diff > 0 ? 1 : -1;
+      }
+      cur_q15 += step;
+    }
+    buf[i] = (int16_t)(((int32_t)buf[i] * cur_q15) >> 15);
   }
 #endif
 }

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -299,6 +299,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
       receiver.timing.deferred_flush_pending = false;
+      audio_timing_reset_continuity(&receiver.timing);
       receiver.blocks_read_in_sequence = 0;
       receiver.discard_before_rtp = rtp_time;
       receiver.discard_before_rtp_valid = true;
@@ -339,6 +340,7 @@ void audio_receiver_set_anchor_time(uint64_t clock_id, uint64_t network_time_ns,
       receiver.timing.pending_frame_len = 0;
       receiver.timing.ready_time_us = 0;
       receiver.timing.deferred_flush_pending = false;
+      audio_timing_reset_continuity(&receiver.timing);
       receiver.blocks_read_in_sequence = 0;
       receiver.timing.quick_start = true;
       if (!gates_armed) {

--- a/main/audio/audio_receiver.c
+++ b/main/audio/audio_receiver.c
@@ -167,6 +167,10 @@ void audio_receiver_set_encryption(const audio_encrypt_t *encrypt) {
   }
 }
 
+void audio_receiver_set_playout_latency_samples(uint32_t latency_samples) {
+  audio_timing_set_playout_latency(&receiver.timing, latency_samples);
+}
+
 void audio_receiver_set_output_latency_us(uint32_t latency_us) {
   if (!receiver.stream) {
     return;

--- a/main/audio/audio_receiver.h
+++ b/main/audio/audio_receiver.h
@@ -146,6 +146,13 @@ void audio_receiver_set_deferred_flush(uint32_t flush_until_ts);
 void audio_receiver_pause(void);
 
 /**
+ * Set the stream playout latency in samples, added to every frame's
+ * anchor-scheduled play time.  Realtime streams (type 96): latencyMin from
+ * SETUP (default 11025 = 250 ms).  Buffered streams (type 103): 0.
+ */
+void audio_receiver_set_playout_latency_samples(uint32_t latency_samples);
+
+/**
  * Set advertised/target output latency in microseconds.
  */
 void audio_receiver_set_output_latency_us(uint32_t latency_us);
@@ -161,10 +168,13 @@ uint32_t audio_receiver_get_output_latency_us(void);
 uint32_t audio_receiver_get_hardware_latency_us(void);
 
 /**
- * Get total advertised latency in microseconds.  Includes the jitter-buffer
- * target depth, hardware DMA delay, and fixed decrypt/decode/network
- * pipeline constant.  Report this in outputLatencyMicros so the phone
- * schedules sends to match our actual end-to-end depth.
+ * Get total latency in microseconds (jitter-buffer target depth + hardware
+ * DMA delay + fixed pipeline constant).
+ *
+ * DIAGNOSTIC ONLY — do NOT report this in outputLatencyMicros.  The RTSP
+ * layer intentionally advertises 0; see audio_timing_get_advertised_latency()
+ * in audio_timing.h for why advertising a non-zero value double-compensates
+ * and makes this device play ahead of other speakers.
  */
 uint32_t audio_receiver_get_advertised_latency_us(void);
 

--- a/main/audio/audio_receiver_internal.h
+++ b/main/audio/audio_receiver_internal.h
@@ -97,6 +97,18 @@ typedef struct {
   bool paused_rtp_valid;
 } audio_receiver_state_t;
 
+// Lightweight RTP gate used by the buffered TCP task before decrypt/decode.
+// Returns false for frames that belong to the pre-seek/old-track backlog.
+bool audio_stream_accept_timestamp(audio_receiver_state_t *state,
+                                   uint32_t timestamp);
+
+// Decode and queue a frame whose timestamp has already passed the RTP gate.
+bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
+                                         uint32_t timestamp,
+                                         const uint8_t *audio_data,
+                                         size_t audio_len);
+
+// Convenience entry point for realtime paths: gate, then decode and queue.
 bool audio_stream_process_frame(audio_receiver_state_t *state,
                                 uint32_t timestamp, const uint8_t *audio_data,
                                 size_t audio_len);

--- a/main/audio/audio_stream.c
+++ b/main/audio/audio_stream.c
@@ -62,6 +62,29 @@ bool audio_stream_accept_timestamp(audio_receiver_state_t *state,
   return true;
 }
 
+// Read-only variant of the RTP gate used for the post-decode re-check.  Unlike
+// audio_stream_accept_timestamp() it does NOT disarm the window gates on a
+// passing frame — disarming is the job of the ordered pre-decode pass.  If a
+// concurrent seek armed a window gate while this frame was mid-decode and the
+// frame happens to fall inside the new window, disarming here would clear the
+// gate and let subsequent stale TCP backlog through.  This check only reports
+// whether the frame must be dropped.
+static bool timestamp_is_gated(const audio_receiver_state_t *state,
+                               uint32_t timestamp) {
+  if (state->discard_all_until_anchor) {
+    return true;
+  }
+  if (state->discard_before_rtp_valid &&
+      (int32_t)(timestamp - state->discard_before_rtp) < 0) {
+    return true;
+  }
+  if (state->discard_above_rtp_valid &&
+      (int32_t)(timestamp - state->discard_above_rtp) > 0) {
+    return true;
+  }
+  return false;
+}
+
 bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
                                          uint32_t timestamp,
                                          const uint8_t *audio_data,
@@ -94,13 +117,13 @@ bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
   apply_aac_transient_mute(state, decode_buffer, (size_t)decoded_samples,
                            channels);
 
-  // Re-check ALL gates after decode.  A concurrent seek/anchor flush (RTSP
-  // task) can either set discard_all_until_anchor OR arm the RTP window gates
+  // Re-check the gates after decode.  A concurrent seek/anchor flush (RTSP
+  // task) can set discard_all_until_anchor OR arm the RTP window gates
   // (discard_before_rtp / discard_above_rtp, Path B) and flush the ring while
-  // this frame was being decrypted/decoded.  Re-running the full timestamp gate
-  // — not just the blanket flag — prevents a stale mid-flight frame from
-  // landing in the freshly flushed buffer.
-  if (!audio_stream_accept_timestamp(state, timestamp)) {
+  // this frame was being decrypted/decoded.  Use the read-only predicate so a
+  // stale mid-flight frame is dropped without disarming a gate a concurrent
+  // seek just armed (which would let later backlog through).
+  if (timestamp_is_gated(state, timestamp)) {
     return false;
   }
 

--- a/main/audio/audio_stream.c
+++ b/main/audio/audio_stream.c
@@ -26,14 +26,16 @@ static bool apply_aac_transient_mute(audio_receiver_state_t *state,
   return false;
 }
 
-bool audio_stream_process_frame(audio_receiver_state_t *state,
-                                uint32_t timestamp, const uint8_t *audio_data,
-                                size_t audio_len) {
-  if (!state || !state->decoder) {
+bool audio_stream_accept_timestamp(audio_receiver_state_t *state,
+                                   uint32_t timestamp) {
+  if (!state) {
     return false;
   }
 
   // Blanket gate: reject everything between seek_flush and the next anchor.
+  // Deliberately checked before decrypt/decode in the buffered TCP task so
+  // old-track backlog is drained from the socket without decoder CPU or PCM
+  // ring use.
   if (state->discard_all_until_anchor) {
     return false;
   }
@@ -56,6 +58,18 @@ bool audio_stream_process_frame(audio_receiver_state_t *state,
     }
     state->discard_above_rtp_valid = false;
   }
+
+  return true;
+}
+
+bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
+                                         uint32_t timestamp,
+                                         const uint8_t *audio_data,
+                                         size_t audio_len) {
+  if (!state || !state->decoder) {
+    return false;
+  }
+
   size_t capacity_samples = 0;
   int16_t *decode_buffer =
       audio_buffer_get_decode_buffer(&state->buffer, &capacity_samples);
@@ -80,9 +94,28 @@ bool audio_stream_process_frame(audio_receiver_state_t *state,
   apply_aac_transient_mute(state, decode_buffer, (size_t)decoded_samples,
                            channels);
 
+  // Re-check the blanket gate after decode.  A concurrent seek_flush (RTSP
+  // task) can set discard_all_until_anchor and flush the ring while this
+  // frame was being decrypted/decoded; without this second check the stale
+  // frame would land in the freshly flushed buffer.  This closes the
+  // gate→enqueue window that widens once gating moves ahead of decrypt.
+  if (state->discard_all_until_anchor) {
+    return false;
+  }
+
   return audio_buffer_queue_decoded(&state->buffer, &state->stats, timestamp,
                                     decode_buffer, (size_t)decoded_samples,
                                     channels);
+}
+
+bool audio_stream_process_frame(audio_receiver_state_t *state,
+                                uint32_t timestamp, const uint8_t *audio_data,
+                                size_t audio_len) {
+  if (!audio_stream_accept_timestamp(state, timestamp)) {
+    return false;
+  }
+  return audio_stream_process_accepted_frame(state, timestamp, audio_data,
+                                             audio_len);
 }
 
 audio_stream_t *audio_stream_create_realtime(void) {

--- a/main/audio/audio_stream.c
+++ b/main/audio/audio_stream.c
@@ -94,12 +94,13 @@ bool audio_stream_process_accepted_frame(audio_receiver_state_t *state,
   apply_aac_transient_mute(state, decode_buffer, (size_t)decoded_samples,
                            channels);
 
-  // Re-check the blanket gate after decode.  A concurrent seek_flush (RTSP
-  // task) can set discard_all_until_anchor and flush the ring while this
-  // frame was being decrypted/decoded; without this second check the stale
-  // frame would land in the freshly flushed buffer.  This closes the
-  // gate→enqueue window that widens once gating moves ahead of decrypt.
-  if (state->discard_all_until_anchor) {
+  // Re-check ALL gates after decode.  A concurrent seek/anchor flush (RTSP
+  // task) can either set discard_all_until_anchor OR arm the RTP window gates
+  // (discard_before_rtp / discard_above_rtp, Path B) and flush the ring while
+  // this frame was being decrypted/decoded.  Re-running the full timestamp gate
+  // — not just the blanket flag — prevents a stale mid-flight frame from
+  // landing in the freshly flushed buffer.
+  if (!audio_stream_accept_timestamp(state, timestamp)) {
     return false;
   }
 

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -219,6 +219,16 @@ static esp_err_t buffered_start(audio_stream_t *stream, uint16_t port) {
     return ESP_FAIL;
   }
 
+  // Worst-case memory snapshot: buffered streaming is the heaviest concurrent
+  // load (WiFi + lwip + decoder + PCM ring, plus BT controller resident on
+  // squeezeamp-bt).  Use this to size WiFi/TCP buffers without risking OOM.
+  ESP_LOGI(TAG,
+           "Buffered start: free heap %lu internal (largest block %lu), "
+           "%lu SPIRAM",
+           (unsigned long)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+           (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+           (unsigned long)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+
   return ESP_OK;
 }
 

--- a/main/audio/audio_stream_buffered.c
+++ b/main/audio/audio_stream_buffered.c
@@ -132,6 +132,14 @@ static void buffered_audio_task(void *pvParameters) {
       uint32_t timestamp =
           (packet[4] << 24) | (packet[5] << 16) | (packet[6] << 8) | packet[7];
 
+      // Drop stale pre-seek/old-track packets before AES and AAC work.  The
+      // bytes still have to be drained from TCP (done above), but they no
+      // longer consume decoder time or enter the PCM ring buffer.
+      if (!audio_stream_accept_timestamp(state, timestamp)) {
+        state->stats.packets_dropped++;
+        continue;
+      }
+
       uint8_t *decrypted = state->decrypt_buffer;
       size_t decrypt_capacity = state->decrypt_buffer_size;
       if (!decrypted) {
@@ -153,8 +161,8 @@ static void buffered_audio_task(void *pvParameters) {
       state->blocks_read++;
       state->blocks_read_in_sequence++;
 
-      if (!audio_stream_process_frame(state, timestamp, decrypted,
-                                      (size_t)decrypted_len)) {
+      if (!audio_stream_process_accepted_frame(state, timestamp, decrypted,
+                                               (size_t)decrypted_len)) {
         state->stats.packets_dropped++;
       }
     }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -239,6 +239,16 @@ void audio_timing_init(audio_timing_t *timing, size_t pending_capacity) {
   }
 }
 
+void audio_timing_reset_continuity(audio_timing_t *timing) {
+  if (!timing) {
+    return;
+  }
+  timing->expected_rtp_valid = false;
+  timing->pos_err_filtered_us = 0;
+  timing->servo_engaged = false;
+  timing->servo_phase = 0;
+}
+
 void audio_timing_reset(audio_timing_t *timing) {
   if (!timing) {
     return;
@@ -255,11 +265,8 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->flush_until_ts = 0;
   timing->late_drop_count = 0;
   timing->late_drop_active = false;
-  timing->pos_err_filtered_us = 0;
-  timing->servo_engaged = false;
-  timing->servo_phase = 0;
   timing->servo_trims = 0;
-  timing->expected_rtp_valid = false;
+  audio_timing_reset_continuity(timing);
 }
 
 void audio_timing_set_format(audio_timing_t *timing,
@@ -523,7 +530,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         }
         audio_buffer_flush(buffer);
         timing->deferred_flush_pending = false;
-        timing->expected_rtp_valid = false;
+        audio_timing_reset_continuity(timing);
         timing->playout_started = false;
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -14,9 +14,55 @@
 // Additional pipeline latency to account for task scheduling, I2S write
 // blocking, and resampler processing.  Without this, frames pass the
 // timing check "on time" but actually exit the speaker several ms later.
-#define PIPELINE_LATENCY_US           5000 // ~5ms scheduling + write delay
-#define MIN_STARTUP_FRAMES            4
-#define DRIFT_ADJUST_THRESHOLD_FRAMES 2
+#define PIPELINE_LATENCY_US 5000 // ~5ms scheduling + write delay
+#define MIN_STARTUP_FRAMES  4
+
+// Position servo: corrects small standing playout offsets by trimming or
+// duplicating single samples.  Residual position errors arise from
+// drop-recovery after network stalls (bounded by the late threshold) and
+// from crystal drift accumulating between sender and local clock (~10-40
+// ppm, i.e. 40-140 ms/hour) — inside the early/late gate's dead zone nothing
+// else corrects position, so without this a 20 ms post-stall bias persists
+// for the rest of the session (observed on hardware).
+//
+// Control law, and why the earlier (removed) servo failed: that design
+// compared the ABSOLUTE error against a deadband and "credited" each trim
+// back onto the filtered error.  Against the then-undiagnosed 250 ms
+// structural offset the credit was ~1000x weaker than the filter's
+// re-tracking, so it pinned at max authority — a continuous 0.28% stretch.
+// This design has no credit term (trims change reality; the filter simply
+// tracks it), engages only outside POS_SERVO_ENGAGE_US with hysteresis, and
+// is rate-limited to one sample per POS_SERVO_TRIM_INTERVAL frames:
+//   1 / (352 x 4) = 710 ppm = 0.07% pitch deviation (inaudible; JND ~0.2%).
+// Saturation is impossible by construction: the early/late gate bounds any
+// played frame's error to +/-threshold (50 ms realtime), and 50 ms at
+// 710 ppm converges in ~70 s, after which the servo disengages.
+#define POS_SERVO_FILTER_DIV    16   // IIR divisor, ~0.13 s time constant
+#define POS_SERVO_ENGAGE_US     5000 // engage when |filtered err| exceeds this
+#define POS_SERVO_DISENGAGE_US  1500 // disengage when it falls below this
+#define POS_SERVO_TRIM_INTERVAL 4    // one 1-sample trim per this many frames
+// Innovation clamp: cap how far one frame's measurement can move the filter.
+// The per-frame error measurement is NOISY in a one-sided way: the DMA ring
+// holds ~40 ms of queued audio, so when the playback task is briefly starved
+// (WiFi, metadata bursts) the READ happens late and the measurement says
+// "late" — but the audio on the wire never moved; the ring absorbed the
+// delay.  These artifacts are always negative (a delayed read can only
+// measure late), so an unclamped average is dragged below the true position
+// and the servo chases offsets that do not exist.  Observed on hardware:
+// engage/disengage chatter every few seconds with apparent inter-cycle
+// "drift" of 750-1650 ppm — 20-60x anything a crystal can do — alongside
+// single-frame err spikes of -22 ms next to -2 ms readings.  With the clamp,
+// a -22 ms spike moves the filter by at most CLAMP/DIV ~= 94 us, so spike
+// clusters cannot reach the engage threshold, while a REAL standing offset
+// (present on every frame) still walks the filter to engagement in ~0.5 s.
+#define POS_SERVO_INNOV_CLAMP_US 1500
+
+// Every audio output backend (I2S, S/PDIF, USB) allocates its read buffer as
+// (FRAME_SAMPLES + 1) * 2 int16 samples — i.e. interleaved stereo — and the
+// output stage is stereo regardless of what an incoming frame header claims.
+// Writes into the caller's buffer must therefore be bounded by this constant,
+// never by hdr->channels.
+#define AUDIO_OUT_CHANNELS 2
 
 // Early/late threshold: how far a frame may be early (held as pending) or late
 // (dropped) before the timing engine acts.  Buffered AirPlay 2 streams have a
@@ -28,7 +74,7 @@
 #ifdef CONFIG_AIRPLAY_TIMING_THRESHOLD_MS
 #define TIMING_THRESHOLD_US (CONFIG_AIRPLAY_TIMING_THRESHOLD_MS * 1000)
 #else
-#define TIMING_THRESHOLD_US 10000 // 10ms. early/late threshold (buffered)
+#define TIMING_THRESHOLD_US 25000 // 25ms early/late threshold (buffered)
 #endif
 
 #ifdef CONFIG_AIRPLAY_RT_TIMING_THRESHOLD_MS
@@ -98,22 +144,44 @@ static bool compute_early_us(const audio_timing_t *timing,
   int64_t frame_offset_ns =
       ((int64_t)rtp_delta * 1000000000LL) / format->sample_rate;
 
+  // Stream playout latency.  For AirPlay 2 REALTIME streams (type 96) the
+  // anchor maps an RTP timestamp onto the sender's source timeline, and the
+  // receiver is expected to emit that frame `latencyMin` samples LATER —
+  // 11025 samples (250 ms) unless SETUP negotiates otherwise.  Every
+  // reference receiver applies this delay; playing at the anchor instant
+  // directly makes this device lead the whole group by exactly 250 ms.
+  //
+  // Field evidence, all fitting latencyMin = 11025 within a few ms:
+  //   - steady jitter-buffer depth measured 1604-1748 ms, median 1716 ms:
+  //     the sender transmits 88200 samples (2 s) ahead of the play deadline,
+  //     so a receiver that fails to wait 11025 holds 88200-11025 = 77175
+  //     samples = 1750 ms;
+  //   - "First early frame" at stream start: 1711/1709 ms early vs anchor;
+  //   - issue #54: a +300 ms manual offset on a build subtracting 46 ms of
+  //     hardware latency (net +254 ms) produced near-perfect sync.
+  //
+  // Buffered streams (type 103) schedule playout with the anchor directly
+  // and keep this at 0.
+  int64_t latency_ns =
+      ((int64_t)timing->playout_latency_samples * 1000000000LL) /
+      format->sample_rate;
+
   int64_t target_ns;
   switch (sync_mode) {
   case SYNC_MODE_PTP:
     // AirPlay 2: use network time with PTP offset for multi-room sync
     target_ns = (int64_t)timing->anchor_network_time_ns -
-                ptp_clock_get_offset_ns() + frame_offset_ns;
+                ptp_clock_get_offset_ns() + frame_offset_ns + latency_ns;
     break;
   case SYNC_MODE_NTP:
     // AirPlay 1: use network time with NTP offset for multi-room sync
     // offset = remote_time - local_time, so local = remote - offset
     target_ns = (int64_t)timing->anchor_network_time_ns -
-                ntp_clock_get_offset_ns() + frame_offset_ns;
+                ntp_clock_get_offset_ns() + frame_offset_ns + latency_ns;
     break;
   default:
     // Fallback: use local anchor time (no multi-room sync)
-    target_ns = timing->anchor_local_time_ns + frame_offset_ns;
+    target_ns = timing->anchor_local_time_ns + frame_offset_ns + latency_ns;
     break;
   }
 
@@ -129,6 +197,29 @@ static bool compute_early_us(const audio_timing_t *timing,
   *early_us = (target_ns - now_ns) / 1000LL;
 
   return true;
+}
+
+// Index of the quietest sample in a frame (smallest summed magnitude across
+// the output channels).  Servo trims drop or duplicate exactly one sample;
+// doing that at the frame's quietest point makes the waveform seam
+// inaudible even on loud tonal content, where trimming the frame's last
+// sample regardless of amplitude could produce a faint click.
+static size_t quietest_sample_index(const int16_t *pcm, size_t frame_samples,
+                                    size_t channels, size_t out_ch) {
+  size_t best = frame_samples - 1;
+  int32_t best_mag = INT32_MAX;
+  for (size_t i = 0; i < frame_samples; i++) {
+    int32_t mag = 0;
+    for (size_t ch = 0; ch < out_ch; ch++) {
+      int32_t s = pcm[i * channels + ch];
+      mag += s < 0 ? -s : s;
+    }
+    if (mag < best_mag) {
+      best_mag = mag;
+      best = i;
+    }
+  }
+  return best;
 }
 
 void audio_timing_init(audio_timing_t *timing, size_t pending_capacity) {
@@ -164,6 +255,11 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->flush_until_ts = 0;
   timing->late_drop_count = 0;
   timing->late_drop_active = false;
+  timing->pos_err_filtered_us = 0;
+  timing->servo_engaged = false;
+  timing->servo_phase = 0;
+  timing->servo_trims = 0;
+  timing->expected_rtp_valid = false;
 }
 
 void audio_timing_set_format(audio_timing_t *timing,
@@ -209,6 +305,14 @@ uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing) {
   uint32_t base =
       timing ? timing->output_latency_us : DEFAULT_BUFFER_LATENCY_US;
   return base + audio_output_get_hardware_latency_us() + PIPELINE_LATENCY_US;
+}
+
+void audio_timing_set_playout_latency(audio_timing_t *timing,
+                                      uint32_t latency_samples) {
+  if (!timing) {
+    return;
+  }
+  timing->playout_latency_samples = latency_samples;
 }
 
 void audio_timing_set_anchor(audio_timing_t *timing,
@@ -324,6 +428,16 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   // this loop normally only clears a small residual PCM backlog.
   enum { MAX_DRAIN_ATTEMPTS = 64 };
   const int64_t drain_deadline_us = esp_timer_get_time() + 1500;
+  // Set when the drain loop below discards at least one late frame in this
+  // call.  After a drop run, the stream is re-locking onto a new position:
+  // the next playable frame must meet the strict (half frame period) release
+  // rather than the wide jitter threshold, otherwise a discontinuity in the
+  // RTP sequence re-starts playback up to threshold_us early and the bias
+  // persists (observed on hardware: a WiFi stall dropped ~9 frames and left
+  // err parked at +20..31 ms for the rest of the session).
+  bool dropped_late = false;
+  // Stale start-island frames skipped in this call (see the check below).
+  int start_skips = 0;
   for (int attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
     // Check the deadline every eight iterations to limit esp_timer overhead.
     if ((attempt & 7) == 0 && attempt != 0 &&
@@ -409,6 +523,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         }
         audio_buffer_flush(buffer);
         timing->deferred_flush_pending = false;
+        timing->expected_rtp_valid = false;
         timing->playout_started = false;
         timing->ready_time_us = 0;
         timing->consecutive_early_frames = 0;
@@ -427,11 +542,108 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     // their scheduled play time, and late frames are dropped.  This mirrors
     // shairport-sync's approach and guarantees the first audible sample is
     // correctly synchronised.
+    // Stale start-island rejection.  A stream start (fresh or post-flush)
+    // can leave a small ISLAND of stale frames stranded at the head of the
+    // buffer, separated from the real stream by a large hole — typically
+    // late retransmissions answering NACKs from before the flush, which
+    // arrive after the RTP gates re-arm and fall inside their 10 s window.
+    // Starting playout from such an island plays a ~100 ms blip of audio,
+    // then the hole (concealed as silence), then the track — an audible pop
+    // at every affected stream start (observed on hardware: a 14-frame
+    // island followed by an 830 ms hole on a track change).  Until playout
+    // has started, skip any frame that sits more than ~100 ms below the
+    // start of the contiguous run that ends at the newest received frame:
+    // the discarded audio is stale by definition, and the real stream still
+    // starts at exactly its scheduled instant via the early-hold.
+    if (!timing->playout_started && format->sample_rate > 0) {
+      uint32_t bulk_rtp = 0;
+      if (audio_buffer_bulk_start_rtp(buffer, &bulk_rtp)) {
+        int32_t behind = (int32_t)(bulk_rtp - hdr->rtp_timestamp);
+        if (behind > (int32_t)(format->sample_rate / 10)) {
+          start_skips++;
+          if (from_pending) {
+            timing->pending_valid = false;
+            timing->pending_frame_len = 0;
+          } else {
+            audio_buffer_return(buffer, item);
+          }
+          continue;
+        }
+      }
+      if (start_skips > 0) {
+        ESP_LOGI(TAG,
+                 "Skipped %d stale start frame(s); contiguous stream begins "
+                 "at rtp=%" PRIu32,
+                 start_skips, hdr->rtp_timestamp);
+        start_skips = 0;
+      }
+    }
+
+    // RTP continuity vs the frame just played.  A fresh frame exactly at
+    // expected_rtp is contiguous audio: it can never legitimately need
+    // holding (its schedule slot begins the instant the previous frame
+    // ends), so it bypasses the early-hold entirely — measurement noise can
+    // then never insert silence into an unbroken stream.  A fresh frame
+    // ABOVE expected_rtp means packets were lost and not recovered by the
+    // resend mechanism: conceal the hole by holding the frame to the strict
+    // release, so exactly gap-length silence plays at the right schedule.
+    // Without this, the post-gap frame (typically ~8 ms early, far inside
+    // the 50 ms realtime threshold) played immediately — an audible skip
+    // AND a permanent early shift of the whole playback position for every
+    // unrecovered packet.  Below expected_rtp (duplicate/overlap from a
+    // redundant resend) is treated as continuous: playing it repeats at
+    // most one frame, which keeps the stream moving.
+    bool continuous = false;
+    bool gap = false;
+    if (!from_pending && timing->playout_started &&
+        timing->expected_rtp_valid) {
+      int32_t cont_delta = (int32_t)(hdr->rtp_timestamp - timing->expected_rtp);
+      if (cont_delta > 0) {
+        gap = true;
+        timing->gaps++;
+        // Rate-limited: a burst of separate holes must not throttle this
+        // path with blocking log writes.
+        int64_t now_us = esp_timer_get_time();
+        if (now_us - timing->last_gap_log_us > 250000) {
+          ESP_LOGW(TAG,
+                   "Gap: %ld samples (%ld ms) missing before rtp=%" PRIu32
+                   " — concealing with silence (gaps=%" PRIu32 ", +%" PRIu32
+                   " unlogged)",
+                   (long)cont_delta,
+                   (long)(cont_delta * 1000L / format->sample_rate),
+                   hdr->rtp_timestamp, timing->gaps, timing->gaps_suppressed);
+          timing->last_gap_log_us = now_us;
+          timing->gaps_suppressed = 0;
+        } else {
+          timing->gaps_suppressed++;
+        }
+      } else {
+        continuous = true;
+      }
+    }
+
     if (timing->anchor_valid && format->sample_rate > 0) {
       int64_t early_us = 0;
       if (compute_early_us(timing, format, hdr->rtp_timestamp, sync_mode,
                            &early_us)) {
-        if (early_us > timing_threshold_us) {
+        // Hold-release point.  A FRESH frame is shelved as pending when it
+        // is more than the (wide, jitter-hysteresis) threshold early.  But a
+        // frame ALREADY pending is re-checked once per frame period (~8 ms),
+        // and must be held until its play time has actually arrived —
+        // releasing it at the threshold instead starts playback up to
+        // threshold_us early, and nothing downstream ever corrects position,
+        // so the whole session inherits that bias (measured: err pinned at
+        // +33..48 ms with the 50 ms realtime threshold).  Releasing at half
+        // a frame period centres the startup error at 0 (±4 ms at 44.1 kHz).
+        // Frames following a drop run or a detected RTP gap also use the
+        // strict release, so discontinuity recovery re-locks position
+        // precisely instead of anywhere inside the wide threshold.
+        int64_t frame_period_us =
+            ((int64_t)frame_samples * 1000000LL) / format->sample_rate;
+        int64_t release_us = (from_pending || dropped_late || gap)
+                                 ? frame_period_us / 2
+                                 : timing_threshold_us;
+        if (!continuous && early_us > release_us) {
           // Only advance the stuck-anchor counter for NEW frames taken from
           // the buffer — not for pending re-checks of the same early frame.
           // A pending frame is re-examined every DMA callback (~8 ms) while
@@ -489,8 +701,19 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
               timing->pending_valid = true;
               audio_buffer_return(buffer, item);
             }
-            memset(out, 0, samples * channels * sizeof(int16_t));
-            return samples;
+            // Emit one frame's worth of silence, not the caller's full
+            // capacity.  Callers allocate exactly `samples` stereo frames
+            // (see audio_output.c), so the write must be bounded by
+            // AUDIO_OUT_CHANNELS rather than the frame header's channel
+            // count — a malformed header claiming >2 channels would
+            // otherwise overrun the caller's buffer.  Returning
+            // frame_samples (not `samples`) also keeps the silence path's
+            // output length consistent with the normal playback path, so
+            // holding a frame pending does not advance the output clock
+            // faster than playing one.
+            memset(out, 0,
+                   frame_samples * AUDIO_OUT_CHANNELS * sizeof(int16_t));
+            return frame_samples;
           }
         } else if (early_us < -timing_threshold_us) {
           // Reset consecutive early counter on late/normal frames
@@ -500,8 +723,20 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
           // Do not log per frame here; UART logging in the playout task is
           // expensive and can itself cause further lateness.  A single summary
           // is emitted when playout resumes.
+          dropped_late = true;
           timing->late_drop_count++;
           timing->late_drop_active = true;
+          // A dropped frame is consumed from the RTP sequence just like a
+          // played one: advance the continuity marker past it (forward
+          // only).  Without this, expected_rtp froze at the last PLAYED
+          // frame during a drain, so every subsequent contiguous stale
+          // frame was miscounted as a fresh loss.
+          uint32_t drop_next = hdr->rtp_timestamp + hdr->samples_per_channel;
+          if (!timing->expected_rtp_valid ||
+              (int32_t)(drop_next - timing->expected_rtp) > 0) {
+            timing->expected_rtp = drop_next;
+            timing->expected_rtp_valid = true;
+          }
           if (stats) {
             stats->late_frames++;
           }
@@ -520,11 +755,151 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     timing->consecutive_early_frames = 0;
 
     // Snapshot metadata before the pool slot is returned below — reading
-    // hdr->rtp_timestamp after audio_buffer_return would be a use-after-return.
+    // hdr fields after audio_buffer_return would be a use-after-return.
     uint32_t played_rtp_timestamp = hdr->rtp_timestamp;
+    uint32_t played_samples = hdr->samples_per_channel;
 
-    // Copy PCM data to output
-    memcpy(out, pcm, frame_samples * channels * sizeof(int16_t));
+    // Playout report (diagnostic) and position servo.
+    int sample_adjust = 0;
+    if (timing->anchor_valid && sync_mode != SYNC_MODE_NONE &&
+        timing->playout_started) {
+      int64_t on_time_err_us = 0;
+      if (compute_early_us(timing, format, played_rtp_timestamp, sync_mode,
+                           &on_time_err_us)) {
+        //   err      — distance from this frame's scheduled play time
+        //              (anchor + stream playout latency).  Should sit near 0.
+        //   buffered — frames still queued behind this one.
+        //   depth_ms — how far the played frame sits behind the NEWEST frame
+        //              in the buffer.  For a realtime stream with the sender
+        //              transmitting 2 s ahead, ~2000 ms minus err is healthy.
+        if (timing->playout_reports++ % 125 == 0) {
+          uint32_t newest_rtp = 0;
+          int64_t depth_ms = -1;
+          if (audio_buffer_peek_newest_rtp(buffer, &newest_rtp)) {
+            depth_ms = ((int64_t)(int32_t)(newest_rtp - played_rtp_timestamp) *
+                        1000LL) /
+                       format->sample_rate;
+          }
+          // PTP filter divergence.  err/lead/depth are all computed THROUGH
+          // filtered_offset_ns, so none of them can reveal an error in that
+          // offset — the device converges perfectly onto a displaced target
+          // and reports err=0 the whole time.  Comparing the filtered offset
+          // against the most recent raw sample is the only independent check
+          // available on-device.
+          ptp_stats_t ps;
+          ptp_clock_get_stats(&ps);
+          int64_t ptp_gap_us =
+              (ps.last_offset_ns - ps.filtered_offset_ns) / 1000LL;
+          ESP_LOGI(TAG,
+                   "Playout: err=%lld ms buffered=%d depth=%lld ms "
+                   "ptp_gap=%lld us outliers=%" PRIu32 " gaps=%" PRIu32
+                   " rtp=%" PRIu32,
+                   (long long)(on_time_err_us / 1000LL), buffered_frames,
+                   (long long)depth_ms, (long long)ptp_gap_us, ps.outlier_count,
+                   timing->gaps, played_rtp_timestamp);
+        }
+
+        // Position servo (see POS_SERVO_* above).  Smooth the per-frame
+        // error with a clamped-innovation IIR (robust to one-sided
+        // late-read measurement spikes), engage outside the hysteresis
+        // band, trim one sample per POS_SERVO_TRIM_INTERVAL frames until
+        // the error is back inside.  No credit term: a trim changes the
+        // real playout position and the IIR tracks that on its own.
+        int64_t innovation = on_time_err_us - timing->pos_err_filtered_us;
+        if (innovation > POS_SERVO_INNOV_CLAMP_US) {
+          innovation = POS_SERVO_INNOV_CLAMP_US;
+        } else if (innovation < -POS_SERVO_INNOV_CLAMP_US) {
+          innovation = -POS_SERVO_INNOV_CLAMP_US;
+        }
+        timing->pos_err_filtered_us += innovation / POS_SERVO_FILTER_DIV;
+
+        int64_t abs_err = timing->pos_err_filtered_us < 0
+                              ? -timing->pos_err_filtered_us
+                              : timing->pos_err_filtered_us;
+        if (!timing->servo_engaged && abs_err > POS_SERVO_ENGAGE_US) {
+          timing->servo_engaged = true;
+          timing->servo_phase = 0;
+          ESP_LOGI(TAG, "Position servo engaged: err=%lld us",
+                   (long long)timing->pos_err_filtered_us);
+        } else if (timing->servo_engaged && abs_err < POS_SERVO_DISENGAGE_US) {
+          timing->servo_engaged = false;
+          ESP_LOGI(TAG, "Position servo disengaged: err=%lld us trims=%" PRIu32,
+                   (long long)timing->pos_err_filtered_us, timing->servo_trims);
+        }
+
+        if (timing->servo_engaged &&
+            ++timing->servo_phase >= POS_SERVO_TRIM_INTERVAL) {
+          timing->servo_phase = 0;
+          // Positive error = playing early = stretch (emit one extra sample)
+          // so playout slows; negative = late = shrink to catch up.
+          sample_adjust = timing->pos_err_filtered_us > 0 ? 1 : -1;
+          timing->servo_trims++;
+        }
+      }
+    }
+
+    // Apply the servo's one-sample trim.  Shrink: copy one sample fewer.
+    // Stretch: copy the frame then repeat its final sample once.  The
+    // stretch stays within the caller's capacity (`samples` frames, which
+    // is FRAME_SAMPLES + 1 in every output backend).
+    size_t out_samples = frame_samples;
+    if (sample_adjust < 0 && out_samples > 1) {
+      out_samples--;
+    } else if (sample_adjust > 0 && out_samples + 1 <= samples) {
+      out_samples++;
+    }
+
+    // Copy PCM data to output.  The output buffer is interleaved stereo of
+    // exactly `samples` frames, so never write more than AUDIO_OUT_CHANNELS
+    // per sample regardless of what the frame header claims.  `channels` is
+    // still used to step through the SOURCE frame, which was
+    // length-validated above against expected_bytes.
+    size_t out_ch =
+        channels < AUDIO_OUT_CHANNELS ? channels : AUDIO_OUT_CHANNELS;
+    if (out_samples == frame_samples) {
+      if (out_ch == channels) {
+        memcpy(out, pcm, frame_samples * out_ch * sizeof(int16_t));
+      } else {
+        // Source has more channels than we emit — take the leading out_ch.
+        for (size_t i = 0; i < frame_samples; i++) {
+          for (size_t ch = 0; ch < out_ch; ch++) {
+            out[i * out_ch + ch] = pcm[i * channels + ch];
+          }
+        }
+      }
+    } else {
+      // Servo trim: drop or duplicate exactly one sample, placed at the
+      // frame's quietest point so the seam is inaudible.
+      size_t m = quietest_sample_index(pcm, frame_samples, channels, out_ch);
+      size_t o = 0;
+      for (size_t i = 0; i < frame_samples; i++) {
+        if (out_samples < frame_samples && i == m) {
+          continue; // shrink: skip the quietest sample
+        }
+        for (size_t ch = 0; ch < out_ch; ch++) {
+          out[o * out_ch + ch] = pcm[i * channels + ch];
+        }
+        o++;
+        if (out_samples > frame_samples && i == m) {
+          // stretch: duplicate the quietest sample
+          for (size_t ch = 0; ch < out_ch; ch++) {
+            out[o * out_ch + ch] = pcm[i * channels + ch];
+          }
+          o++;
+        }
+      }
+    }
+
+    // The next contiguous frame starts where this one's SOURCE data ends
+    // (servo trims alter output length, not source consumption).  Forward
+    // only: playing a duplicate (redundant resend) must not rewind the
+    // marker, which would misread the following real frame as a gap.
+    uint32_t play_next = played_rtp_timestamp + played_samples;
+    if (!timing->expected_rtp_valid ||
+        (int32_t)(play_next - timing->expected_rtp) > 0) {
+      timing->expected_rtp = play_next;
+      timing->expected_rtp_valid = true;
+    }
 
     // Cleanup
     if (from_pending) {
@@ -549,7 +924,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       timing->late_drop_active = false;
     }
 
-    return frame_samples;
+    return out_samples;
   }
 
   return 0;

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -162,6 +162,8 @@ void audio_timing_reset(audio_timing_t *timing) {
   timing->quick_start = false;
   timing->deferred_flush_pending = false;
   timing->flush_until_ts = 0;
+  timing->late_drop_count = 0;
+  timing->late_drop_active = false;
 }
 
 void audio_timing_set_format(audio_timing_t *timing,
@@ -316,15 +318,18 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     sync_mode = SYNC_MODE_NTP;
   }
 
-  // Drain up to MAX_DRAIN_ATTEMPTS late/invalid frames within a SINGLE
-  // DMA callback.  The previous limit of 8 was the root cause of run-away
-  // lateness: each call that returned silence (instead of playing a frame)
-  // forfeited ~23 ms of RTP advancement while wall time kept moving, so
-  // every late frame we dropped MADE us more late.  Draining many frames
-  // in one pass advances RTP at zero wall-time cost and lets the buffer
-  // skip past stale data without the DMA ever idling.
-  enum { MAX_DRAIN_ATTEMPTS = 256 };
+  // Keep the playout task bounded.  Stale frames are still drained in batches,
+  // but a single call may spend at most ~1.5 ms here.  The RTP gate in the
+  // buffered receiver now prevents new old-track frames from being decoded, so
+  // this loop normally only clears a small residual PCM backlog.
+  enum { MAX_DRAIN_ATTEMPTS = 64 };
+  const int64_t drain_deadline_us = esp_timer_get_time() + 1500;
   for (int attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
+    // Check the deadline every eight iterations to limit esp_timer overhead.
+    if ((attempt & 7) == 0 && attempt != 0 &&
+        esp_timer_get_time() >= drain_deadline_us) {
+      break;
+    }
     size_t item_size = 0;
     void *item = NULL;
     bool from_pending = false;
@@ -491,11 +496,12 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
           // Reset consecutive early counter on late/normal frames
           timing->consecutive_early_frames = 0;
 
-          // Late frame — drop it and continue draining within the SAME call.
-          // The 256-attempt drain loop chews through stale frames at zero
-          // wall-time cost, skipping past arbitrarily many stale frames in
-          // one pass without the DMA ever idling.
-          ESP_LOGW(TAG, "Dropping late frame: %lld ms", -early_us / 1000LL);
+          // Late frame: count it and continue within the bounded drain budget.
+          // Do not log per frame here; UART logging in the playout task is
+          // expensive and can itself cause further lateness.  A single summary
+          // is emitted when playout resumes.
+          timing->late_drop_count++;
+          timing->late_drop_active = true;
           if (stats) {
             stats->late_frames++;
           }
@@ -513,6 +519,10 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
     // Frame is on time (or anchor-invalid) — reset counter.
     timing->consecutive_early_frames = 0;
 
+    // Snapshot metadata before the pool slot is returned below — reading
+    // hdr->rtp_timestamp after audio_buffer_return would be a use-after-return.
+    uint32_t played_rtp_timestamp = hdr->rtp_timestamp;
+
     // Copy PCM data to output
     memcpy(out, pcm, frame_samples * channels * sizeof(int16_t));
 
@@ -529,7 +539,14 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       bool was_quick = timing->quick_start;
       timing->quick_start = false;
       ESP_LOGI(TAG, "Playout started%s: rtp=%" PRIu32,
-               was_quick ? " (quick_start)" : "", hdr->rtp_timestamp);
+               was_quick ? " (quick_start)" : "", played_rtp_timestamp);
+    }
+
+    if (timing->late_drop_active) {
+      ESP_LOGW(TAG, "Late-frame drain complete: dropped=%" PRIu32,
+               timing->late_drop_count);
+      timing->late_drop_count = 0;
+      timing->late_drop_active = false;
     }
 
     return frame_samples;

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -28,7 +28,39 @@ typedef struct {
   // anchor. Reset whenever a new anchor is set or a late/on-time frame is
   // played.
   int consecutive_early_frames;
-  // Late-frame guard: counts consecutive individually-late frames.  When this
+  // Stream playout latency in samples, added to every frame's scheduled
+  // play time.  Realtime streams (type 96): the anchor maps RTP onto the
+  // sender's source timeline and playout happens latencyMin samples later
+  // (11025 = 250 ms unless SETUP says otherwise).  Buffered streams
+  // (type 103): 0 — the anchor is the play time.  Set at stream SETUP;
+  // survives audio_timing_reset() because it is stream configuration, not
+  // playback state.
+  uint32_t playout_latency_samples;
+  // Counts played frames so the periodic playout report can be rate-limited.
+  uint32_t playout_reports;
+  // RTP continuity tracking.  expected_rtp is the timestamp the NEXT frame
+  // must carry to be contiguous with what was just played.  A fresh frame
+  // above it means packets were lost and never recovered: the playout gap is
+  // concealed with schedule-length silence instead of skipping ahead (which
+  // would both pop and shift the whole playback position early).  gaps
+  // counts concealed discontinuities (diagnostics).
+  uint32_t expected_rtp;
+  bool expected_rtp_valid;
+  uint32_t gaps;
+  // Rate limiting for the gap-conceal warning logs.  Logging is blocking
+  // (UART + ring mutex), so unthrottled per-frame warnings slow the
+  // late-frame drain loop to roughly realtime — turning a stream change
+  // with a deep stale buffer into seconds of stalled audio.
+  int64_t last_gap_log_us;
+  uint32_t gaps_suppressed;
+  // Position servo state (see POS_SERVO_* in audio_timing.c).
+  // pos_err_filtered_us: IIR-smoothed playout position error.
+  // servo_engaged/servo_phase: hysteresis state and trim rate divider.
+  // servo_trims: total single-sample corrections applied (diagnostics).
+  int64_t pos_err_filtered_us;
+  bool servo_engaged;
+  uint8_t servo_phase;
+  uint32_t servo_trims;
   // Quick-start flag: set after a seek/flush/track-change so that
   // audio_timing_read starts playback with just 1 buffered frame instead of
   // waiting for target_buffer_frames.  Anchor-based timing is used from the
@@ -60,11 +92,23 @@ void audio_timing_set_output_latency(audio_timing_t *timing,
                                      uint32_t latency_us);
 uint32_t audio_timing_get_output_latency(const audio_timing_t *timing);
 uint32_t audio_timing_get_hardware_latency(void);
-// Total advertised latency (output + HW + fixed pipeline processing).
-// Use this for outputLatencyMicros, NOT (output + HW) alone — otherwise the
-// phone schedules sends 15 ms tight and the fill controller will pad
-// silence to compensate for the missing decode/decrypt/net delay.
+// Total end-to-end latency (output target + HW DMA + fixed pipeline delay).
+//
+// DIAGNOSTIC ONLY — do NOT wire this into outputLatencyMicros.
+// rtsp_handlers.c deliberately advertises 0 for both inputLatencyMicros and
+// outputLatencyMicros because compute_early_us() already compensates for the
+// hardware and pipeline delay internally; advertising a non-zero value makes
+// the sender adjust its anchor as well and the delay is applied twice.
+// shairport-sync likewise advertises no audioLatencies.
+//
+// Note also that this figure does not include the sender-driven pre-buffer
+// actually sitting in the jitter buffer during playback (frequently 1.5 s+),
+// so it is not the true end-to-end delay either. Use it for logging and
+// introspection, not for protocol negotiation.
 uint32_t audio_timing_get_advertised_latency(const audio_timing_t *timing);
+// Set the stream playout latency (samples).  See playout_latency_samples.
+void audio_timing_set_playout_latency(audio_timing_t *timing,
+                                      uint32_t latency_samples);
 void audio_timing_set_anchor(audio_timing_t *timing,
                              const audio_format_t *format, uint64_t clock_id,
                              uint64_t network_time_ns, uint32_t rtp_time);

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -85,6 +85,10 @@ typedef struct {
 
 void audio_timing_init(audio_timing_t *timing, size_t pending_capacity);
 void audio_timing_reset(audio_timing_t *timing);
+// Clear playback-derived continuity + servo filter state. Must run on every
+// re-lock (flush/seek/track-change), else a stale expected_rtp or servo bias
+// survives into the new segment.
+void audio_timing_reset_continuity(audio_timing_t *timing);
 void audio_timing_set_format(audio_timing_t *timing,
                              const audio_format_t *format);
 void audio_timing_set_output_latency(audio_timing_t *timing,

--- a/main/audio/audio_timing.h
+++ b/main/audio/audio_timing.h
@@ -43,6 +43,12 @@ typedef struct {
   // mutex (write flush_until_ts first, arm bool second; read bool first).
   bool deferred_flush_pending;
   uint32_t flush_until_ts;
+
+  // Persistent statistics for a late-frame drain episode.  Kept in the timing
+  // state so repeated playout callbacks produce one summary log instead of
+  // one UART write per dropped frame.
+  uint32_t late_drop_count;
+  bool late_drop_active;
 } audio_timing_t;
 
 void audio_timing_init(audio_timing_t *timing, size_t pending_capacity);

--- a/main/bt_coex.c
+++ b/main/bt_coex.c
@@ -100,9 +100,15 @@ static coex_state_t coex_on_event(coex_state_t state, bt_coex_event_t evt,
 
   case BT_COEX_EVT_BT_CONNECTED:
   case BT_COEX_EVT_BT_DISCONNECTED:
-    // Bluetooth owns the radio: AirPlay is stopped while a BT device is
-    // connected and restarts when it disconnects.  Either way the radio is
-    // active with no pending coexistence action.
+    // Bluetooth owns the radio and needs it up.  Normally the radio is already
+    // active here.  But if a suspend raced with the connection (suspend passed
+    // its s_connected check, then the connection completed before the disable),
+    // the radio can actually be suspended while our tracked state says
+    // otherwise — reconcile with the hardware by resuming, so the state never
+    // desyncs and leaves Bluetooth off until reboot.
+    if (bt_a2dp_sink_is_suspended()) {
+      return coex_do_resume(wake_at);
+    }
     return COEX_ACTIVE;
   }
   return state;

--- a/main/bt_coex.c
+++ b/main/bt_coex.c
@@ -1,0 +1,173 @@
+#include "bt_coex.h"
+
+#include "a2dp_sink.h"
+#include "spiram_task.h"
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+static const char *TAG = "bt_coex";
+
+// Idle delay after AirPlay disconnects before the BT radio is resumed, so a
+// quick reconnect / track change does not flap the radio.
+#define BT_COEX_RESUME_IDLE_MS 15000
+// Backoff before retrying a suspend/resume that failed with a transient error.
+#define BT_COEX_RETRY_MS 2000
+
+#define BT_COEX_QUEUE_LEN  8
+#define BT_COEX_TASK_STACK 4096
+#define BT_COEX_TASK_PRIO  5
+
+// Radio state owned exclusively by the coexistence task.
+//
+//   ACTIVE ──PLAYING──▶ SUSPENDED ──DISCONNECTED──▶ RESUME_WAIT ──(idle)──▶
+//   ACTIVE
+//     ▲                    │  ▲                          │
+//     └── BT_CONNECTED ────┘  └── CONNECTED/PAUSED ──────┘   (cancel resume)
+//
+// SUSPEND_RETRY / RESUME_WAIT also re-arm a short timer to retry a failed op.
+typedef enum {
+  COEX_ACTIVE = 0,    // radio up; no pending action
+  COEX_SUSPENDED,     // radio suspended; no pending action
+  COEX_SUSPEND_RETRY, // want suspended; last attempt failed, retry on timeout
+  COEX_RESUME_WAIT,   // suspended; resume scheduled (idle delay or retry)
+} coex_state_t;
+
+static QueueHandle_t s_queue = NULL;
+static TaskHandle_t s_task = NULL;
+
+// Attempt to suspend the radio; returns the resulting state and, for a
+// transient failure, arms the retry deadline.
+static coex_state_t coex_do_suspend(TickType_t *wake_at) {
+  esp_err_t err = bt_a2dp_sink_suspend();
+  if (err == ESP_OK) {
+    return COEX_SUSPENDED;
+  }
+  if (err == ESP_ERR_INVALID_STATE) {
+    // A Bluetooth device is connected, so the radio must stay up.  The
+    // BT_CONNECTED event settles us in COEX_ACTIVE; nothing to retry.
+    return COEX_ACTIVE;
+  }
+  ESP_LOGW(TAG, "suspend failed (%s), retrying", esp_err_to_name(err));
+  *wake_at = xTaskGetTickCount() + pdMS_TO_TICKS(BT_COEX_RETRY_MS);
+  return COEX_SUSPEND_RETRY;
+}
+
+// Attempt to resume the radio; returns the resulting state and, on failure,
+// arms the retry deadline.
+static coex_state_t coex_do_resume(TickType_t *wake_at) {
+  esp_err_t err = bt_a2dp_sink_resume();
+  if (err == ESP_OK) {
+    return COEX_ACTIVE;
+  }
+  ESP_LOGW(TAG, "resume failed (%s), retrying", esp_err_to_name(err));
+  *wake_at = xTaskGetTickCount() + pdMS_TO_TICKS(BT_COEX_RETRY_MS);
+  return COEX_RESUME_WAIT;
+}
+
+// Transition on an incoming event.
+static coex_state_t coex_on_event(coex_state_t state, bt_coex_event_t evt,
+                                  TickType_t *wake_at) {
+  switch (evt) {
+  case BT_COEX_EVT_AIRPLAY_PLAYING:
+    // Streaming — free the radio for WiFi now (idempotent if already down).
+    if (state == COEX_SUSPENDED) {
+      return COEX_SUSPENDED;
+    }
+    return coex_do_suspend(wake_at);
+
+  case BT_COEX_EVT_AIRPLAY_CONNECTED:
+  case BT_COEX_EVT_AIRPLAY_PAUSED:
+    // Session active/starting: cancel a scheduled resume so the radio stays
+    // suspended, but do not newly suspend (only PLAYING suspends).
+    if (state == COEX_RESUME_WAIT) {
+      return COEX_SUSPENDED;
+    }
+    return state;
+
+  case BT_COEX_EVT_AIRPLAY_DISCONNECTED:
+    // Session ended: schedule a resume after the idle delay, but only if the
+    // radio is actually suspended.  In ACTIVE and SUSPEND_RETRY the radio is
+    // up (a transient suspend failure rolls back to active), so just settle in
+    // ACTIVE and abandon any suspend attempt.
+    if (state == COEX_SUSPENDED || state == COEX_RESUME_WAIT) {
+      *wake_at = xTaskGetTickCount() + pdMS_TO_TICKS(BT_COEX_RESUME_IDLE_MS);
+      return COEX_RESUME_WAIT;
+    }
+    return COEX_ACTIVE;
+
+  case BT_COEX_EVT_BT_CONNECTED:
+  case BT_COEX_EVT_BT_DISCONNECTED:
+    // Bluetooth owns the radio: AirPlay is stopped while a BT device is
+    // connected and restarts when it disconnects.  Either way the radio is
+    // active with no pending coexistence action.
+    return COEX_ACTIVE;
+  }
+  return state;
+}
+
+// Transition when the state's timer expires.
+static coex_state_t coex_on_timeout(coex_state_t state, TickType_t *wake_at) {
+  switch (state) {
+  case COEX_SUSPEND_RETRY:
+    return coex_do_suspend(wake_at);
+  case COEX_RESUME_WAIT:
+    return coex_do_resume(wake_at);
+  default:
+    return state; // no timer runs in this state
+  }
+}
+
+static void bt_coex_task(void *arg) {
+  (void)arg;
+  coex_state_t state = COEX_ACTIVE;
+  TickType_t wake_at = 0;
+
+  for (;;) {
+    // Block on the event queue, but only until the pending timed action (retry
+    // or resume-after-idle) is due.  A negative remaining means it is already
+    // due, so poll with a zero timeout.
+    TickType_t timeout = portMAX_DELAY;
+    if (state == COEX_SUSPEND_RETRY || state == COEX_RESUME_WAIT) {
+      int32_t remaining = (int32_t)(wake_at - xTaskGetTickCount());
+      timeout = (remaining > 0) ? (TickType_t)remaining : 0;
+    }
+
+    bt_coex_event_t evt;
+    if (xQueueReceive(s_queue, &evt, timeout) == pdTRUE) {
+      state = coex_on_event(state, evt, &wake_at);
+    } else {
+      state = coex_on_timeout(state, &wake_at);
+    }
+  }
+}
+
+esp_err_t bt_coex_start(void) {
+  if (s_task) {
+    return ESP_OK;
+  }
+  s_queue = xQueueCreate(BT_COEX_QUEUE_LEN, sizeof(bt_coex_event_t));
+  if (!s_queue) {
+    return ESP_ERR_NO_MEM;
+  }
+  BaseType_t ok =
+      task_create_spiram(bt_coex_task, "bt_coex", BT_COEX_TASK_STACK, NULL,
+                         BT_COEX_TASK_PRIO, &s_task, NULL);
+  if (ok != pdPASS) {
+    vQueueDelete(s_queue);
+    s_queue = NULL;
+    return ESP_ERR_NO_MEM;
+  }
+  return ESP_OK;
+}
+
+void bt_coex_post(bt_coex_event_t event) {
+  if (!s_queue) {
+    return;
+  }
+  if (xQueueSend(s_queue, &event, 0) != pdTRUE) {
+    ESP_LOGW(TAG, "coex queue full, dropped event %d", (int)event);
+  }
+}

--- a/main/bt_coex.h
+++ b/main/bt_coex.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * WiFi/BT coexistence coordinator.
+ *
+ * On ESP32 the single radio is shared between WiFi and Classic Bluetooth; the
+ * coexistence arbiter throttles WiFi RX whenever the BT controller is enabled,
+ * even when idle.  To give AirPlay full WiFi bandwidth this module suspends the
+ * BT radio while AirPlay is actively streaming and resumes it after AirPlay has
+ * been idle for a short settling delay.
+ *
+ * All BT radio suspend/resume operations are performed by a single owner task,
+ * driven by an ordered event queue.  Callers only post events (from any task
+ * context); the task serialises every transition, which removes the flag races
+ * that plagued the earlier ad-hoc implementation.
+ */
+typedef enum {
+  BT_COEX_EVT_AIRPLAY_CONNECTED,    // AirPlay client attached (not yet playing)
+  BT_COEX_EVT_AIRPLAY_PLAYING,      // AirPlay audio actively streaming
+  BT_COEX_EVT_AIRPLAY_PAUSED,       // AirPlay paused (session still active)
+  BT_COEX_EVT_AIRPLAY_DISCONNECTED, // AirPlay session ended
+  BT_COEX_EVT_BT_CONNECTED,         // A Bluetooth device connected
+  BT_COEX_EVT_BT_DISCONNECTED,      // The Bluetooth device disconnected
+} bt_coex_event_t;
+
+/**
+ * Start the coexistence state machine (creates its event queue and owner task).
+ * Idempotent — a second call is a no-op.
+ */
+esp_err_t bt_coex_start(void);
+
+/**
+ * Post an event to the coexistence state machine.  Safe to call from any task
+ * context (RTSP callback, Bluetooth app task).  Never blocks the caller; if the
+ * queue is somehow full the event is dropped with a warning.
+ */
+void bt_coex_post(bt_coex_event_t event);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -41,12 +41,14 @@ static bool s_airplay_infrastructure_ready = false;
 #ifdef CONFIG_BT_A2DP_ENABLE
 // WiFi/BT coexistence: the BT controller throttles WiFi RX even when idle, so
 // the radio is suspended while AirPlay is actively streaming and resumed after
-// a period with no AirPlay activity.  Flags are set from the RTSP event
-// callback and acted on in network_monitor_task (a safe task context — BT
-// enable/disable must not run in the esp_timer/callback context).
+// a period with no AirPlay activity.  These bool request flags are set from the
+// RTSP event callback and acted on in network_monitor_task (a safe task context
+// — BT enable/disable must not run in the esp_timer/callback context).  The
+// resume countdown deadline lives task-locally in network_monitor_task, so no
+// 64-bit value is shared across cores (avoids torn reads on dual-core ESP32).
 #define BT_RESUME_IDLE_US (15 * 1000000LL)
 static volatile bool s_bt_suspend_requested = false;
-static volatile int64_t s_bt_resume_deadline_us = 0; // 0 = no resume pending
+static volatile bool s_bt_resume_requested = false;
 #endif
 
 static void start_airplay_services(void) {
@@ -103,6 +105,11 @@ static void network_monitor_task(void *pvParameters) {
   bool dns_running = !had_network;
   bool wifi_started = wifi_is_connected() || !ethernet_is_connected();
   bool had_eth = ethernet_is_connected();
+#ifdef CONFIG_BT_A2DP_ENABLE
+  // Task-local BT resume deadline (0 = none).  Only this task touches it, so
+  // there is no cross-core 64-bit sharing to tear.
+  int64_t bt_resume_deadline_us = 0;
+#endif
 
   // Start captive portal DNS if no network yet
   if (dns_running) {
@@ -119,10 +126,16 @@ static void network_monitor_task(void *pvParameters) {
     // resume brings BT back after the post-playback idle delay.
     if (s_bt_suspend_requested) {
       s_bt_suspend_requested = false;
+      bt_resume_deadline_us = 0; // a new stream cancels any pending resume
       bt_a2dp_sink_suspend();
-    } else if (s_bt_resume_deadline_us != 0 &&
-               esp_timer_get_time() >= s_bt_resume_deadline_us) {
-      s_bt_resume_deadline_us = 0;
+    }
+    if (s_bt_resume_requested) {
+      s_bt_resume_requested = false;
+      bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
+    }
+    if (bt_resume_deadline_us != 0 &&
+        esp_timer_get_time() >= bt_resume_deadline_us) {
+      bt_resume_deadline_us = 0;
       bt_a2dp_sink_resume();
     }
 #endif
@@ -203,20 +216,20 @@ static void on_airplay_client_event(rtsp_event_t event,
   case RTSP_EVENT_PLAYING:
     // Audio is actively streaming — free the radio for WiFi by suspending BT.
     // Cancel any pending resume so a brief pause→play does not flap the radio.
-    s_bt_resume_deadline_us = 0;
+    s_bt_resume_requested = false;
     s_bt_suspend_requested = true;
     break;
   case RTSP_EVENT_PAUSED:
-    // V1 grace period active — keep BT hidden so the phone reconnects
-    // to AirPlay rather than falling back to BT.  Arm the idle timer so BT
-    // resumes if the pause turns into a prolonged stop.
-    ESP_LOGI(TAG, "AirPlay paused — keeping BT hidden");
-    s_bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
+    // Keep BT suspended AND hidden during a pause: the AirPlay session is still
+    // active, so resuming BT here would only reintroduce coexistence throttling
+    // without making BT usable (it stays non-discoverable).  BT resumes only
+    // when the session actually ends (RTSP_EVENT_DISCONNECTED).
+    ESP_LOGI(TAG, "AirPlay paused — keeping BT suspended and hidden");
     break;
   case RTSP_EVENT_DISCONNECTED:
     ESP_LOGI(TAG, "AirPlay client disconnected — BT resumes after idle delay");
     bt_a2dp_sink_set_discoverable(true);
-    s_bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
+    s_bt_resume_requested = true;
     break;
   default:
     break;

--- a/main/main.c
+++ b/main/main.c
@@ -26,6 +26,7 @@
 #include "iot_board.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -36,6 +37,17 @@ static const char *TAG = "main";
 
 static bool s_airplay_started = false;
 static bool s_airplay_infrastructure_ready = false;
+
+#ifdef CONFIG_BT_A2DP_ENABLE
+// WiFi/BT coexistence: the BT controller throttles WiFi RX even when idle, so
+// the radio is suspended while AirPlay is actively streaming and resumed after
+// a period with no AirPlay activity.  Flags are set from the RTSP event
+// callback and acted on in network_monitor_task (a safe task context — BT
+// enable/disable must not run in the esp_timer/callback context).
+#define BT_RESUME_IDLE_US (15 * 1000000LL)
+static volatile bool s_bt_suspend_requested = false;
+static volatile int64_t s_bt_resume_deadline_us = 0; // 0 = no resume pending
+#endif
 
 static void start_airplay_services(void) {
   if (s_airplay_started) {
@@ -99,6 +111,21 @@ static void network_monitor_task(void *pvParameters) {
 
   while (1) {
     vTaskDelay(pdMS_TO_TICKS(2000));
+
+#ifdef CONFIG_BT_A2DP_ENABLE
+    // Act on BT suspend/resume requests here — a normal task context, since
+    // esp_bt_controller_*/esp_bluedroid_* must not run in the RTSP callback or
+    // esp_timer context.  Suspend frees the radio for WiFi during AirPlay;
+    // resume brings BT back after the post-playback idle delay.
+    if (s_bt_suspend_requested) {
+      s_bt_suspend_requested = false;
+      bt_a2dp_sink_suspend();
+    } else if (s_bt_resume_deadline_us != 0 &&
+               esp_timer_get_time() >= s_bt_resume_deadline_us) {
+      s_bt_resume_deadline_us = 0;
+      bt_a2dp_sink_resume();
+    }
+#endif
 
     bool eth_up = ethernet_is_connected();
     bool wifi_up = wifi_is_connected();
@@ -173,14 +200,23 @@ static void on_airplay_client_event(rtsp_event_t event,
     ESP_LOGI(TAG, "AirPlay client connected — disabling BT");
     bt_a2dp_sink_set_discoverable(false);
     break;
+  case RTSP_EVENT_PLAYING:
+    // Audio is actively streaming — free the radio for WiFi by suspending BT.
+    // Cancel any pending resume so a brief pause→play does not flap the radio.
+    s_bt_resume_deadline_us = 0;
+    s_bt_suspend_requested = true;
+    break;
   case RTSP_EVENT_PAUSED:
     // V1 grace period active — keep BT hidden so the phone reconnects
-    // to AirPlay rather than falling back to BT.
+    // to AirPlay rather than falling back to BT.  Arm the idle timer so BT
+    // resumes if the pause turns into a prolonged stop.
     ESP_LOGI(TAG, "AirPlay paused — keeping BT hidden");
+    s_bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
     break;
   case RTSP_EVENT_DISCONNECTED:
-    ESP_LOGI(TAG, "AirPlay client disconnected — enabling BT");
+    ESP_LOGI(TAG, "AirPlay client disconnected — BT resumes after idle delay");
     bt_a2dp_sink_set_discoverable(true);
+    s_bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
     break;
   default:
     break;

--- a/main/main.c
+++ b/main/main.c
@@ -49,6 +49,10 @@ static bool s_airplay_infrastructure_ready = false;
 #define BT_RESUME_IDLE_US (15 * 1000000LL)
 static volatile bool s_bt_suspend_requested = false;
 static volatile bool s_bt_resume_requested = false;
+// Set when an AirPlay client (re)connects to cancel any pending resume armed by
+// a previous disconnect, so a quick reconnect keeps BT suspended instead of
+// briefly resuming it during session setup.
+static volatile bool s_bt_cancel_resume = false;
 #endif
 
 static void start_airplay_services(void) {
@@ -126,6 +130,12 @@ static void network_monitor_task(void *pvParameters) {
     // resume brings BT back after the post-playback idle delay.  Each request
     // flag / deadline is cleared only once the operation succeeds, so a
     // transient failure is retried on the next loop rather than being lost.
+    if (s_bt_cancel_resume) {
+      // A client (re)connected: drop any pending resume so BT stays suspended.
+      s_bt_cancel_resume = false;
+      s_bt_resume_requested = false;
+      bt_resume_deadline_us = 0;
+    }
     if (s_bt_suspend_requested) {
       if (bt_a2dp_sink_suspend() == ESP_OK) {
         s_bt_suspend_requested = false;
@@ -217,6 +227,9 @@ static void on_airplay_client_event(rtsp_event_t event,
   case RTSP_EVENT_CLIENT_CONNECTED:
     ESP_LOGI(TAG, "AirPlay client connected — disabling BT");
     bt_a2dp_sink_set_discoverable(false);
+    // Cancel any resume armed by a previous disconnect so a quick reconnect
+    // keeps BT suspended (PLAYING will re-request suspend shortly).
+    s_bt_cancel_resume = true;
     break;
   case RTSP_EVENT_PLAYING:
     // Audio is actively streaming — free the radio for WiFi by suspending BT.

--- a/main/main.c
+++ b/main/main.c
@@ -131,9 +131,12 @@ static void network_monitor_task(void *pvParameters) {
     // flag / deadline is cleared only once the operation succeeds, so a
     // transient failure is retried on the next loop rather than being lost.
     if (s_bt_cancel_resume) {
-      // A client (re)connected: drop any pending resume so BT stays suspended.
+      // A client (re)connected: cancel a resume deadline armed in an EARLIER
+      // poll window so BT stays suspended.  Do NOT clear s_bt_resume_requested
+      // here — a DISCONNECTED that fired after the connect (same window)
+      // supersedes this cancel and clears s_bt_cancel_resume itself, so the
+      // newer resume request survives (last-writer-wins on the paired flags).
       s_bt_cancel_resume = false;
-      s_bt_resume_requested = false;
       bt_resume_deadline_us = 0;
     }
     if (s_bt_suspend_requested) {
@@ -237,8 +240,11 @@ static void on_airplay_client_event(rtsp_event_t event,
   case RTSP_EVENT_CLIENT_CONNECTED:
     ESP_LOGI(TAG, "AirPlay client connected — disabling BT");
     bt_a2dp_sink_set_discoverable(false);
-    // Cancel any resume armed by a previous disconnect so a quick reconnect
-    // keeps BT suspended (PLAYING will re-request suspend shortly).
+    // Cancel any resume queued/armed by a previous disconnect so a quick
+    // reconnect keeps BT suspended (PLAYING will re-request suspend shortly).
+    // Paired with DISCONNECTED as last-writer-wins: each clears the other's
+    // flag, so a disconnect after this connect still resumes BT.
+    s_bt_resume_requested = false;
     s_bt_cancel_resume = true;
     break;
   case RTSP_EVENT_PLAYING:
@@ -257,6 +263,9 @@ static void on_airplay_client_event(rtsp_event_t event,
   case RTSP_EVENT_DISCONNECTED:
     ESP_LOGI(TAG, "AirPlay client disconnected — BT resumes after idle delay");
     bt_a2dp_sink_set_discoverable(true);
+    // Supersede a cancel queued by an earlier connect in the same poll window
+    // so this (newer) resume request wins.
+    s_bt_cancel_resume = false;
     s_bt_resume_requested = true;
     break;
   default:

--- a/main/main.c
+++ b/main/main.c
@@ -20,13 +20,13 @@
 
 #ifdef CONFIG_BT_A2DP_ENABLE
 #include "a2dp_sink.h"
+#include "bt_coex.h"
 #include "rtsp_events.h"
 #endif
 
 #include "iot_board.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
-#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -37,23 +37,6 @@ static const char *TAG = "main";
 
 static bool s_airplay_started = false;
 static bool s_airplay_infrastructure_ready = false;
-
-#ifdef CONFIG_BT_A2DP_ENABLE
-// WiFi/BT coexistence: the BT controller throttles WiFi RX even when idle, so
-// the radio is suspended while AirPlay is actively streaming and resumed after
-// a period with no AirPlay activity.  These bool request flags are set from the
-// RTSP event callback and acted on in network_monitor_task (a safe task context
-// — BT enable/disable must not run in the esp_timer/callback context).  The
-// resume countdown deadline lives task-locally in network_monitor_task, so no
-// 64-bit value is shared across cores (avoids torn reads on dual-core ESP32).
-#define BT_RESUME_IDLE_US (15 * 1000000LL)
-static volatile bool s_bt_suspend_requested = false;
-static volatile bool s_bt_resume_requested = false;
-// Set when an AirPlay client (re)connects to cancel any pending resume armed by
-// a previous disconnect, so a quick reconnect keeps BT suspended instead of
-// briefly resuming it during session setup.
-static volatile bool s_bt_cancel_resume = false;
-#endif
 
 static void start_airplay_services(void) {
   if (s_airplay_started) {
@@ -109,11 +92,6 @@ static void network_monitor_task(void *pvParameters) {
   bool dns_running = !had_network;
   bool wifi_started = wifi_is_connected() || !ethernet_is_connected();
   bool had_eth = ethernet_is_connected();
-#ifdef CONFIG_BT_A2DP_ENABLE
-  // Task-local BT resume deadline (0 = none).  Only this task touches it, so
-  // there is no cross-core 64-bit sharing to tear.
-  int64_t bt_resume_deadline_us = 0;
-#endif
 
   // Start captive portal DNS if no network yet
   if (dns_running) {
@@ -122,47 +100,6 @@ static void network_monitor_task(void *pvParameters) {
 
   while (1) {
     vTaskDelay(pdMS_TO_TICKS(2000));
-
-#ifdef CONFIG_BT_A2DP_ENABLE
-    // Act on BT suspend/resume requests here — a normal task context, since
-    // esp_bt_controller_*/esp_bluedroid_* must not run in the RTSP callback or
-    // esp_timer context.  Suspend frees the radio for WiFi during AirPlay;
-    // resume brings BT back after the post-playback idle delay.  Each request
-    // flag / deadline is cleared only once the operation succeeds, so a
-    // transient failure is retried on the next loop rather than being lost.
-    if (s_bt_cancel_resume) {
-      // A client (re)connected: cancel a resume deadline armed in an EARLIER
-      // poll window so BT stays suspended.  Do NOT clear s_bt_resume_requested
-      // here — a DISCONNECTED that fired after the connect (same window)
-      // supersedes this cancel and clears s_bt_cancel_resume itself, so the
-      // newer resume request survives (last-writer-wins on the paired flags).
-      s_bt_cancel_resume = false;
-      bt_resume_deadline_us = 0;
-    }
-    if (s_bt_suspend_requested) {
-      // ESP_OK = suspended (or already suspended).  ESP_ERR_INVALID_STATE =
-      // a BT device is connected, so suspend is not applicable — clear the
-      // request in both cases.  Any other error is transient: retry next loop.
-      esp_err_t serr = bt_a2dp_sink_suspend();
-      if (serr == ESP_OK || serr == ESP_ERR_INVALID_STATE) {
-        s_bt_suspend_requested = false;
-        if (serr == ESP_OK) {
-          bt_resume_deadline_us = 0; // a new stream cancels any pending resume
-        }
-      }
-    }
-    if (s_bt_resume_requested) {
-      s_bt_resume_requested = false;
-      bt_resume_deadline_us = esp_timer_get_time() + BT_RESUME_IDLE_US;
-    }
-    if (bt_resume_deadline_us != 0 &&
-        esp_timer_get_time() >= bt_resume_deadline_us) {
-      if (bt_a2dp_sink_resume() == ESP_OK) {
-        bt_resume_deadline_us = 0;
-      }
-      // On failure leave the deadline expired so the next loop retries.
-    }
-#endif
 
     bool eth_up = ethernet_is_connected();
     bool wifi_up = wifi_is_connected();
@@ -214,13 +151,11 @@ static void on_bt_state_changed(bool connected) {
   if (connected) {
     ESP_LOGI(TAG, "BT connected — disabling AirPlay");
     stop_airplay_services();
-    // BT is now the active source: drop any pending AirPlay-driven suspend
-    // request so it doesn't fire the moment BT later disconnects (which would
-    // block a BT reconnect until the idle-resume timer runs).
-    s_bt_suspend_requested = false;
+    bt_coex_post(BT_COEX_EVT_BT_CONNECTED);
     playback_control_set_source(PLAYBACK_SOURCE_BLUETOOTH);
   } else {
     ESP_LOGI(TAG, "BT disconnected — re-enabling AirPlay");
+    bt_coex_post(BT_COEX_EVT_BT_DISCONNECTED);
     playback_control_set_source(PLAYBACK_SOURCE_NONE);
     if (ethernet_is_connected() || wifi_is_connected()) {
       start_airplay_services();
@@ -240,33 +175,21 @@ static void on_airplay_client_event(rtsp_event_t event,
   case RTSP_EVENT_CLIENT_CONNECTED:
     ESP_LOGI(TAG, "AirPlay client connected — disabling BT");
     bt_a2dp_sink_set_discoverable(false);
-    // Cancel any resume queued/armed by a previous disconnect so a quick
-    // reconnect keeps BT suspended (PLAYING will re-request suspend shortly).
-    // Paired with DISCONNECTED as last-writer-wins: each clears the other's
-    // flag, so a disconnect after this connect still resumes BT.
-    s_bt_resume_requested = false;
-    s_bt_cancel_resume = true;
+    bt_coex_post(BT_COEX_EVT_AIRPLAY_CONNECTED);
     break;
   case RTSP_EVENT_PLAYING:
-    // Audio is actively streaming — free the radio for WiFi by suspending BT.
-    // Cancel any pending resume so a brief pause→play does not flap the radio.
-    s_bt_resume_requested = false;
-    s_bt_suspend_requested = true;
+    bt_coex_post(BT_COEX_EVT_AIRPLAY_PLAYING);
     break;
   case RTSP_EVENT_PAUSED:
-    // Keep BT suspended AND hidden during a pause: the AirPlay session is still
-    // active, so resuming BT here would only reintroduce coexistence throttling
-    // without making BT usable (it stays non-discoverable).  BT resumes only
-    // when the session actually ends (RTSP_EVENT_DISCONNECTED).
+    // Session still active — BT stays suspended and hidden so the phone
+    // reconnects to AirPlay rather than falling back to BT.
     ESP_LOGI(TAG, "AirPlay paused — keeping BT suspended and hidden");
+    bt_coex_post(BT_COEX_EVT_AIRPLAY_PAUSED);
     break;
   case RTSP_EVENT_DISCONNECTED:
     ESP_LOGI(TAG, "AirPlay client disconnected — BT resumes after idle delay");
     bt_a2dp_sink_set_discoverable(true);
-    // Supersede a cancel queued by an earlier connect in the same poll window
-    // so this (newer) resume request wins.
-    s_bt_cancel_resume = false;
-    s_bt_resume_requested = true;
+    bt_coex_post(BT_COEX_EVT_AIRPLAY_DISCONNECTED);
     break;
   default:
     break;
@@ -369,6 +292,9 @@ void app_main(void) {
     if (bt_err != ESP_OK) {
       ESP_LOGE(TAG, "BT A2DP init failed: %s", esp_err_to_name(bt_err));
     } else {
+      if (bt_coex_start() != ESP_OK) {
+        ESP_LOGE(TAG, "BT coexistence task start failed");
+      }
       rtsp_events_register(on_airplay_client_event, NULL);
     }
   }

--- a/main/main.c
+++ b/main/main.c
@@ -24,6 +24,7 @@
 #endif
 
 #include "iot_board.h"
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -286,6 +287,16 @@ void app_main(void) {
     }
   }
 #endif
+
+  // Boot baseline: free internal DRAM once WiFi (and BT, where enabled) are
+  // resident but before any stream is active.  Compare against the
+  // "Buffered start" log to see the headroom available for WiFi/TCP buffers.
+  ESP_LOGI(TAG,
+           "Boot baseline: free heap %lu internal (largest block %lu), "
+           "%lu SPIRAM",
+           (unsigned long)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+           (unsigned long)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+           (unsigned long)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
 
   buttons_init();
 

--- a/main/main.c
+++ b/main/main.c
@@ -137,9 +137,15 @@ static void network_monitor_task(void *pvParameters) {
       bt_resume_deadline_us = 0;
     }
     if (s_bt_suspend_requested) {
-      if (bt_a2dp_sink_suspend() == ESP_OK) {
+      // ESP_OK = suspended (or already suspended).  ESP_ERR_INVALID_STATE =
+      // a BT device is connected, so suspend is not applicable — clear the
+      // request in both cases.  Any other error is transient: retry next loop.
+      esp_err_t serr = bt_a2dp_sink_suspend();
+      if (serr == ESP_OK || serr == ESP_ERR_INVALID_STATE) {
         s_bt_suspend_requested = false;
-        bt_resume_deadline_us = 0; // a new stream cancels any pending resume
+        if (serr == ESP_OK) {
+          bt_resume_deadline_us = 0; // a new stream cancels any pending resume
+        }
       }
     }
     if (s_bt_resume_requested) {
@@ -205,6 +211,10 @@ static void on_bt_state_changed(bool connected) {
   if (connected) {
     ESP_LOGI(TAG, "BT connected — disabling AirPlay");
     stop_airplay_services();
+    // BT is now the active source: drop any pending AirPlay-driven suspend
+    // request so it doesn't fire the moment BT later disconnects (which would
+    // block a BT reconnect until the idle-resume timer runs).
+    s_bt_suspend_requested = false;
     playback_control_set_source(PLAYBACK_SOURCE_BLUETOOTH);
   } else {
     ESP_LOGI(TAG, "BT disconnected — re-enabling AirPlay");

--- a/main/main.c
+++ b/main/main.c
@@ -123,11 +123,14 @@ static void network_monitor_task(void *pvParameters) {
     // Act on BT suspend/resume requests here — a normal task context, since
     // esp_bt_controller_*/esp_bluedroid_* must not run in the RTSP callback or
     // esp_timer context.  Suspend frees the radio for WiFi during AirPlay;
-    // resume brings BT back after the post-playback idle delay.
+    // resume brings BT back after the post-playback idle delay.  Each request
+    // flag / deadline is cleared only once the operation succeeds, so a
+    // transient failure is retried on the next loop rather than being lost.
     if (s_bt_suspend_requested) {
-      s_bt_suspend_requested = false;
-      bt_resume_deadline_us = 0; // a new stream cancels any pending resume
-      bt_a2dp_sink_suspend();
+      if (bt_a2dp_sink_suspend() == ESP_OK) {
+        s_bt_suspend_requested = false;
+        bt_resume_deadline_us = 0; // a new stream cancels any pending resume
+      }
     }
     if (s_bt_resume_requested) {
       s_bt_resume_requested = false;
@@ -135,8 +138,10 @@ static void network_monitor_task(void *pvParameters) {
     }
     if (bt_resume_deadline_us != 0 &&
         esp_timer_get_time() >= bt_resume_deadline_us) {
-      bt_resume_deadline_us = 0;
-      bt_a2dp_sink_resume();
+      if (bt_a2dp_sink_resume() == ESP_OK) {
+        bt_resume_deadline_us = 0;
+      }
+      // On failure leave the deadline expired so the next loop retries.
     }
 #endif
 

--- a/main/network/log_stream.c
+++ b/main/network/log_stream.c
@@ -24,7 +24,6 @@
 #define LOG_RING_SIZE 8192
 #define LOG_RING_MASK (LOG_RING_SIZE - 1)
 
-#define MAX_WS_CLIENTS        3
 #define BROADCAST_TASK_STACK  4096
 #define BROADCAST_INTERVAL_MS 100
 #define MAX_SEND_CHUNK        1024
@@ -35,9 +34,6 @@ static volatile size_t s_tail; /* next read position   */
 static SemaphoreHandle_t s_mutex;
 
 static httpd_handle_t s_server;
-static int s_clients[MAX_WS_CLIENTS];
-static int s_client_count;
-static SemaphoreHandle_t s_client_mutex;
 
 static vprintf_like_t s_orig_vprintf;
 
@@ -106,29 +102,18 @@ static int log_vprintf_hook(const char *fmt, va_list args) {
 /* ------------------------------------------------------------------ */
 
 static esp_err_t ws_log_handler(httpd_req_t *req) {
-  if (req->method == HTTP_GET) {
-    /* Handshake — register this socket. */
-    int fd = httpd_req_to_sockfd(req);
-    if (xSemaphoreTake(s_client_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-      if (s_client_count < MAX_WS_CLIENTS) {
-        s_clients[s_client_count++] = fd;
-        xSemaphoreGive(s_client_mutex);
-        ESP_LOGI("log_stream", "WebSocket client connected (fd=%d, total=%d)",
-                 fd, s_client_count);
-      } else {
-        xSemaphoreGive(s_client_mutex);
-        ESP_LOGW("log_stream", "Max WebSocket clients reached, rejecting fd=%d",
-                 fd);
-        return ESP_FAIL;
-      }
-    } else {
-      ESP_LOGW("log_stream", "Client mutex timeout, rejecting fd=%d", fd);
-      return ESP_FAIL;
-    }
-    return ESP_OK;
-  }
-
-  /* We only stream logs out; ignore any incoming frames. */
+  /* On ESP-IDF >= 5.x the server completes the WebSocket handshake
+   * internally and does NOT invoke this handler for the handshake GET
+   * (httpd_uri.c: "If the request is websocket handshake, then do not
+   * call the uri->handler").  Clients are therefore not tracked here at
+   * all — the broadcast task discovers active WebSocket sessions each
+   * tick via httpd_get_client_list()/httpd_ws_get_fd_info().  An earlier
+   * version registered clients from a handshake-time HTTP_GET call that
+   * never happens on this IDF, so the viewer connected successfully but
+   * never received a single frame.
+   *
+   * This handler now only runs for incoming data frames, which a log
+   * viewer does not send; drain and ignore them. */
   httpd_ws_frame_t frame = {.type = HTTPD_WS_TYPE_TEXT};
   return httpd_ws_recv_frame(req, &frame, 0);
 }
@@ -137,13 +122,6 @@ static esp_err_t ws_log_handler(httpd_req_t *req) {
 /*  Broadcast task                                                     */
 /* ------------------------------------------------------------------ */
 
-static void remove_client(int index) {
-  if (index < s_client_count - 1) {
-    s_clients[index] = s_clients[s_client_count - 1];
-  }
-  s_client_count--;
-}
-
 static void broadcast_task(void *arg) {
   (void)arg;
   char buf[MAX_SEND_CHUNK];
@@ -151,8 +129,25 @@ static void broadcast_task(void *arg) {
   while (1) {
     vTaskDelay(pdMS_TO_TICKS(BROADCAST_INTERVAL_MS));
 
-    if (s_client_count == 0) {
+    /* Discover active WebSocket sessions fresh each tick.  No connect-time
+     * registration (see ws_log_handler) and no stale-fd list: a client
+     * that disconnected simply stops appearing here, so log frames can
+     * never be sent to a reused fd now serving an unrelated request. */
+    int fds[CONFIG_LWIP_MAX_SOCKETS];
+    size_t fd_count = CONFIG_LWIP_MAX_SOCKETS;
+    if (httpd_get_client_list(s_server, &fd_count, fds) != ESP_OK) {
       continue;
+    }
+
+    int ws_fds[CONFIG_LWIP_MAX_SOCKETS];
+    size_t ws_count = 0;
+    for (size_t i = 0; i < fd_count; i++) {
+      if (httpd_ws_get_fd_info(s_server, fds[i]) == HTTPD_WS_CLIENT_WEBSOCKET) {
+        ws_fds[ws_count++] = fds[i];
+      }
+    }
+    if (ws_count == 0) {
+      continue; /* leave data in the ring as backlog for the next viewer */
     }
 
     size_t len = 0;
@@ -170,17 +165,14 @@ static void broadcast_task(void *arg) {
         .len = len,
     };
 
-    if (xSemaphoreTake(s_client_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
-      for (int i = s_client_count - 1; i >= 0; i--) {
-        esp_err_t err =
-            httpd_ws_send_frame_async(s_server, s_clients[i], &frame);
-        if (err != ESP_OK) {
-          ESP_LOGW("log_stream", "Dropping WebSocket client fd=%d: %s",
-                   s_clients[i], esp_err_to_name(err));
-          remove_client(i);
-        }
+    for (size_t i = 0; i < ws_count; i++) {
+      esp_err_t err = httpd_ws_send_frame_async(s_server, ws_fds[i], &frame);
+      if (err != ESP_OK) {
+        /* Session is closing; httpd cleans it up and it will no longer
+         * be listed on the next tick. */
+        ESP_LOGD("log_stream", "WS send to fd=%d failed: %s", ws_fds[i],
+                 esp_err_to_name(err));
       }
-      xSemaphoreGive(s_client_mutex);
     }
   }
 }
@@ -206,12 +198,6 @@ esp_err_t log_stream_init(void) {
   }
 
   s_head = s_tail = 0;
-  s_client_count = 0;
-
-  s_client_mutex = xSemaphoreCreateMutex();
-  if (!s_client_mutex) {
-    return ESP_ERR_NO_MEM;
-  }
 
   /* Hook into esp_log — keep the original so UART output continues. */
   s_orig_vprintf = esp_log_set_vprintf(log_vprintf_hook);

--- a/main/network/log_stream.c
+++ b/main/network/log_stream.c
@@ -102,20 +102,32 @@ static int log_vprintf_hook(const char *fmt, va_list args) {
 /* ------------------------------------------------------------------ */
 
 static esp_err_t ws_log_handler(httpd_req_t *req) {
-  /* On ESP-IDF >= 5.x the server completes the WebSocket handshake
-   * internally and does NOT invoke this handler for the handshake GET
-   * (httpd_uri.c: "If the request is websocket handshake, then do not
-   * call the uri->handler").  Clients are therefore not tracked here at
-   * all — the broadcast task discovers active WebSocket sessions each
-   * tick via httpd_get_client_list()/httpd_ws_get_fd_info().  An earlier
-   * version registered clients from a handshake-time HTTP_GET call that
-   * never happens on this IDF, so the viewer connected successfully but
-   * never received a single frame.
-   *
-   * This handler now only runs for incoming data frames, which a log
-   * viewer does not send; drain and ignore them. */
-  httpd_ws_frame_t frame = {.type = HTTPD_WS_TYPE_TEXT};
-  return httpd_ws_recv_frame(req, &frame, 0);
+  /* The server completes the WebSocket handshake internally; depending on the
+   * IDF build the handshake GET may or may not reach here.  Return OK for it
+   * and do nothing — clients are tracked by the broadcast task, not here. */
+  if (req->method == HTTP_GET) {
+    return ESP_OK;
+  }
+
+  /* A log viewer only receives, but browsers still send frames here (notably
+   * CLOSE on tab close/reconnect).  Probe the length, then CONSUME the
+   * payload: reading only the header (max_len 0) leaves the 4-byte mask key
+   * and payload in the socket, so the next frame is parsed mid-stream and
+   * misreported as "not properly masked", failing the handler.  Fully
+   * draining each frame keeps the framing aligned; ignore recv errors instead
+   * of returning them (which httpd logs as "uri handler execution failed"). */
+  httpd_ws_frame_t frame = {0};
+  if (httpd_ws_recv_frame(req, &frame, 0) != ESP_OK) {
+    return ESP_OK;
+  }
+  if (frame.len > 0) {
+    uint8_t buf[128];
+    if (frame.len <= sizeof(buf)) {
+      frame.payload = buf;
+      httpd_ws_recv_frame(req, &frame, sizeof(buf));
+    }
+  }
+  return ESP_OK;
 }
 
 /* ------------------------------------------------------------------ */

--- a/main/network/ptp_clock.c
+++ b/main/network/ptp_clock.c
@@ -88,6 +88,13 @@ static struct {
 
   // Asymmetric smoothing state (replaces median ring buffer)
   int64_t previous_offset;
+  // Most recent RAW (unsmoothed) offset sample.  The smoothing filter is
+  // deliberately asymmetric (see SMOOTH_* below), so filtered_offset_ns can
+  // sit a long way from the truth without any existing log revealing it —
+  // every timing figure the firmware prints is derived from the filtered
+  // value, so an error in it is invisible to those figures.  Keeping the raw
+  // sample lets callers compare the two and detect filter divergence.
+  int64_t raw_offset_ns;
   uint32_t previous_offset_time_ms; // 0 = no previous sample yet
   uint32_t mastership_start_ms;     // when continuous tracking began
 
@@ -152,6 +159,9 @@ static void update_offset(int64_t new_offset_ns) {
   uint32_t now_ms = xTaskGetTickCount() * portTICK_PERIOD_MS;
   ptp.last_sync_ms = now_ms;
   ptp.sample_count++;
+  // Record the raw sample before any smoothing or outlier rejection, so the
+  // divergence between measured and filtered offset stays observable.
+  ptp.raw_offset_ns = new_offset_ns;
 
   int64_t smoothed_offset;
 
@@ -628,8 +638,12 @@ uint64_t ptp_clock_get_master_clock_id(void) {
 void ptp_clock_get_stats(ptp_stats_t *stats) {
   stats->sync_count = ptp.sync_count;
   stats->followup_count = ptp.followup_count;
-  stats->last_offset_ns = ptp.previous_offset;
+  // last_offset_ns previously reported previous_offset, which is itself a
+  // smoothed value — so it could never reveal filter divergence.  Report the
+  // genuinely raw sample instead.
+  stats->last_offset_ns = ptp.raw_offset_ns;
   stats->filtered_offset_ns = ptp.filtered_offset_ns;
+  stats->outlier_count = ptp.outlier_count;
 
   if (ptp.locked && ptp.lock_start_ms > 0) {
     uint32_t now_ms = xTaskGetTickCount() * portTICK_PERIOD_MS;

--- a/main/network/ptp_clock.h
+++ b/main/network/ptp_clock.h
@@ -68,9 +68,10 @@ void ptp_clock_notify_resume(uint32_t pause_duration_ms);
 typedef struct {
   uint32_t sync_count;        // Number of SYNC messages received
   uint32_t followup_count;    // Number of FOLLOW_UP messages received
-  int64_t last_offset_ns;     // Last measured offset
-  int64_t filtered_offset_ns; // Filtered/averaged offset
+  int64_t last_offset_ns;     // Last RAW measured offset (pre-smoothing)
+  int64_t filtered_offset_ns; // Filtered/averaged offset (what timing uses)
   uint32_t lock_time_ms;      // Time since lock achieved (0 if not locked)
+  uint32_t outlier_count;     // Samples rejected as outliers since start
 } ptp_stats_t;
 
 void ptp_clock_get_stats(ptp_stats_t *stats);

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -81,6 +81,12 @@ bool rtsp_codec_configure(int64_t type_id, audio_format_t *fmt,
 
 // Event port task state
 #define EVENT_STACK_SIZE 3072
+
+// Default playout latency for realtime (type 96) streams when SETUP does not
+// carry a usable latencyMin: 11025 samples = 250 ms at 44.1 kHz.  This is the
+// standard AirPlay realtime-stream minimum latency; senders transmit audio
+// ~2 s (88200 samples) ahead of this deadline.
+#define AIRPLAY_RT_LATENCY_DEFAULT_SAMPLES 11025
 static int event_client_socket = -1;
 static int event_listen_socket = -1;
 static TaskHandle_t event_task_handle = NULL;
@@ -1268,6 +1274,36 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
 
   if (!start_audio_receiver_or_fail(socket, conn, req, stream_type)) {
     return;
+  }
+
+  // Playout latency.  For REALTIME streams (type 96) the anchor from
+  // SETRATEANCHORTIME maps an RTP timestamp onto the sender's source
+  // timeline; actual playout is expected latencyMin samples later.  Every
+  // reference receiver applies this, so playing at the anchor directly puts
+  // this device ~250 ms AHEAD of the rest of a multi-room group (issue #54:
+  // an empirical +300 ms offset on a build that subtracted 46 ms of
+  // hardware latency — net +254 ms — gave near-perfect sync; 11025 samples
+  // is 250.0 ms).  Use the sender's latencyMin from the SETUP stream dict
+  // when present and sane, else the AirPlay default of 11025.
+  // Buffered streams (type 103) schedule playout with the anchor directly.
+  // Only applied on the AirPlay 2 (bplist SETUP) path; the AirPlay 1 path
+  // keeps its existing behavior (0) — no field evidence either way there.
+  if (!is_bplist || buffered) {
+    audio_receiver_set_playout_latency_samples(0);
+  } else {
+    int64_t latency_min = 0;
+    const char *latency_src = "default";
+    if (body && body_len > 0 &&
+        bplist_find_int(body, body_len, "latencyMin", &latency_min) &&
+        latency_min > 0 && latency_min <= 5 * 44100) {
+      latency_src = "SETUP latencyMin";
+    } else {
+      latency_min = AIRPLAY_RT_LATENCY_DEFAULT_SAMPLES;
+    }
+    audio_receiver_set_playout_latency_samples((uint32_t)latency_min);
+    ESP_LOGI(TAG, "Realtime playout latency: %lld samples (%lld ms, %s)",
+             (long long)latency_min, (long long)(latency_min * 1000 / 44100),
+             latency_src);
   }
 
   if (is_bplist) {

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1293,9 +1293,22 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   } else {
     int64_t latency_min = 0;
     const char *latency_src = "default";
-    if (body && body_len > 0 &&
-        bplist_find_int(body, body_len, "latencyMin", &latency_min) &&
-        latency_min > 0 && latency_min <= 5 * 44100) {
+    // latencyMin is a per-stream key inside the SETUP streams[] dict, not a
+    // top-level key — read it the same way as ct/sr/spf above.
+    if (body && body_len > 0) {
+      bplist_kv_info_t kv[16];
+      size_t kv_count = 0;
+      if (bplist_get_stream_kv_info(body, body_len, 0, kv, 16, &kv_count)) {
+        for (size_t k = 0; k < kv_count; k++) {
+          if (kv[k].value_type == BPLIST_VALUE_INT &&
+              strcmp(kv[k].key, "latencyMin") == 0) {
+            latency_min = kv[k].int_value;
+            break;
+          }
+        }
+      }
+    }
+    if (latency_min > 0 && latency_min <= 5 * 44100) {
       latency_src = "SETUP latencyMin";
     } else {
       latency_min = AIRPLAY_RT_LATENCY_DEFAULT_SAMPLES;

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1372,6 +1372,10 @@ static void handle_setup(int socket, rtsp_conn_t *conn,
   audio_receiver_set_playing(true);
   conn->stream_paused = false;
   conn->stream_active = true;
+  // RECORD emits PLAYING on the initial connection only; a resume after a
+  // stream TEARDOWN sends just a new SETUP, so emit it here too or the DAC
+  // stays in the standby it entered on pause and the stream plays silent.
+  rtsp_events_emit(RTSP_EVENT_PLAYING, NULL);
 }
 
 static void handle_record(int socket, rtsp_conn_t *conn,

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -1798,6 +1798,16 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
   // TEARDOWN without streams = full session teardown (disconnect)
   ESP_LOGI(TAG, "TEARDOWN: has_streams=%d stream_count=%zu", has_streams,
            stream_count);
+  // Stream-level teardown is a pause: freeze playout immediately so audio
+  // silences on ALL boards. playing=false makes the output emit silence at
+  // once (software mute, for software-volume/DAC-less boards); the synchronous
+  // PAUSED event mutes the hardware DAC.  Both run ahead of the slower
+  // receiver/decoder teardown below (audio_receiver_stop can block ~1 s
+  // waiting for the listener task to exit).
+  if (has_streams) {
+    audio_receiver_set_playing(false);
+    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
+  }
   audio_receiver_stop();
   audio_output_flush();
   // Drop PTP lock + offset history.  AirPlay group rejoins reuse the same
@@ -1809,10 +1819,7 @@ static void handle_teardown(int socket, rtsp_conn_t *conn,
   conn->stream_paused =
       has_streams; // Keep session ready if only streams torn down
 
-  if (has_streams) {
-    // Stream-level teardown — session still open, iOS considers this paused
-    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
-  } else {
+  if (!has_streams) {
     // Full teardown — server cleanup will emit RTSP_EVENT_DISCONNECTED
     // when the TCP connection closes.
     // For v1 sessions, keep the DACP session alive across teardown so the
@@ -1883,10 +1890,11 @@ static void handle_setrateanchortime(int socket, rtsp_conn_t *conn,
 
   if (rate == 0.0) {
     ESP_LOGI(TAG, "SETRATEANCHORTIME: rate=0 -> PAUSING");
+    // Mute the DAC first via the synchronous event so audio stops now.
+    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
     conn->stream_paused = true;
     audio_receiver_pause();
     audio_output_flush();
-    rtsp_events_emit(RTSP_EVENT_PAUSED, NULL);
   } else {
     ESP_LOGI(TAG, "SETRATEANCHORTIME: rate=%.1f -> RESUMING (was_paused=%d)",
              rate, conn->stream_paused);

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -192,6 +193,12 @@ static void client_task(void *pvParameters) {
   // Socket timeout for stop signal responsiveness
   struct timeval tv = {.tv_sec = 1, .tv_usec = 0};
   setsockopt(slot->socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  // Disable Nagle: RTSP control commands (volume, pause) are tiny and must
+  // not wait for coalescing/delayed-ACK, which adds tens to hundreds of ms of
+  // latency to every command on this connection.
+  int nodelay = 1;
+  setsockopt(slot->socket, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
 
   while (server_running && !slot->should_stop) {
     if (conn->encrypted_mode) {

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -41,6 +41,13 @@ CONFIG_LWIP_MAX_SOCKETS=16
 # sender is responsive when our PCM ring runs full.
 CONFIG_LWIP_SO_RCVBUF=y
 
+# Deepen the UDP receive mailbox.  The default of 6 overflows under the
+# bursty RTP delivery of AirPlay realtime (ALAC) unbuffered streams,
+# dropping datagrams before the audio task can drain them (~8% loss).
+# The mailbox holds pbuf pointers only (~4 bytes/slot), so this is cheap
+# and cuts realtime UDP loss to ~1-2%.
+CONFIG_LWIP_UDP_RECVMBOX_SIZE=64
+
 # Logging
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y
 CONFIG_LOG_DEFAULT_LEVEL=3

--- a/sdkconfig.defaults.bt
+++ b/sdkconfig.defaults.bt
@@ -32,13 +32,17 @@ CONFIG_BT_ACL_CONNECTIONS=1
 # Classic BT are both active.
 CONFIG_BT_ALLOCATION_FROM_SPIRAM_FIRST=y
 
-# Reduce WiFi buffer pressure — AirPlay is stopped while BT is streaming,
-# so lower counts are safe and recover ~20 KB of internal DRAM.
-CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=6
-CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=16
+# WiFi buffer pressure vs. AirPlay realtime UDP resilience — a balance.
+# AirPlay is stopped while BT is streaming, so these only matter for the
+# WiFi/AirPlay path.  Kept modest to stay well clear of the BT+WiFi OOM
+# ceiling (the BT controller/Bluedroid stack already claims ~100 KB of
+# internal DRAM), while giving the realtime (ALAC) UDP path enough RX
+# headroom to reduce packet loss.
+CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=8
+CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=24
 CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=16
 # RX BA window must be ≤ 2 × STATIC_RX_BUFFER_NUM
-CONFIG_ESP_WIFI_RX_BA_WIN=6
+CONFIG_ESP_WIFI_RX_BA_WIN=12
 
 # Bluedroid creates many software timers; the default queue of 10 is
 # borderline.  Increase to avoid commands backing up.

--- a/sdkconfig.defaults.bt
+++ b/sdkconfig.defaults.bt
@@ -54,10 +54,17 @@ CONFIG_FREERTOS_TIMER_QUEUE_LENGTH=16
 # already consumes ~100 KB of the ~320 KB budget.
 CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=1024
 
-# Smaller TCP windows — BT/WiFi coexistence halves radio bandwidth,
-# so the default 4×MSS buffers waste memory.  2×MSS is sufficient.
+# TCP receive window for data flowing TO the device (uploads, OTA, buffered
+# AAC). SND_BUF stays small — device→peer bulk sends are rare and irrelevant here.
+# NOTE: while the BT controller is active, WiFi/BT coexistence pins the
+# effective RTT (~200 ms, delayed-ACK under bursty coex RX), so this window has
+# little effect (measured ~0.6 Mbit/s regardless of size).  It only pays off
+# once BT is suspended during AirPlay (see bt_a2dp_sink_suspend), when the radio
+# is clear and receive throughput jumps (~4 Mbit/s).  TCP buffers allocate as
+# small pbuf chains on demand, so this costs aggregate internal heap (worst case
+# ~55 KB free), not the largest-free-block.
 CONFIG_LWIP_TCP_SND_BUF_DEFAULT=2880
-CONFIG_LWIP_TCP_WND_DEFAULT=2880
+CONFIG_LWIP_TCP_WND_DEFAULT=15840
 
 # Reduce IRAM usage: WiFi ISR optimisations moved to flash (saves ~12 KB)
 CONFIG_ESP_WIFI_IRAM_OPT=n


### PR DESCRIPTION
Improves real-time (ALAC/UDP) resilience, WiFi/Bluetooth coexistence, and
AirPlay 2 multi-room sync, plus a batch of audio-quality and diagnostic fixes.

## Bluetooth / WiFi coexistence
- **Dedicated coexistence state machine** (`bt_coex.c/.h`): on the ESP32 the
  single radio is shared between WiFi and Classic BT, and the arbiter throttles
  WiFi RX whenever the BT controller is enabled — even when idle. A single owner
  task now serialises all BT radio suspend/resume transitions from an ordered
  event queue, replacing the earlier flag-race-prone ad-hoc logic.
- BT radio is fully suspended while AirPlay is actively streaming and resumed
  after a short idle settling delay, giving AirPlay full WiFi bandwidth
  (measured receive throughput ~0.6 → ~4 Mbit/s once BT is suspended).

## Realtime UDP resilience & buffering - issue #113
- **Deeper UDP receive mailbox** (`CONFIG_LWIP_UDP_RECVMBOX_SIZE=64`): the
  default of 6 (~48 ms) overflowed under bursty RTP delivery, dropping ~8% of
  real-time datagrams on-device; deepening it cuts loss to ~1–2%. (from #107) 
- **Retuned WiFi/TCP buffers for the BT build** (`sdkconfig.defaults.bt`):
  WiFi RX buffers and BA window raised for realtime UDP headroom while staying
  clear of the BT+WiFi OOM ceiling; TCP window raised (2880 → 15840) to exploit
  the clear radio once BT is suspended.
- **Early stale-packet drop** (`audio_stream_buffered.c`): (from #114) pre-seek/old-track
  packets are rejected before AES + AAC decode, so they no longer consume
  decoder time or enter the PCM ring (bytes are still drained from TCP).
- **Worst-case memory logging** at buffered-stream start to size WiFi/TCP
  buffers without risking OOM.

## AirPlay 2 real-time (type 96) timing & sync — issue #54
Code integrated from [hsand](https://github.com/hsand/airplay-esp32/tree/fix/timing-drift-servo)

- **Realtime playout latency**: type 96 anchors RTP onto the sender's source
  timeline, and receivers are expected to emit each frame `latencyMin` samples
  later (default 11025 = 250 ms). Playing at the anchor directly made the device
  lead a multi-room group by ~250 ms. `latencyMin` is parsed from the AirPlay 2
  SETUP bplist (clamped, default 11025) and applied in `compute_early_us()`;
  AirPlay 1 and buffered paths keep 0.
- **Position servo**: corrects small standing offsets (post-stall residuals,
  clock drift) by trimming/duplicating one sample per 4 frames at the frame's
  quietest point. 5 ms engage / 1.5 ms disengage hysteresis; innovation-clamped
  IIR rejects one-sided late-read spikes.
- **RTP continuity + gap concealment**: unrecovered losses insert exact-length
  silence at the right schedule instead of skipping (which popped and shifted
  position early). `expected_rtp` advances on both played and dropped frames.
- **Precise starts**: pending frames release at half a frame period (±4 ms)
  instead of the wide jitter threshold; stale start-islands below the
  contiguous stream head are skipped instead of played as a blip.
- **Buffered early/late threshold 10 → 25 ms**: 10 ms sat below the I2S DMA
  ring's own ~3 ms jitter and caused drop storms; steady-state sync is now held
  by the servo, not a tight threshold.
- **DMA hardware-latency** modeled as the ring midpoint instead of the full
  ring, removing a ~2.9 ms constant bias.
- Output bounded to stereo (`AUDIO_OUT_CHANNELS`) so a malformed channel count
  cannot overrun the caller's buffer.

## Audio quality & robustness — NEW
- **Volume ramping** (I2S / S-PDIF / USB): gain approaches the target
  exponentially (~3 ms) instead of stepping, removing the volume-slider
  "zipper" click.
- **I2S `auto_clear`**: an underrun now degrades to silence instead of the DMA
  replaying stale ring contents in a loud loop.

## Diagnostics & tooling
- **Web log viewer fix**: on IDF 5.x the server completes the WebSocket
  handshake internally and never calls the URI handler, so clients were never
  registered and received no frames. The broadcaster now discovers active WS
  sessions each tick via `httpd_get_client_list()`. `logs.html` gets a pinned
  toolbar and reader-aware auto-scroll.
- **PTP diagnostics**: raw (pre-smoothing) offset and outlier count exposed so
  filter divergence is observable.
- **Once-per-second `Playout:` line** (err / buffered / depth / ptp_gap / gaps)
  for validating the timing changes.

## Testing
Built with the standard PlatformIO targets (`esp32s3`, `squeezeamp-bt`).
The real-time timing commit was confirmed on A/V sync on video

Should also fix #91 and #99

Code from hsand and Kristian8606 integrated into this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to playout timing, BT stack suspend/resume, and WiFi/BT buffer tuning on a shared radio—regressions could affect multi-room sync, dropouts, or Bluetooth availability until reboot if rollback paths fail.
> 
> **Overview**
> This PR targets **multi-room sync**, **realtime UDP stability**, and **ESP32 WiFi/BT radio sharing** in one pass.
> 
> **WiFi / Bluetooth coexistence:** A new **`bt_coex`** state machine suspends the Classic BT controller while AirPlay is actively playing and resumes it after an idle delay, with **`bt_a2dp_sink_suspend`/`resume`** tearing down and restoring profiles on **`bt_app_task`** to avoid stack races. **`main.c`** posts coexistence events from AirPlay RTSP lifecycle and BT connect/disconnect.
> 
> **AirPlay 2 realtime timing (type 96):** SETUP applies **`latencyMin`** (default **11025** samples) in scheduling; buffered early/late threshold default rises **10 → 25 ms**. **`audio_timing`** adds RTP gap concealment, stale start-island skipping, stricter pending release, a **position servo**, corrected DMA latency modeling, and **`RTSP_EVENT_PLAYING`** on SETUP resume so DAC does not stay muted.
> 
> **Buffering / network:** Buffered TCP drops stale RTP **before** decrypt/decode; **`CONFIG_LWIP_UDP_RECVMBOX_SIZE=64`** and BT-build WiFi/TCP tuning reduce realtime loss; RTSP sockets get **TCP_NODELAY**.
> 
> **Audio output:** Exponential **volume ramping** on I2S/S/PDIF/USB, I2S **`auto_clear`** on underrun, and underflow silence paced with blocking DMA writes.
> 
> **Diagnostics:** Web log streaming discovers WS clients via **`httpd_get_client_list`**; **`logs.html`** reader-aware auto-scroll; PTP raw offset/outlier stats and periodic playout logging; buffer RTP peek helpers for depth diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d5496a4979357aa4dbf17631de45898639a90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->