### PR TITLE
display: cut OLED scroll render cost and hold a steady cadence

### DIFF
--- a/components/display/display.c
+++ b/components/display/display.c
@@ -53,12 +53,13 @@ typedef struct {
   display_state_t state;
 } display_snapshot_t;
 
-// Scroll configuration
-#define SCROLL_PX_PER_TICK 2
-#define SCROLL_GAP_PX      30 // pixel gap before text wraps
-#define SCROLL_PAUSE_TICKS 3  // pause before scrolling restarts
-#define SCROLL_INTERVAL_MS 50 // render interval during active scroll
-#define PAUSE_INDICATOR_W  14 // reserved width for "||" + gap
+// Scroll configuration. The interval is picked so the step lands on a whole
+// pixel; a fractional step quantises and reads as jitter.
+#define SCROLL_PX_PER_SEC  25  // 3 px per frame at the interval below
+#define SCROLL_GAP_PX      30  // pixel gap before text wraps
+#define SCROLL_PAUSE_TICKS 3   // pause before scrolling restarts
+#define SCROLL_INTERVAL_MS 120 // render interval during active scroll
+#define PAUSE_INDICATOR_W  14  // reserved width for "||" + gap
 
 #if defined(CONFIG_DISPLAY_HEIGHT_32)
 #define NUM_SCROLL_LINES 1
