### PR TITLE
Let non-I2S output backends link again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ jobs:
   # that misses part of the audio_output API links fine there and breaks only
   # for whoever selects it. These configurations ship no firmware artifact;
   # they exist to keep every backend linking.
-  #
-  # AUDIO_OUTPUT_USB is not covered yet: it fails earlier, in the UAC
-  # component's TinyUSB descriptor wiring, which is unrelated to this job.
   output-backends:
     needs: [format-check, lint-check]
     runs-on: ubuntu-latest
@@ -80,6 +77,9 @@ jobs:
           - name: spdif
             target: esp32s3
             sdkconfig: "sdkconfig.defaults;sdkconfig.defaults.esp32s3;sdkconfig.defaults.spdif"
+          - name: usb
+            target: esp32s3
+            sdkconfig: "sdkconfig.defaults;sdkconfig.defaults.esp32s3;sdkconfig.defaults.usb"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,34 @@ jobs:
           fi
           echo "All files pass clang-tidy checks"
 
+  # The release matrix in build.yml only covers I2S/DAC boards, so a backend
+  # that misses part of the audio_output API links fine there and breaks only
+  # for whoever selects it. These configurations ship no firmware artifact;
+  # they exist to keep every backend linking.
+  #
+  # AUDIO_OUTPUT_USB is not covered yet: it fails earlier, in the UAC
+  # component's TinyUSB descriptor wiring, which is unrelated to this job.
+  output-backends:
+    needs: [format-check, lint-check]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: spdif
+            target: esp32s3
+            sdkconfig: "sdkconfig.defaults;sdkconfig.defaults.esp32s3;sdkconfig.defaults.spdif"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
+
+      - name: Build ${{ matrix.name }} output backend
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.5
+          target: ${{ matrix.target }}
+          command: idf.py -DSDKCONFIG_DEFAULTS="${{ matrix.sdkconfig }}" build
+
   build:
     needs: [format-check, lint-check]
     uses: ./.github/workflows/build.yml

--- a/cmake/fix_usb_device_uac_platformio.cmake
+++ b/cmake/fix_usb_device_uac_platformio.cmake
@@ -1,6 +1,13 @@
-# Work around espressif/usb_device_uac exporting its descriptor source as a
-# PUBLIC TinyUSB source. PlatformIO/SCons then sees usb_descriptors.c twice:
-# once under TinyUSB and once under usb_device_uac with different compile flags.
+# espressif/usb_device_uac attaches its descriptor source to the TinyUSB
+# component with target_sources(... PUBLIC ...), which lands the file in both
+# SOURCES and INTERFACE_SOURCES. The INTERFACE half propagates to every
+# dependent of TinyUSB, so PlatformIO/SCons compiled usb_descriptors.c twice
+# with different flags.
+#
+# Drop only the INTERFACE copy. The file stays in TinyUSB's own SOURCES, so it
+# is compiled exactly once and tud_descriptor_device_cb() and friends still
+# resolve — stripping SOURCES as well is what used to make every
+# CONFIG_AUDIO_OUTPUT_USB build fail to link.
 idf_build_get_property(build_components BUILD_COMPONENTS)
 set(tinyusb_component "")
 if(espressif__tinyusb IN_LIST build_components)
@@ -11,17 +18,15 @@ endif()
 
 if(tinyusb_component)
     idf_component_get_property(tusb_lib ${tinyusb_component} COMPONENT_LIB)
-    foreach(source_property SOURCES INTERFACE_SOURCES)
-        get_target_property(tusb_sources ${tusb_lib} ${source_property})
-        if(tusb_sources)
-            set(filtered_tusb_sources "")
-            foreach(src IN LISTS tusb_sources)
-                if(NOT src MATCHES "usb_device_uac[/\\\\]tusb[/\\\\]usb_descriptors\\.c$")
-                    list(APPEND filtered_tusb_sources "${src}")
-                endif()
-            endforeach()
-            set_target_properties(${tusb_lib} PROPERTIES
-                ${source_property} "${filtered_tusb_sources}")
-        endif()
-    endforeach()
+    get_target_property(tusb_sources ${tusb_lib} INTERFACE_SOURCES)
+    if(tusb_sources)
+        set(filtered_tusb_sources "")
+        foreach(src IN LISTS tusb_sources)
+            if(NOT src MATCHES "usb_device_uac[/\\\\]tusb[/\\\\]usb_descriptors\\.c$")
+                list(APPEND filtered_tusb_sources "${src}")
+            endif()
+        endforeach()
+        set_target_properties(${tusb_lib} PROPERTIES
+            INTERFACE_SOURCES "${filtered_tusb_sources}")
+    endif()
 endif()

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -45,7 +45,10 @@ set( SRC_FILES
     "dacp_client.c"
 )
 
