### PR TITLE
Stop the realtime stream drifting late behind its own output

### DIFF
--- a/main/audio/audio_output.c
+++ b/main/audio/audio_output.c
@@ -7,7 +7,9 @@
 #include "settings.h"
 #include "driver/i2s_std.h"
 #include "driver/gpio.h"
+#include "esp_attr.h"
 #include "esp_check.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "audio_receiver.h"
@@ -60,6 +62,62 @@ static TaskHandle_t playback_task_handle = NULL;
 static volatile int source_rate = 44100;
 static volatile bool resample_reinit_needed = false;
 static volatile audio_channel_mode_t channel_mode = AUDIO_CHANNEL_STEREO;
+
+/* Live output cursor.  output_submitted_frames advances after a successful
+ * i2s_channel_write(); output_sent_frames is advanced by the TX DMA
+ * completion ISR.  Their difference is the amount of audio queued ahead of
+ * the next write, i.e. the real pipeline delay.
+ *
+ * auto_clear keeps the DMA clocking descriptors even when the writer stalls,
+ * so sent can overtake submitted.  The excess is output time that was played
+ * as silence and can never be recovered; it is folded into
+ * output_lost_frames so that the queue depth stays non-negative and the
+ * cursor keeps a stable meaning across a starvation episode. */
+static uint64_t output_submitted_frames;
+static uint64_t output_sent_frames;
+static uint64_t output_lost_frames;
+static uint32_t output_underruns;
+
+static bool IRAM_ATTR audio_output_on_sent(i2s_chan_handle_t handle,
+                                           i2s_event_data_t *event,
+                                           void *user_ctx) {
+  (void)handle;
+  (void)user_ctx;
+  if (event && event->size > 0) {
+    __atomic_add_fetch(&output_sent_frames,
+                       (uint64_t)(event->size / (2U * sizeof(int16_t))),
+                       __ATOMIC_RELAXED);
+  }
+  return false;
+}
+
+static void output_cursor_reset(void) {
+  __atomic_store_n(&output_submitted_frames, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&output_sent_frames, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&output_lost_frames, 0, __ATOMIC_RELAXED);
+}
+
+/* Frames queued in the DMA ring ahead of the next write.  Called from the
+ * playback task only, which is also the sole writer of the submitted and
+ * lost counters, so the rebase below needs no lock. */
+static uint32_t output_queued_frames(void) {
+  uint64_t submitted =
+      __atomic_load_n(&output_submitted_frames, __ATOMIC_RELAXED);
+  uint64_t lost = __atomic_load_n(&output_lost_frames, __ATOMIC_RELAXED);
+  uint64_t sent = __atomic_load_n(&output_sent_frames, __ATOMIC_RELAXED);
+
+  if (sent > submitted + lost) {
+    /* The ring ran dry: rebase so queued reads 0 and remember how much
+     * output time went out as silence. */
+    __atomic_store_n(&output_lost_frames, sent - submitted, __ATOMIC_RELAXED);
+    output_underruns++;
+    return 0;
+  }
+
+  uint64_t queued = submitted + lost - sent;
+  const uint64_t ring = (uint64_t)I2S_DMA_DESC_NUM * I2S_DMA_FRAME_NUM;
+  return queued > ring ? (uint32_t)ring : (uint32_t)queued;
+}
 
 /* A bi-amp hybrid flow drives one output per crossover way, so there is no
  * left and right to pick from downstream — the DSP's input mixer makes the
@@ -164,6 +222,7 @@ static void playback_task(void *arg) {
       flush_requested = false;
       audio_resample_reset();
       i2s_channel_disable(tx_handle);
+      output_cursor_reset();
       i2s_channel_enable(tx_handle);
     }
     size_t samples = audio_receiver_read(pcm, FRAME_SAMPLES + 1);
@@ -178,17 +237,26 @@ static void playback_task(void *arg) {
       apply_volume(play_buf, play_samples * 2);
       apply_channel_mode(play_buf, play_samples);
       led_audio_feed(play_buf, play_samples);
-      i2s_channel_write(tx_handle, play_buf, play_samples * 2 * sizeof(int16_t),
-                        &written, portMAX_DELAY);
+      if (i2s_channel_write(tx_handle, play_buf,
+                            play_samples * 2 * sizeof(int16_t), &written,
+                            portMAX_DELAY) == ESP_OK) {
+        __atomic_add_fetch(&output_submitted_frames,
+                           (uint64_t)(written / (2U * sizeof(int16_t))),
+                           __ATOMIC_RELAXED);
+      }
       taskYIELD();
     } else {
       // Receiver underflow — output a frame of silence.  Block on the DMA
       // write (portMAX_DELAY) so the write itself paces the loop, instead of a
       // short timeout plus vTaskDelay(1) which produced jittery silence.
       led_audio_feed(silence, FRAME_SAMPLES);
-      i2s_channel_write(tx_handle, silence,
-                        (size_t)FRAME_SAMPLES * 2 * sizeof(int16_t), &written,
-                        portMAX_DELAY);
+      if (i2s_channel_write(tx_handle, silence,
+                            (size_t)FRAME_SAMPLES * 2 * sizeof(int16_t),
+                            &written, portMAX_DELAY) == ESP_OK) {
+        __atomic_add_fetch(&output_submitted_frames,
+                           (uint64_t)(written / (2U * sizeof(int16_t))),
+                           __ATOMIC_RELAXED);
+      }
     }
   }
 
@@ -256,6 +324,20 @@ esp_err_t audio_output_init(void) {
 
   ESP_RETURN_ON_ERROR(i2s_channel_init_std_mode(tx_handle, &std_cfg), TAG,
                       "std mode init failed");
+
+  // TX completion callback drives the live output cursor used by the timing
+  // engine (see audio_output_get_pipeline_us).
+  const i2s_event_callbacks_t callbacks = {
+      .on_recv = NULL,
+      .on_recv_q_ovf = NULL,
+      .on_sent = audio_output_on_sent,
+      .on_send_q_ovf = NULL,
+  };
+  ESP_RETURN_ON_ERROR(
+      i2s_channel_register_event_callback(tx_handle, &callbacks, NULL), TAG,
+      "event callback registration failed");
+  output_cursor_reset();
+
   ESP_RETURN_ON_ERROR(i2s_channel_enable(tx_handle), TAG,
                       "channel enable failed");
   ESP_LOGI(TAG, "I2S initialized: Rate=%u, DMA_Desc=%d, DMA_Frame=%d",
@@ -276,8 +358,13 @@ void audio_output_start(void) {
     return; // already running
   }
   playback_running = true;
-  xTaskCreatePinnedToCore(playback_task, "audio_play", 4096, NULL, 7,
-                          &playback_task_handle, PLAYBACK_CORE);
+  // The DMA has been free-running (A2DP, or plain silence) since the last
+  // AirPlay session, so the cursor carries an arbitrary submitted/sent skew.
+  // Start the new session from a clean slate.
+  output_cursor_reset();
+  xTaskCreatePinnedToCore(playback_task, "audio_play", 4096, NULL,
+                          AUDIO_PLAYBACK_TASK_PRIORITY, &playback_task_handle,
+                          PLAYBACK_CORE);
 }
 
 void audio_output_stop(void) {
@@ -310,6 +397,7 @@ void audio_output_set_sample_rate(uint32_t rate) {
   i2s_channel_disable(tx_handle);
   i2s_std_clk_config_t clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(rate);
   i2s_channel_reconfig_std_clock(tx_handle, &clk_cfg);
+  output_cursor_reset();
   i2s_channel_enable(tx_handle);
   dac_on_i2s_started();
 }
@@ -344,6 +432,26 @@ uint32_t audio_output_get_hardware_latency_us(void) {
                       1000000ULL) /
                      2) /
                     OUTPUT_RATE);
+}
+
+bool audio_output_get_pipeline_us(int64_t *now_us, uint32_t *pipeline_us) {
+  // Sample the queue depth first, then the clock: any DMA completion that
+  // lands between the two makes the reported depth slightly stale in the
+  // conservative direction (we believe the pipeline is fuller, i.e. that the
+  // next sample plays later, than it really is).  The error is bounded by
+  // one descriptor period and is absorbed by the position servo.
+  uint32_t queued = output_queued_frames();
+  if (now_us) {
+    *now_us = esp_timer_get_time();
+  }
+  if (pipeline_us) {
+    *pipeline_us = (uint32_t)(((uint64_t)queued * 1000000ULL) / OUTPUT_RATE);
+  }
+  return true;
+}
+
+uint32_t audio_output_get_underruns(void) {
+  return __atomic_load_n(&output_underruns, __ATOMIC_RELAXED);
 }
 
 /* With two amplifiers the DAC configuration already fixes the routing, so a

--- a/main/audio/audio_output.h
+++ b/main/audio/audio_output.h
@@ -1,8 +1,28 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #include "esp_err.h"
 
 #include "freertos/FreeRTOS.h"
+
+/**
+ * Priority of the playback task in every output backend.
+ *
+ * It MUST outrank every audio source task (realtime UDP receiver = 8,
+ * control receiver = 7, buffered TCP reader = 5) because the source tasks
+ * are pinned to the same core.  A source task that outranks playback starves
+ * it during a receive burst; the DMA ring (~46 ms) then runs dry and
+ * auto_clear emits silence, so wall-clock advances while no audio is
+ * consumed and the playout position slips permanently late.  That was the
+ * mechanism behind the realtime-stream drift in issue #122 — the buffered
+ * path was unaffected only because its reader task sits at priority 5.
+ *
+ * Playback cannot starve the sources in return: it blocks on the DMA write
+ * for all but a few hundred microseconds of each ~8 ms frame period.
+ */
+#define AUDIO_PLAYBACK_TASK_PRIORITY 9
 
 /**
  * Output channel mode. LEFT/RIGHT route the chosen source channel to both
@@ -72,6 +92,36 @@ void audio_output_set_source_rate(int rate);
  * stays correct if the DMA config or sample rate is ever changed.
  */
 uint32_t audio_output_get_hardware_latency_us(void);