@@ -69,8 +70,26 @@ typedef struct {
 static struct {
   int offset[NUM_SCROLL_LINES];
   int pause_ticks[NUM_SCROLL_LINES];
+  int step;    // pixels to advance this frame
   bool active; // true if any line is scrolling
 } s_scroll;
+
+// Advance on elapsed time, not per frame, so a late frame steps further rather
+// than scrolling slower.
+static void scroll_tick(void) {
+  static int64_t last_us;
+  static int carry_subpx;
+
+  const int64_t now = esp_timer_get_time();
+  int64_t dt = (last_us == 0) ? (SCROLL_INTERVAL_MS * 1000) : (now - last_us);
+  last_us = now;
+  if (dt > (4 * SCROLL_INTERVAL_MS * 1000)) {
+    dt = 4 * SCROLL_INTERVAL_MS * 1000; // resuming, not catching up
+  }
+  carry_subpx += (int)((dt * SCROLL_PX_PER_SEC * 256) / 1000000);
+  s_scroll.step = carry_subpx / 256;
+  carry_subpx -= s_scroll.step * 256;
+}
 
 static void scroll_reset(void) {
   memset(&s_scroll, 0, sizeof(s_scroll));
@@ -138,9 +157,9 @@ static void draw_scrolling_line(u8g2_t *u8g2, int idx, int y, const char *str,
   if (s_scroll.pause_ticks[idx] > 0) {
     s_scroll.pause_ticks[idx]--;
   } else {
-    s_scroll.offset[idx] += SCROLL_PX_PER_TICK;
+    s_scroll.offset[idx] += s_scroll.step;
     if (s_scroll.offset[idx] >= loop_w) {
-      s_scroll.offset[idx] = 0;
+      s_scroll.offset[idx] -= loop_w;
     }
   }
 }
@@ -202,6 +221,50 @@ static void draw_progress(u8g2_t *u8g2, int y, uint32_t pos, uint32_t dur) {
 // Rendering
 // ============================================================================
 
+static uint8_t s_shadow[1024];
+static bool s_shadow_valid;
+
+// Each tile row is a separate blocking I2C transfer, and waiting for those is
+// most of a frame, so resend only the rows whose pixels moved.
+static void send_dirty_rows(void) {
+  const uint8_t *buf = u8g2_GetBufferPtr(&s_u8g2);
+  const uint8_t tiles_w = u8g2_GetBufferTileWidth(&s_u8g2);
+  const uint8_t tiles_h = u8g2_GetBufferTileHeight(&s_u8g2);
+  const size_t row_bytes = (size_t)tiles_w * 8;
+  const size_t total = row_bytes * tiles_h;
+
+  if (total > sizeof(s_shadow)) {
+    u8g2_SendBuffer(&s_u8g2);
+    return;
+  }
+
+  if (!s_shadow_valid) {
+    u8g2_SendBuffer(&s_u8g2);
+  } else {
+    uint8_t row = 0;
+    while (row < tiles_h) {
+      const size_t off = (size_t)row * row_bytes;
+      if (memcmp(buf + off, s_shadow + off, row_bytes) == 0) {
+        row++;
+        continue;
+      }
+      const uint8_t first = row;
+      while (row < tiles_h) {
+        const size_t run = (size_t)row * row_bytes;
+        if (memcmp(buf + run, s_shadow + run, row_bytes) == 0) {
+          break;
+        }
+        row++;
+      }
+      u8g2_UpdateDisplayArea(&s_u8g2, 0, first, tiles_w,
+                             (uint8_t)(row - first));
+    }
+  }
+
+  memcpy(s_shadow, buf, total);
+  s_shadow_valid = true;
+}
+
 static void display_render(void) {
   display_snapshot_t snap;
 
@@ -216,6 +279,7 @@ static void display_render(void) {
 
   u8g2_ClearBuffer(&s_u8g2);
   s_scroll.active = false;
+  scroll_tick();
 
   switch (snap.state) {
   case DISPLAY_STATE_STANDBY:
@@ -291,7 +355,7 @@ static void display_render(void) {
   }
   }
 
-  u8g2_SendBuffer(&s_u8g2);
+  send_dirty_rows();
 }
 
 // ============================================================================
@@ -394,6 +458,7 @@ static void display_task(void *pvParameters) {
   const TickType_t interval = pdMS_TO_TICKS(CONFIG_DISPLAY_UPDATE_MS);
   const TickType_t one_sec = pdMS_TO_TICKS(1000);
   const TickType_t scroll_interval = pdMS_TO_TICKS(SCROLL_INTERVAL_MS);
+  TickType_t last_wake = xTaskGetTickCount();
 
   // Initial render
   display_render();
@@ -401,18 +466,26 @@ static void display_task(void *pvParameters) {
   while (1) {
     bool is_playing = (s_display.state == DISPLAY_STATE_PLAYING);
     if (s_scroll.active) {
-      vTaskDelay(scroll_interval);
+      // A plain delay would add each render to the frame period, tying the
+      // scroll speed to I2C timing rather than to the clock.
+      if (xTaskDelayUntil(&last_wake, scroll_interval) == pdFALSE) {
+        // Overran the frame. Yield regardless, or the loop never sleeps.
+        vTaskDelay(scroll_interval);
+        last_wake = xTaskGetTickCount();
+      }
       s_display.dirty = false;
       display_render();
       continue;
     }
     if (is_playing) {
       vTaskDelay(one_sec);
+      last_wake = xTaskGetTickCount();
       s_display.dirty = false;
       display_render();
       continue;
     }
     vTaskDelay(interval);
+    last_wake = xTaskGetTickCount();
     if (s_display.dirty) {
       s_display.dirty = false;
       display_render();
@@ -568,7 +641,8 @@ void display_init(void *bus) {
   // Register for RTSP events
   rtsp_events_register(on_rtsp_event, NULL);
 
-  // Start display refresh task
+  // Start display refresh task. Left unpinned: SendBuffer blocks eight times a
+  // frame, and the audio core wakes every 5.8 ms, so affinity there is costly.
   xTaskCreate(display_task, "display", 4096, NULL, 3, NULL);
 
   ESP_LOGI(TAG, "OLED display initialized");

--- a/components/display/display.c
+++ b/components/display/display.c
@@ -232,6 +232,7 @@ static void send_dirty_rows(void) {
   const uint8_t tiles_h = u8g2_GetBufferTileHeight(&s_u8g2);
   const size_t row_bytes = (size_t)tiles_w * 8;
   const size_t total = row_bytes * tiles_h;
+  const uint32_t errors_before = u8g2_esp32_i2c_error_count();
 
   if (total > sizeof(s_shadow)) {
     u8g2_SendBuffer(&s_u8g2);
@@ -259,6 +260,14 @@ static void send_dirty_rows(void) {
       u8g2_UpdateDisplayArea(&s_u8g2, 0, first, tiles_w,
                              (uint8_t)(row - first));
     }
+  }
+
+  // A dropped transfer leaves the panel showing something other than what was
+  // sent, so keep the shadow invalid and repaint in full next frame rather
+  // than recording rows that never landed as clean.
+  if (u8g2_esp32_i2c_error_count() != errors_before) {
+    s_shadow_valid = false;
+    return;
   }
 
   memcpy(s_shadow, buf, total);
@@ -469,8 +478,11 @@ static void display_task(void *pvParameters) {
       // A plain delay would add each render to the frame period, tying the
       // scroll speed to I2C timing rather than to the clock.
       if (xTaskDelayUntil(&last_wake, scroll_interval) == pdFALSE) {
-        // Overran the frame. Yield regardless, or the loop never sleeps.
-        vTaskDelay(scroll_interval);
+        // Already past the deadline, so xTaskDelayUntil did not block. Yield
+        // the minimum to keep the loop from spinning, then restart the cadence
+        // from now; waiting out another whole interval would stall the scroll
+        // exactly when it is already behind.
+        vTaskDelay(1);
         last_wake = xTaskGetTickCount();
       }
       s_display.dirty = false;

--- a/components/u8g2-hal-esp-idf/include/u8g2_esp32_hal.h
+++ b/components/u8g2-hal-esp-idf/include/u8g2_esp32_hal.h
@@ -101,6 +101,14 @@ void u8g2_esp32_hal_set_i2c_bus(i2c_master_bus_handle_t bus);
  */
 void u8g2_esp32_hal_set_spi_host(spi_host_device_t host);
 
+/**
+ * Number of I2C transfers that have failed since boot.
+ * The byte callback cannot report a failure back through u8g2, so a caller
+ * that caches what it has already sent needs this to tell that a transfer was
+ * dropped and its cache no longer matches the panel.
+ */
+uint32_t u8g2_esp32_i2c_error_count(void);
+
 uint8_t u8g2_esp32_spi_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int,
                                void *arg_ptr);
 uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int,

--- a/components/u8g2-hal-esp-idf/include/u8g2_esp32_hal.h
+++ b/components/u8g2-hal-esp-idf/include/u8g2_esp32_hal.h
@@ -34,7 +34,7 @@
 
 #define I2C_MASTER_TX_BUF_DISABLE 0      //  I2C master do not need buffer
 #define I2C_MASTER_RX_BUF_DISABLE 0      //  I2C master do not need buffer
-#define I2C_MASTER_FREQ_HZ        100000 //  I2C master clock frequency
+#define I2C_MASTER_FREQ_HZ        400000 //  I2C master clock frequency
 #define ACK_CHECK_EN              0x1 //  I2C master will check ack from slave
 #define ACK_CHECK_DIS 0x0 //  I2C master will not check ack from slave
 

--- a/components/u8g2-hal-esp-idf/src/u8g2_esp32_hal.c
+++ b/components/u8g2-hal-esp-idf/src/u8g2_esp32_hal.c
@@ -25,6 +25,8 @@ static size_t i2c_buf_idx;                  // Current index in I2C buffer.
 static spi_host_device_t s_spi_host = SPI2_HOST;
 static bool s_spi_bus_external = false;
 
+static volatile uint32_t s_i2c_errors;
+
 #undef ESP_ERROR_CHECK
 #define ESP_ERROR_CHECK(x)                                  \
   do {                                                      \
@@ -55,6 +57,10 @@ void u8g2_esp32_hal_set_i2c_bus(i2c_master_bus_handle_t bus) {
 void u8g2_esp32_hal_set_spi_host(spi_host_device_t host) {
   s_spi_host = host;
   s_spi_bus_external = true;
+}
+
+uint32_t u8g2_esp32_i2c_error_count(void) {
+  return s_i2c_errors;
 }
 
 /*
@@ -208,6 +214,7 @@ uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int,
     esp_err_t rc =
         i2c_master_transmit(dev_i2c, i2c_buffer, i2c_buf_idx, I2C_TIMEOUT_MS);
     if (rc != ESP_OK) {
+      s_i2c_errors++;
       ESP_LOGW(TAG, "I2C transmit failed: %s — resetting bus",
                esp_err_to_name(rc));
       i2c_master_bus_reset(bus_i2c);


### PR DESCRIPTION
## Problem

On a 128x64 SSD1306 the scrolling metadata text was visibly uneven, and the display was taking noticeably more CPU than the same board without a panel.

Measuring a frame rather than guessing at it turned up two independent causes.

**The bus was running at a quarter of its rated speed.** The vendored u8g2 HAL hardcodes `I2C_MASTER_FREQ_HZ` to 100 kHz and does not expose it through Kconfig. A full 1 KB frame is ~92 ms on the wire at that rate.

**The transfer was dominated by scheduling, not bandwidth.** u8g2 issues one blocking `i2c_master_transmit()` per tile row, so a full frame blocks eight separate times. The display task sits at priority 3, below `audio_play` (9), `audio_recv` (8), `ctrl_recv` (7), `audio_decode` (6) and `buff_audio` (5), so each of those eight waits is resumed only once the audio tasks yield. Instrumenting the render split it as:

| | measured |
|---|---|
| render, total | ~77 ms |
| of which `SendBuffer` | ~73 ms (91-96%) |
| bus time at 400 kHz | ~23 ms |
| implied wait per transfer | ~6.7 ms |

That per-transfer wait is close to the 5.8 ms playback DMA period, which is what it is queued behind. Raising the display task's priority is not an option since anything above 5 preempts a receive or decode task, so the only lever is **fewer transfers**.

## Changes

**1. Run the OLED bus at 400 kHz** — the rate the SSD1306 is rated for. The DAC is on a separate bus and the new I2C driver takes `scl_speed_hz` per device, so nothing else on the board is affected.

**2. Resend only the tile rows whose pixels changed.** A shadow copy of the last frame is compared row by row and only differing runs are pushed via `u8g2_UpdateDisplayArea()`. A scrolling line touches two rows and the progress row changes once a second, so a frame sends **two rows instead of eight**.

Deciding the rows by comparison rather than from the layout was deliberate: an earlier attempt derived them from font baselines and was both wrong at the boundaries and dependent on the layout staying put.

**3. Advance the scroll on elapsed time rather than per frame.** The offset previously moved a fixed step each frame, so the text travelled at the frame rate rather than at a speed, and every scheduling stall showed up as the text briefly slowing down. The step is now derived from elapsed time with the sub-pixel remainder carried, so a late frame covers the ground it missed. Long gaps are clamped so a panel returning from idle resumes instead of leaping.

**4. Hold the frame period with `xTaskDelayUntil()`** so a render's cost does not add to the interval, and choose an interval with real margin over a render. 120 ms at 25 px/s is a whole 3 px step.

The interval must divide the speed into an integer step — a fractional one (say 2.5 px) quantises into a 2,3,2,3 pattern and reintroduces exactly the jitter the timing fix removes.

## Result

Measured on an ESP32 + SSD1306 while streaming AirPlay:

| | before | after |
|---|---|---|
| transfers per frame | 8 | 2 |
| render, avg | ~77 ms | ~28 ms |
| `SendBuffer`, avg | ~73 ms | ~23 ms |
| worst frame | 250-393 ms | 135-156 ms |
| frames missing cadence | ~50% | **1%** |

Audio was checked at every step and is unaffected: `concealed=0`, `holes=0`, `trims=0/s`, no warnings.

## Notes for review

- `components/u8g2-hal-esp-idf` is vendored rather than a submodule (only `components/u8g2` is listed in `.gitmodules`), so the 400 kHz change is committed directly here. It is a candidate to send to the HAL upstream separately if preferred. Note `CLAUDE.md` currently describes it as a submodule.
- The shadow buffer is 1 KB of static RAM, with a fallback to a full `SendBuffer` if a panel's buffer ever exceeds it.
- It assumes nothing writes the panel outside `display_render()`; the only other `SendBuffer` is the one in `display_init()`, and the shadow starts invalid so the first frame is always a full send.
- Only the 128x64 and x32 paths were exercised on hardware. 
- Tested on ESP32 + SSD1306 over I2C. Other panels and the SPI paths are untested.

## Testing

- Built `esp32s3` (display enabled) and `squeezeamp-bt`.
- `clang-format` clean on both changed files.
- Soak-tested on hardware over several AirPlay sessions with the render instrumentation in place; the counters were removed before this branch was finalised.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vendored I2C HAL timing and partial framebuffer updates; incorrect shadow sync could cause transient display corruption, though I2C errors force a full repaint next frame.
> 
> **Overview**
> Reduces OLED I2C load and smooths scrolling metadata on SSD1306-class panels.
> 
> **Bus and transfer path:** The vendored u8g2 ESP32 HAL now runs I2C at **400 kHz** (was 100 kHz). `display_render()` no longer always calls `u8g2_SendBuffer()`; **`send_dirty_rows()`** keeps a 1 KB shadow of the framebuffer, diffs tile rows, and pushes only changed runs via **`u8g2_UpdateDisplayArea()`**, falling back to a full send when the buffer is too large or the shadow is invalid. **`u8g2_esp32_i2c_error_count()`** was added so a failed transmit invalidates the shadow instead of treating dropped rows as synced.
> 
> **Scroll timing:** Scroll speed is **`SCROLL_PX_PER_SEC`** with a **120 ms** tick chosen for whole-pixel steps; **`scroll_tick()`** advances offset from elapsed time (with sub-pixel carry and a gap clamp) instead of a fixed pixels-per-frame. The display task uses **`xTaskDelayUntil()`** during active scroll so render/I2C time does not stretch the interval, with a short yield when already behind.
> 
> **Small scroll fix:** Wrapping uses **`offset -= loop_w`** rather than resetting to zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8dea0030dd5ff5f040311b916312e1903785ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->