-# Select audio output implementation at compile time
+# Select audio output implementation at compile time. audio_output_common.c
+# carries weak defaults for the optional entry points, so a backend only has
+# to implement what it actually supports.
+list(APPEND SRC_FILES "audio/audio_output_common.c")
 if(CONFIG_AUDIO_OUTPUT_SPDIF)
     list(APPEND SRC_FILES "audio/audio_output_spdif.c")
 elseif(CONFIG_AUDIO_OUTPUT_USB)

--- a/main/audio/audio_output_common.c
+++ b/main/audio/audio_output_common.c
@@ -1,0 +1,55 @@
+/**
+ * @file audio_output_common.c
+ * @brief Weak defaults for the optional half of the audio output API.
+ *
+ * Exactly one backend (audio_output.c, _spdif.c, _usb.c, ...) is compiled in,
+ * chosen by Kconfig. Callers such as web_server.c and audio_timing.c reference
+ * the full API unconditionally, so a backend that does not implement the
+ * capability calls used to fail the link — which is why only the I2S build,
+ * the one the CI matrix covers, kept working.
+ *
+ * The defaults below describe a backend with no channel routing and no
+ * hardware completion cursor. A backend overrides one by defining it, the
+ * same way boards override iot_board_*() in board_common.c. Only genuinely
+ * optional entry points belong here: the core ones (init/start/write/...) are
+ * deliberately left undefined so a backend missing them still fails loudly.
+ */
+
+#include "audio_output.h"
+
+__attribute__((weak)) bool audio_output_get_pipeline_us(int64_t *now_us,
+                                                        uint32_t *pipeline_us) {
+  (void)now_us;
+  (void)pipeline_us;
+  // No completion cursor: the timing engine falls back to the modelled
+  // hardware latency.
+  return false;
+}
+
+__attribute__((weak)) uint32_t audio_output_get_underruns(void) {
+  return 0;
+}
+
+__attribute__((weak)) audio_channel_mode_t
+audio_output_cycle_channel_mode(void) {
+  return AUDIO_CHANNEL_STEREO;
+}
+
+__attribute__((weak)) void
+audio_output_set_channel_mode(audio_channel_mode_t mode) {
+  (void)mode;
+}
+
+__attribute__((weak)) audio_channel_mode_t audio_output_get_channel_mode(void) {
+  return AUDIO_CHANNEL_STEREO;
+}
+
+// Routing is fixed at stereo, which is what "locked" reports to the web UI so
+// it renders the control as unavailable rather than as a working toggle.
+__attribute__((weak)) bool audio_output_channel_mode_locked(void) {
+  return true;
+}
+
+__attribute__((weak)) bool audio_output_channel_mode_in_dsp(void) {
+  return false;
+}

--- a/main/audio/audio_output_usb.c
+++ b/main/audio/audio_output_usb.c
@@ -214,14 +214,6 @@ uint32_t audio_output_get_hardware_latency_us(void) {
   return 2000;
 }
 
-/* The UAC driver does not expose a transfer-completion cursor, so the timing
- * engine falls back to the fixed endpoint latency above. */
-bool audio_output_get_pipeline_us(int64_t *now_us, uint32_t *pipeline_us) {
-  (void)now_us;
-  (void)pipeline_us;
-  return false;
-}
-
-uint32_t audio_output_get_underruns(void) {
-  return 0;
-}
+/* The UAC driver exposes neither a transfer-completion cursor nor an underrun
+ * count, and there is no channel routing to control, so the weak defaults in
+ * audio_output_common.c cover the rest of the API. */

--- a/sdkconfig.defaults.spdif
+++ b/sdkconfig.defaults.spdif
@@ -1,0 +1,5 @@
+# S/PDIF output (bit-banged through I2S) instead of a normal I2S DAC.
+# Layer on top of a board's defaults, e.g.
+#   idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.esp32s3;sdkconfig.defaults.spdif" build
+
+CONFIG_AUDIO_OUTPUT_SPDIF=y

--- a/sdkconfig.defaults.usb
+++ b/sdkconfig.defaults.usb
@@ -1,0 +1,6 @@
+# USB Audio Class (UAC) device output: the board appears as a USB audio
+# source to whatever host it is plugged into. Needs a chip with USB-OTG
+# (ESP32-S2/S3/P4). Layer on top of a board's defaults, e.g.
+#   idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.esp32s3;sdkconfig.defaults.usb" build
+
+CONFIG_AUDIO_OUTPUT_USB=y


### PR DESCRIPTION
Found while rebasing #108 onto `main`. Two independent pre-existing breaks, neither introduced by that PR: every non-I2S audio backend fails to link, and the USB device backend fails again for a second reason once the first is fixed.

## Problem 1 — missing `audio_output_*` implementations

`web_server.c` and `audio_timing.c` call the channel-mode, pipeline-depth and underrun entry points unconditionally, but only `audio_output.c` (I2S) implements them. Building any other backend fails at link time:

```
undefined reference to `audio_output_channel_mode_in_dsp'
undefined reference to `audio_output_channel_mode_locked'
undefined reference to `audio_output_get_channel_mode'
undefined reference to `audio_output_set_channel_mode'
```

