### PR TITLE
Keep mDNS hostnames ASCII so non-Latin device names resolve

### DIFF
--- a/main/network/ethernet.c
+++ b/main/network/ethernet.c
@@ -203,24 +203,7 @@ void ethernet_set_hostname(const char *device_name) {
     return;
   }
   char hostname[DHCP_HOSTNAME_MAX_LEN + 1];
-  size_t j = 0;
-  for (size_t i = 0; device_name[i] && j < sizeof(hostname) - 1; i++) {
-    char c = device_name[i];
-    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-        (c >= '0' && c <= '9')) {
-      hostname[j++] = c;
-    } else if (j > 0 && hostname[j - 1] != '-') {
-      hostname[j++] = '-';
-    }
-  }
-  while (j > 0 && hostname[j - 1] == '-') {
-    j--;
-  }
-  if (j == 0) {
-    strlcpy(hostname, "esp32-airplay", sizeof(hostname));
-  } else {
-    hostname[j] = '\0';
-  }
+  settings_device_name_to_hostname(device_name, hostname, sizeof(hostname));
   esp_err_t err = esp_netif_set_hostname(s_eth_netif, hostname);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to set hostname '%s': %s", hostname,

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -12,6 +12,10 @@
 
 static const char *TAG = "mdns_airplay";
 
+// Longest single DNS label (RFC 1035). The mDNS component caps names at
+// MDNS_NAME_MAX_LEN, which is never smaller than this.
+#define MDNS_HOSTNAME_MAX_LEN 63
+
 // Feature flags are defined in rtsp_handlers.h (shared with /info handler)
 
 // Protocol version
@@ -48,9 +52,13 @@ void mdns_airplay_init(void) {
   char service_name[80];
   char pk_str[65]; // 32 bytes = 64 hex chars + null
   char device_name[65];
+  char hostname[MDNS_HOSTNAME_MAX_LEN + 1];
 
-  // Get device name from settings
+  // Get device name from settings. This is the user-facing name and stays
+  // UTF-8 for the service instance names below; only the hostname is
+  // restricted to ASCII.
   settings_get_device_name(device_name, sizeof(device_name));
+  settings_device_name_to_hostname(device_name, hostname, sizeof(hostname));
 
   // Get MAC address
   wifi_get_mac_str(mac_str, sizeof(mac_str));
@@ -75,8 +83,16 @@ void mdns_airplay_init(void) {
   // Initialize mDNS
   ESP_ERROR_CHECK(mdns_init());
 
-  // Set hostname
-  ESP_ERROR_CHECK(mdns_hostname_set(device_name));
+  // Set hostname. A bad name must not panic the device, so this is logged
+  // like the service registrations below rather than ESP_ERROR_CHECK'd.
+  esp_err_t err_host = mdns_hostname_set(hostname);
+  if (err_host != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set mDNS hostname '%s': %s", hostname,
+             esp_err_to_name(err_host));
+  } else {
+    ESP_LOGI(TAG, "mDNS hostname: %s.local (device name: %s)", hostname,
+             device_name);
+  }
 
 #ifndef CONFIG_AIRPLAY_FORCE_V1
   // ========================================

--- a/main/network/wifi.c
+++ b/main/network/wifi.c
@@ -40,33 +40,12 @@ static wifi_config_t s_ap_config;
 static void wifi_select_best_ap(const char *ssid);
 static void scan_and_connect_task(void *arg);
 
-static void sanitize_hostname(const char *name, char *out, size_t out_len) {
-  size_t j = 0;
-  for (size_t i = 0; name[i] && j < out_len - 1; i++) {
-    char c = name[i];
-    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-        (c >= '0' && c <= '9')) {
-      out[j++] = c;
-    } else if (j > 0 && out[j - 1] != '-') {
-      out[j++] = '-';
-    }
-  }
-  while (j > 0 && out[j - 1] == '-') {
-    j--;
-  }
-  if (j == 0) {
-    strlcpy(out, "esp32-airplay", out_len);
-    return;
-  }
-  out[j] = '\0';
-}
-
 void wifi_set_hostname(const char *device_name) {
   if (!s_sta_netif || !device_name) {
     return;
   }
   char hostname[DHCP_HOSTNAME_MAX_LEN + 1];
-  sanitize_hostname(device_name, hostname, sizeof(hostname));
+  settings_device_name_to_hostname(device_name, hostname, sizeof(hostname));
   esp_err_t err = esp_netif_set_hostname(s_sta_netif, hostname);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to set hostname '%s': %s", hostname,

--- a/main/settings.c
+++ b/main/settings.c
@@ -2,7 +2,9 @@
 
 #include "dac.h"
 #include "esp_log.h"
+#include "esp_mac.h"
 #include "nvs.h"
+#include <stdio.h>
 #include <string.h>
 
 static const char *TAG = "settings";
@@ -316,6 +318,39 @@ esp_err_t settings_set_device_name(const char *name) {
   }
 
   return err;
+}
+
+void settings_device_name_to_hostname(const char *name, char *out,
+                                      size_t out_len) {
+  if (!out || out_len < 2) {
+    return;
+  }
+
+  size_t j = 0;
+  for (size_t i = 0; name && name[i] && j < out_len - 1; i++) {
+    char c = name[i];
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9')) {
+      out[j++] = c;
+    } else if (j > 0 && out[j - 1] != '-') {
+      out[j++] = '-';
+    }
+  }
+  while (j > 0 && out[j - 1] == '-') {
+    j--;
+  }
+
+  if (j == 0) {
+    // No ASCII survived (e.g. an all-Cyrillic name). Suffix the MAC so two
+    // such devices do not both answer to the same hostname.
+    uint8_t mac[6] = {0};
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    snprintf(out, out_len, "esp32-airplay-%02x%02x%02x", mac[3], mac[4],
+             mac[5]);
+    return;
+  }
+
+  out[j] = '\0';
 }
 
 /* ================================================================== */