+
+/**
+ * Sample the live output pipeline delay: how long from now until the first
+ * sample of the NEXT backend write is heard.
+ *
+ * Unlike audio_output_get_hardware_latency_us(), which models a permanently
+ * half-full DMA ring, this reports the measured queue depth (frames handed
+ * to the hardware minus frames the hardware reports as clocked out).  The
+ * measurement is what makes the timing engine's error signal honest:
+ *
+ *   - it is unaffected by when the playback task happens to be scheduled,
+ *     removing the one-sided "late read" noise the model suffers from;
+ *   - after a writer stall it correctly reports a near-empty ring, so the
+ *     engine sees the real lateness of the content it is about to submit
+ *     instead of a fixed 43 ms guess.
+ *
+ * @param now_us      out: esp_timer_get_time() sampled with the queue depth.
+ * @param pipeline_us out: queue depth in microseconds at the output rate.
+ * @return false if the backend cannot report a hardware completion cursor,
+ *         in which case the caller should fall back to the modelled latency.
+ */
+bool audio_output_get_pipeline_us(int64_t *now_us, uint32_t *pipeline_us);
+
+/**
+ * Number of output-underrun episodes since boot: the DMA clocked out
+ * descriptors the playback task never filled, so that much output time was
+ * emitted as silence and lost from the playout position.  Non-zero values
+ * mean the playback task is being starved.
+ */
+uint32_t audio_output_get_underruns(void);
 
 /**
  * Cycle the output channel mode: STEREO -> LEFT -> RIGHT -> MONO -> STEREO.

--- a/main/audio/audio_output_spdif.c
+++ b/main/audio/audio_output_spdif.c
@@ -328,8 +328,8 @@ esp_err_t audio_output_init(void) {
 }
 
 void audio_output_start(void) {
-  xTaskCreatePinnedToCore(playback_task, "spdif_play", 4096, NULL, 7, NULL,
-                          PLAYBACK_CORE);
+  xTaskCreatePinnedToCore(playback_task, "spdif_play", 4096, NULL,
+                          AUDIO_PLAYBACK_TASK_PRIORITY, NULL, PLAYBACK_CORE);
 }
 
 void audio_output_flush(void) {
@@ -348,4 +348,16 @@ uint32_t audio_output_get_hardware_latency_us(void) {
   // audio samples (= 96 stereo frames per buffer).
   const uint32_t audio_samples = DMA_BUF_COUNT * (SPDIF_BLOCK / SPDIF_BUF_DIV);
   return (uint32_t)((uint64_t)audio_samples * 1000000ULL / OUTPUT_RATE);
+}
+
+/* The BMC-encoded write path has no hardware completion cursor, so the timing
+ * engine falls back to the modelled ring latency above. */
+bool audio_output_get_pipeline_us(int64_t *now_us, uint32_t *pipeline_us) {
+  (void)now_us;
+  (void)pipeline_us;
+  return false;
+}
+
+uint32_t audio_output_get_underruns(void) {
+  return 0;
 }