That is a clean `origin/main` checkout with `CONFIG_AUDIO_OUTPUT_SPDIF=y`. `CONFIG_AUDIO_OUTPUT_USB=y` hits the same wall, plus `audio_output_get_pipeline_us` and `audio_output_get_underruns` for the USB host backend in #108.

Nothing caught this because the CI matrix in `build.yml` only builds I2S and DAC boards.

### Fix

`main/audio/audio_output_common.c` holds weak defaults for the optional half of the API, following the `iot_board_*()` pattern already used in `components/boards/board_common.c`. A backend defines only what it supports; the rest describes a backend with no channel routing and no hardware completion cursor.

Reporting the mode as *locked* is the meaningful bit. Per the header, locked means "the DAC configuration already fixes the per-output routing, in which case the mode is forced to STEREO and set/cycle are ignored" — exactly true for a backend without routing, and it makes the web UI render the control as unavailable instead of as a toggle that silently does nothing.

Only optional entry points get a default. `init`, `start`, `write` and the other core ones are deliberately left undefined so a backend that forgets them still fails the build rather than going quiet at runtime.

The two stubs in `audio_output_usb.c` were returning exactly what the shared defaults return, so they are gone.

## Problem 2 — TinyUSB descriptors never compiled

With the above fixed, `CONFIG_AUDIO_OUTPUT_USB=y` gets past every `audio_output_*` symbol and then dies on:

```
undefined reference to `tud_descriptor_device_cb'
undefined reference to `tud_descriptor_configuration_cb'
undefined reference to `tud_descriptor_string_cb'
```

`espressif/usb_device_uac` attaches its `tusb/usb_descriptors.c` to the TinyUSB component with `target_sources(... PUBLIC ...)`. `PUBLIC` puts the file in both `SOURCES` and `INTERFACE_SOURCES`, and the `INTERFACE` half propagates to every dependent of TinyUSB — which is why PlatformIO/SCons ended up compiling it twice with different flags.

d55ab3f dealt with that by stripping the file from *both* properties, so nothing compiled it at all. Harmless for I2S boards, fatal for anyone selecting the USB backend.

### Fix

Strip only the `INTERFACE` copy. The file stays in TinyUSB's own `SOURCES`, so it is compiled exactly once, inside TinyUSB, which is where the component's `target_include_directories()` call already points. That keeps the PlatformIO duplicate fixed and makes the symbols resolve.

## CI

A new `output-backends` job links the S/PDIF and USB device configurations, with `sdkconfig.defaults.spdif` and `sdkconfig.defaults.usb` overlays so both are selectable locally too. It sits outside the release matrix in `build.yml`, so it publishes no firmware artifact.

## Test plan

- [x] `esp32s3` default (I2S) builds, and `objdump` confirms the linker takes the strong `audio_output.c` implementation over the weak one — the linked `audio_output_channel_mode_locked` returns 0, while the weak default returns 1
- [x] `esp32s3` + `sdkconfig.defaults.spdif` builds; previously it failed to link. `objdump` confirms it picks up the weak defaults (`channel_mode_locked` returns 1, `get_underruns` returns 0)
- [x] `esp32s3` + `sdkconfig.defaults.usb` builds; previously it failed to link twice over
- [x] `usb_descriptors.c` produces exactly one object file and one `tud_descriptor_device_cb` definition in the final ELF
- [x] `pio run -e esp32s3` still succeeds and still compiles `usb_descriptors.c` exactly once, so d55ab3f's original duplicate does not come back
- [x] `clang-format` / `clang-tidy` clean via the pre-commit hook
- [ ] Hardware check on an S/PDIF board, to confirm the channel-mode control shows as unavailable in the web UI rather than misbehaving
- [ ] Hardware check that a USB device build actually enumerates as an audio device — CI only proves it links

Once this lands, #108 will link and the `esp32s3-usbhost` env can join the `output-backends` job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the audio output ABI (weak symbols vs strong I2S implementations) and TinyUSB source filtering, which can cause silent fallbacks or USB descriptor link failures if wrong. CI now covers those backends.
> 
> **Overview**
> S/PDIF and USB audio backends can link again. Callers always use channel-mode, pipeline-depth, and underrun APIs, but only the I2S backend implemented them, so other configs failed at link time and CI never caught it.
> 
> Adds `audio_output_common.c` with **weak defaults** for those optional entry points (no routing, no hardware cursor, channel mode reported as locked so the web UI hides the control). Core APIs stay undefined so a missing backend still fails loudly. Duplicate USB stubs that matched the defaults are removed.
> 
> The TinyUSB UAC cmake workaround now strips only `INTERFACE_SOURCES` for `usb_descriptors.c`, keeping the file in TinyUSB `SOURCES` so descriptor callbacks still resolve. CI gains an `output-backends` job that builds SPDIF and USB overlays without publishing firmware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40719e91f817d8849f2fc4a7648963514e838937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->