--- a/main/settings.h
+++ b/main/settings.h
@@ -99,6 +99,25 @@ esp_err_t settings_get_device_name(char *name, size_t len);
  */
 esp_err_t settings_set_device_name(const char *name);
 
+/**
+ * Derive a DNS/DHCP-safe hostname from a device name.
+ *
+ * Host names are restricted to ASCII letters, digits and hyphens (RFC 1123),
+ * so the UTF-8 device name cannot be used verbatim. Alphanumerics are kept,
+ * every other byte collapses into a single hyphen, and the result is
+ * truncated to fit @p len. Names with no usable ASCII (for example Cyrillic
+ * or CJK) fall back to "esp32-airplay-<mac>", which stays unique per device.
+ *
+ * The device name itself must keep its original UTF-8 form wherever it is
+ * shown to the user (mDNS service instance names, AirPlay metadata).
+ *
+ * @param name    Device name (UTF-8, may be NULL)
+ * @param out     Output buffer for the hostname
+ * @param out_len Size of @p out, must be at least 2
+ */
+void settings_device_name_to_hostname(const char *name, char *out,
+                                      size_t out_len);
+
 // ---- LED settings ----
 
 /**


### PR DESCRIPTION
Fixes #120.

## Problem

`mdns_airplay_init()` passed the raw UTF-8 device name straight to `mdns_hostname_set()`:

```c
settings_get_device_name(device_name, sizeof(device_name));
...
ESP_ERROR_CHECK(mdns_hostname_set(device_name));
```

DNS host names are limited to ASCII letters, digits and hyphens (RFC 1123), so a name like `Гостиная` produced an unusable `.local` hostname and showed up mangled (`Ð…`) on the sender side. ASCII names such as `Gostinaya-AirPlay` were unaffected, which matches the report.

The DHCP paths already worked around this, but with the same sanitising loop copy-pasted into `wifi.c` and `ethernet.c`, and mDNS had no equivalent.

## Change

- Added `settings_device_name_to_hostname()` next to the existing device-name accessors, holding the single copy of the sanitising logic.
- `wifi.c` and `ethernet.c` now call it instead of carrying their own duplicates (no behaviour change for ASCII names).
- `mdns_airplay.c` uses it for `mdns_hostname_set()`.
- Names with no usable ASCII fall back to `esp32-airplay-<mac>` instead of a fixed `esp32-airplay`, so two such devices on one LAN no longer claim the same hostname.
- `mdns_hostname_set()` is no longer wrapped in `ESP_ERROR_CHECK`. A user-supplied name that the mDNS component rejects now logs an error rather than panicking, matching how the two `mdns_service_add()` calls just below it already behave.

The device name itself is deliberately untouched. The `_airplay._tcp` and `_raop._tcp` service instance names keep the original UTF-8, which is what the AirPlay picker displays and what RFC 6763 expects.

## Test plan

- [x] `idf.py build` for `esp32s3` (default config) — clean, no new warnings
- [x] `idf.py build` for `esp32` with `sdkconfig.defaults.esparagus-audio-brick`, to cover `ethernet.c` behind `CONFIG_ETH_W5500_ENABLED`
- [x] `clang-format` / `clang-tidy` clean via the pre-commit hook
- [ ] Hardware check: set the device name to `Гостиная` via `POST /api/device/name`, reboot, confirm the AirPlay picker shows the Cyrillic name and that the boot log reports `mDNS hostname: esp32-airplay-<mac>.local`
- [ ] Regression check: an ASCII name keeps its existing hostname (for example `Living Room` → `Living-Room`)

I do not have a device with a non-Latin name set up to confirm the picker rendering end to end, so the last two boxes want a look from someone who can reproduce the original report — @hordesnake1 if you are around.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Networking hostname formatting only; no auth or data-path changes. Fallback uniqueness and dropping ESP_ERROR_CHECK on hostname set are small, well-scoped behavior tweaks.
> 
> **Overview**
> mDNS now uses an ASCII hostname derived from the UTF-8 device name instead of passing the raw name to `mdns_hostname_set()`, so names like Cyrillic still get a valid `.local` host. AirPlay/RAOP **service instance names stay UTF-8** for the picker.
> 
> Hostname sanitizing is centralized in `settings_device_name_to_hostname()` (Wi‑Fi and Ethernet DHCP paths drop their copies). Empty/non-ASCII names fall back to `esp32-airplay-<mac>` so devices do not collide. A rejected mDNS hostname is logged instead of aborting via `ESP_ERROR_CHECK`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f7b8136c5e1005f53edf2ee927cf8d10c5e179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->