--- a/main/audio/audio_output_usb.c
+++ b/main/audio/audio_output_usb.c
@@ -194,8 +194,8 @@ esp_err_t audio_output_init(void) {
 }
 
 void audio_output_start(void) {
-  xTaskCreatePinnedToCore(playback_task, "usb_play", 4096, NULL, 7, NULL,
-                          PLAYBACK_CORE);
+  xTaskCreatePinnedToCore(playback_task, "usb_play", 4096, NULL,
+                          AUDIO_PLAYBACK_TASK_PRIORITY, NULL, PLAYBACK_CORE);
 }
 
 void audio_output_flush(void) {
@@ -212,4 +212,16 @@ void audio_output_set_source_rate(int rate) {
 uint32_t audio_output_get_hardware_latency_us(void) {
   // USB isochronous audio: ~2ms double-buffered endpoint latency.
   return 2000;
+}
+
+/* The UAC driver does not expose a transfer-completion cursor, so the timing
+ * engine falls back to the fixed endpoint latency above. */
+bool audio_output_get_pipeline_us(int64_t *now_us, uint32_t *pipeline_us) {
+  (void)now_us;
+  (void)pipeline_us;
+  return false;
+}
+
+uint32_t audio_output_get_underruns(void) {
+  return 0;
 }

--- a/main/audio/audio_timing.c
+++ b/main/audio/audio_timing.c
@@ -185,16 +185,36 @@ static bool compute_early_us(const audio_timing_t *timing,
     break;
   }
 
-  // Subtract hardware latency to account for I2S DMA delay
-  // and pipeline latency for task scheduling and write blocking.
-  // The hardware latency is computed from the DMA descriptor/frame
-  // configuration rather than being hard-coded.
-  target_ns -=
-      (int64_t)(audio_output_get_hardware_latency_us() + PIPELINE_LATENCY_US) *
-      1000LL;
+  // Subtract the output pipeline delay: the time between this call handing a
+  // sample to the backend and that sample leaving the DAC.
+  //
+  // Prefer the LIVE measurement (frames accepted by the hardware minus frames
+  // the hardware reports as clocked out).  The modelled constant is only a
+  // fallback for backends without a completion cursor, and it is wrong in the
+  // two situations that matter:
+  //
+  //   - it assumes the ring is always at its steady-state occupancy, so when
+  //     the playback task is briefly starved the read happens late against a
+  //     ring that is emptier than modelled and the error reads far more
+  //     negative than reality (the one-sided noise the position servo's
+  //     innovation clamp was added to survive);
+  //   - after a real underrun the ring is dry, so the next sample is heard
+  //     almost immediately rather than ~43 ms later.  With the model the
+  //     engine cannot tell the difference and the lost output time is never
+  //     recovered — the mechanism behind the drift in issue #122.
+  //
+  // The live depth is self-consistent while the ring refills: each frame
+  // consumed adds its own duration to the queue, so the measured error stays
+  // put instead of walking, and no extra frames are dropped during recovery.
+  int64_t now_us = 0;
+  uint32_t pipeline_us = 0;
+  if (!audio_output_get_pipeline_us(&now_us, &pipeline_us)) {
+    now_us = esp_timer_get_time();
+    pipeline_us = audio_output_get_hardware_latency_us();
+  }
+  target_ns -= (int64_t)(pipeline_us + PIPELINE_LATENCY_US) * 1000LL;
 
-  int64_t now_ns = (int64_t)esp_timer_get_time() * 1000LL;
-  *early_us = (target_ns - now_ns) / 1000LL;
+  *early_us = (target_ns / 1000LL) - now_us;
 
   return true;
 }
@@ -436,13 +456,12 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
   enum { MAX_DRAIN_ATTEMPTS = 64 };
   const int64_t drain_deadline_us = esp_timer_get_time() + 1500;
   // Set when the drain loop below discards at least one late frame in this
-  // call.  After a drop run, the stream is re-locking onto a new position:
-  // the next playable frame must meet the strict (half frame period) release
-  // rather than the wide jitter threshold, otherwise a discontinuity in the
-  // RTP sequence re-starts playback up to threshold_us early and the bias
-  // persists (observed on hardware: a WiFi stall dropped ~9 frames and left
-  // err parked at +20..31 ms for the rest of the session).
-  bool dropped_late = false;
+  // call, or when a previous call left a drop run unfinished.  A drop run
+  // re-locks the stream onto a new position, so both the release point for
+  // the next playable frame and the point at which dropping stops tighten
+  // from the wide jitter threshold to half a frame period — see the gate
+  // below.
+  bool dropped_late = timing->late_drop_active;
   // Stale start-island frames skipped in this call (see the check below).
   int start_skips = 0;
   for (int attempt = 0; attempt < MAX_DRAIN_ATTEMPTS; attempt++) {
@@ -586,21 +605,18 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
       }
     }
 
-    // RTP continuity vs the frame just played.  A fresh frame exactly at
-    // expected_rtp is contiguous audio: it can never legitimately need
-    // holding (its schedule slot begins the instant the previous frame
-    // ends), so it bypasses the early-hold entirely — measurement noise can
-    // then never insert silence into an unbroken stream.  A fresh frame
-    // ABOVE expected_rtp means packets were lost and not recovered by the
-    // resend mechanism: conceal the hole by holding the frame to the strict
+    // RTP continuity vs the frame just played.  A fresh frame ABOVE
+    // expected_rtp means packets were lost and not recovered by the resend
+    // mechanism: conceal the hole by holding the frame to the strict
     // release, so exactly gap-length silence plays at the right schedule.
     // Without this, the post-gap frame (typically ~8 ms early, far inside
     // the 50 ms realtime threshold) played immediately — an audible skip
     // AND a permanent early shift of the whole playback position for every
-    // unrecovered packet.  Below expected_rtp (duplicate/overlap from a
-    // redundant resend) is treated as continuous: playing it repeats at
-    // most one frame, which keeps the stream moving.
-    bool continuous = false;
+    // unrecovered packet.  At or below expected_rtp is contiguous audio (or
+    // a duplicate from a redundant resend, which is played because repeating
+    // at most one frame keeps the stream moving); its schedule slot begins
+    // the instant the previous frame ends, so it is normally released
+    // straight away by the wide threshold below.
     bool gap = false;
     if (!from_pending && timing->playout_started &&
         timing->expected_rtp_valid) {
@@ -624,8 +640,6 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         } else {
           timing->gaps_suppressed++;
         }
-      } else {
-        continuous = true;
       }
     }
 
@@ -647,10 +661,36 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
         // precisely instead of anywhere inside the wide threshold.
         int64_t frame_period_us =
             ((int64_t)frame_samples * 1000000LL) / format->sample_rate;
+        int64_t strict_us = frame_period_us / 2;
         int64_t release_us = (from_pending || dropped_late || gap)
-                                 ? frame_period_us / 2
+                                 ? strict_us
                                  : timing_threshold_us;
-        if (!continuous && early_us > release_us) {
+
+        // Late gate, with hysteresis.  Lateness beyond the wide threshold
+        // STARTS a drop run; once started, frames keep being dropped until
+        // the stream is back on schedule rather than until it is merely
+        // inside the threshold again.
+        //
+        // Stopping at the threshold is what left the realtime path parked at
+        // err = -(threshold - one drain overshoot) for the rest of a session
+        // and made the drop path the sole regulator of queue depth (issue
+        // #122): every disturbance walked the position later, the drain
+        // clawed back just enough to re-enter the threshold, and the standing
+        // offset survived because the position servo's 710 ppm of authority
+        // needs ~11 minutes to remove 470 ms.  Draining to the strict window
+        // instead makes err ≈ 0 the equilibrium, so the servo only ever has
+        // to handle crystal drift — which is what it was designed for.
+        int64_t late_limit_us =
+            dropped_late ? -strict_us : -timing_threshold_us;
+
+        // A contiguous frame is no longer exempt from the early gate.  It
+        // used to bypass it entirely so that measurement noise could not
+        // insert silence into an unbroken stream, but that also meant a
+        // forward anchor jump mid-stream was never corrected.  Now that
+        // compute_early_us() measures the live output queue instead of
+        // modelling it, the residual noise is a fraction of a DMA descriptor
+        // (~±3 ms) and cannot reach the 25/50 ms threshold.
+        if (early_us > release_us) {
           // Only advance the stuck-anchor counter for NEW frames taken from
           // the buffer — not for pending re-checks of the same early frame.
           // A pending frame is re-examined every DMA callback (~8 ms) while
@@ -722,7 +762,7 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
                    frame_samples * AUDIO_OUT_CHANNELS * sizeof(int16_t));
             return frame_samples;
           }
-        } else if (early_us < -timing_threshold_us) {
+        } else if (early_us < late_limit_us) {
           // Reset consecutive early counter on late/normal frames
           timing->consecutive_early_frames = 0;
 
@@ -797,13 +837,17 @@ size_t audio_timing_read(audio_timing_t *timing, audio_buffer_t *buffer,
           ptp_clock_get_stats(&ps);
           int64_t ptp_gap_us =
               (ps.last_offset_ns - ps.filtered_offset_ns) / 1000LL;
+          // under: output underruns since boot.  Any increase means the
+          // playback task was starved long enough for the DMA ring to run
+          // dry, which is the disturbance the drain has to clean up after.
           ESP_LOGI(TAG,
                    "Playout: err=%lld ms buffered=%d depth=%lld ms "
                    "ptp_gap=%lld us outliers=%" PRIu32 " gaps=%" PRIu32
-                   " rtp=%" PRIu32,
+                   " under=%" PRIu32 " rtp=%" PRIu32,
                    (long long)(on_time_err_us / 1000LL), buffered_frames,
                    (long long)depth_ms, (long long)ptp_gap_us, ps.outlier_count,
-                   timing->gaps, played_rtp_timestamp);
+                   timing->gaps, audio_output_get_underruns(),
+                   played_rtp_timestamp);
         }
 
         // Position servo (see POS_SERVO_* above).  Smooth the per-frame


### PR DESCRIPTION
Fixes the realtime (AirPlay 1 / ALAC) stream drifting permanently late behind its own output, reported in #122 as "buffer grows to ~2.4 s and playout error parks at −460 ms".

## Root cause

Three defects compounded.

**1. Priority inversion in the audio pipeline.** `playback_task` ran at priority 7 while `receiver_task` ran at 8 on the same core. When the sender emits its ~2 s UDP burst, AES-CBC decrypt plus ALAC decode monopolises the core, the 46 ms I2S DMA ring empties, and `chan_cfg.auto_clear` quietly clocks silence into the DAC. Wall-clock time advances while no queued audio is consumed, so the stream slips late and never recovers. The buffered (AAC) path was immune only because its reader sits at priority 5.

The playout reports in #122 show this directly: a report every 125 frames is 997.7 ms of audio, but the timestamps between consecutive reports measured 1000–1090 ms — 3–9 % of the stream was being under-consumed. Over the logged window that accounts for the entire 471 ms of accumulated error.

**2. The measurement could not see it.** `compute_early_us()` subtracted a constant modelled DMA latency (`((2·8−1)·256·1e6/2)/44100` ≈ 43.5 ms), so the scheduler believed the ring was full even when it had run dry. Every correction was computed against fiction.

**3. The drain stopped at the threshold.** Late-frame dropping ceased the moment the error re-entered the band, which made `−threshold` a stable equilibrium rather than a boundary to be crossed. The position servo's ~710 ppm trim rate needs roughly 11 minutes to remove 470 ms on its own, so in practice the error simply stayed there.

## Changes

**`audio_output.c` / `audio_output.h`**

- Raise the playback task to priority 9 (new `AUDIO_PLAYBACK_TASK_PRIORITY`) so it outranks every audio source that shares its core: realtime UDP receiver (8), control (7), buffered TCP reader (5). The constant is documented at the declaration so the ordering constraint is not re-broken by accident.
- Register an `on_sent` I2S callback and track submitted / sent / lost frame counters, giving a live measurement of how much audio is genuinely still in the DMA ring.
- Expose `audio_output_get_pipeline_us()` (real queue depth plus the clock sampled together) and `audio_output_get_underruns()`.
- Detect the underrun case — DMA reported more frames sent than were ever submitted, meaning `auto_clear` silence went out — then rebase the cursor and count it. Reset the cursor on flush, on start, and on sample-rate change.

`audio_output_spdif.c` and `audio_output_usb.c` take the same priority constant and return `false` / `0` from the two new accessors. Neither is built by any current environment, so both were syntax-checked directly.

**`audio_timing.c`**

- `compute_early_us()` now uses the live pipeline measurement, falling back to the old model only if the output cannot report.
- Seed `dropped_late` from `timing->late_drop_active` instead of `false`. That flag already existed and was already being maintained — it was simply never read. This is what makes the drain continue past the threshold.
- Replace the contiguous-frame exemption with a hysteretic gate: while draining, resync out to half a frame period rather than the full threshold, so the error is pulled back through zero instead of being abandoned at the boundary.
- Report `under=` in the playout line. Any increase means the playback task was starved, which is the disturbance everything else has to clean up after.

## Verification

Measured on SqueezeAMP hardware, AirPlay 1 / ALAC, mid-track:

```
Playout: err=-3 ms buffered=248 depth=1979 ms ptp_gap=-23418 us outliers=25 gaps=0 under=45
Playout: err=-3 ms buffered=247 depth=1971 ms ptp_gap=-8517 us  outliers=25 gaps=0 under=45
Playout: err=-3 ms buffered=246 depth=1963 ms ptp_gap=-3 us     outliers=25 gaps=0 under=45
Playout: err=-3 ms buffered=247 depth=1971 ms ptp_gap=-7821 us  outliers=25 gaps=0 under=45
```

`err` holds at −3 ms across repeated anchor updates instead of sliding out to −460 ms, and `under` does not move — no starvation during steady playback. The −3 ms residual is a constant model bias, not drift.

A WiFi loss burst during the same session exercised the recovery path. `buffered` (a frame count) diverging from `depth` (the RTP span from played to newest) is a direct packet-loss signature:

```
buffered=141 depth=1125 ms   <- 141 frames spanning 1125 ms: contiguous, just short
buffered=122 depth=1963 ms   <- 122 frames spanning 1963 ms: holes
Gap: 12320 samples (279 ms) missing — concealing with silence
```

Concealment filled the holes, `under` stayed put, and `err` returned to −3 ms. Buffered/AAC playback is unaffected.

## Note on the reported buffer depth

A realtime queue sitting at ~1.75–2 s is normal and not a bug — RAOP senders transmit roughly 2 s ahead and shairport-sync behaves identically. The defect in #122 was the −463 ms playout error, not the depth.

## Scope

Deliberately unchanged: `RT_TIMING_THRESHOLD_US` (50 ms), `TIMING_THRESHOLD_US` (25 ms), `PIPELINE_LATENCY_US`, the position servo constants, and the realtime `playout_latency_samples`. The realtime threshold in particular stays fixed — an adaptive value was tried previously and regressed on hardware into runaway lateness (580→900 ms within a single track).

All 15 PlatformIO environments build, including the RISC-V `esp32c5-xiao` target. clang-format clean; clang-tidy produces no new findings against `main` (verified by building a comparison database from a worktree of the base commit).

Refs #122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time scheduling, I2S ISR accounting, and the playout early/late gates that control drop/hold behavior. Wrong cursor or gate hysteresis could cause extra drops, inserted silence, or remaining drift.
> 
> **Overview**
> Fixes realtime (AirPlay 1 / ALAC) playout parking hundreds of milliseconds late (#122) by making the output pipeline honest and recovering all the way to schedule.
> 
> Playback now runs at priority **9** (`AUDIO_PLAYBACK_TASK_PRIORITY`) so it outranks same-core source tasks and no longer starves the I2S DMA ring during UDP bursts.
> 
> I2S tracks a live submitted/sent/lost cursor via an `on_sent` callback. `compute_early_us()` uses that measured queue depth instead of a constant ~43 ms model, so underruns (silence from `auto_clear`) are visible. SPDIF/USB still fall back to the model.
> 
> Late-frame drain now continues from `late_drop_active` until error is inside half a frame period, not just the wide threshold. Contiguous frames are no longer exempt from the early gate. Playout logs include `under=` underrun counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42151cf2c5ebf7bd9528ee986e4b1e917a1aab9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->