### PR TITLE
Make forced-v1 mode a faithful classic RAOP receiver

### DIFF
--- a/docs/features/airplay-tuning.md
+++ b/docs/features/airplay-tuning.md
@@ -50,8 +50,16 @@ If you still hear drop-outs on AirPlay 1 / realtime playback, increase
 ## Forcing AirPlay v1
 
 `CONFIG_AIRPLAY_FORCE_V1=y` makes the receiver advertise itself as a classic AirPlay
-receiver. The main reason to do this is to get working
-[hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement), since iOS only
-sends DACP headers in v1 mode.
+receiver. There are two reasons to do this:
+
+- **Hardware buttons.** iOS only sends DACP headers in v1 mode, so this is what makes
+  [hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement) work.
+- **Apple Music for Windows.** It is a RAOP-only sender and refuses any device carrying
+  AirPlay 2 markers, reporting that the device "is not compatible with this version of
+  AMPLibraryAgent".
+
+In this mode the receiver mirrors a classic RAOP advertisement: no `_airplay._tcp`
+service, a shairport-sync-style `_raop._tcp` TXT record, `Server: AirTunes/105.1` on RTSP
+responses, and RTSP on port 5000 instead of 7000.
 
 It costs you AirPlay 2 features: HomeKit pairing, encrypted transport and multi-room sync.

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -483,10 +483,12 @@ menu "Airplay ESP Configuration"
 
                 Enable this option only if AirPlay 2 advertisement causes
                 problems on your network (e.g. iOS preferring AirPlay 2
-                with broken FairPlay verification). It hides the
-                _airplay._tcp service entirely, leaving only _raop._tcp
-                for classic RAOP clients. iOS will fall back to AirPlay 1
-                with DACP remote control.
+                with broken FairPlay verification), or to stream from
+                Apple Music for Windows, which refuses any device that
+                advertises AirPlay 2 markers. It hides the _airplay._tcp
+                service entirely and moves RTSP to the classic RAOP port
+                5000, leaving only _raop._tcp for classic clients. iOS
+                will fall back to AirPlay 1 with DACP remote control.
 
                 When disabled (default), the receiver advertises as an
                 AirPlay 2 device. Modern iOS uses the MRP (Media Remote

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -1,3 +1,4 @@
+#include "esp_app_desc.h"
 #include "esp_log.h"
 #include "esp_mac.h"
 #include "mdns.h"
@@ -7,6 +8,7 @@
 #include "hap.h"
 #include "mdns_airplay.h"
 #include "rtsp_handlers.h"
+#include "rtsp_server.h"
 #include "wifi.h"
 #include "settings.h"
 
@@ -44,6 +46,12 @@ static const char *TAG = "mdns_airplay";
 // Model identifier - AudioAccessory for speaker appearance
 // AppleTV3,2 = Apple TV, AudioAccessory5,1 = HomePod mini (speaker)
 #define AIRPLAY_MODEL "AudioAccessory5,1"
+
+// In classic mode the device must not look like an AirPlay 2 speaker at all:
+// AirPort4,107 is the first-generation AirPort Express and 105.1 is the source
+// version it reported.
+#define AIRPLAY_V1_MODEL          "AirPort4,107"
+#define AIRPLAY_V1_SOURCE_VERSION "105.1"
 
 void mdns_airplay_init(void) {
   char mac_str[18];
@@ -96,7 +104,7 @@ void mdns_airplay_init(void) {
 
 #ifndef CONFIG_AIRPLAY_FORCE_V1
   // ========================================
-  // _airplay._tcp service (port 7000)
+  // _airplay._tcp service
   // Only registered for AirPlay 2 mode
   // ========================================
   mdns_txt_item_t airplay_txt[] = {
@@ -111,9 +119,9 @@ void mdns_airplay_init(void) {
       {"acl", "0"},
   };
 
-  esp_err_t err =
-      mdns_service_add(device_name, "_airplay", "_tcp", 7000, airplay_txt,
-                       sizeof(airplay_txt) / sizeof(airplay_txt[0]));
+  esp_err_t err = mdns_service_add(
+      device_name, "_airplay", "_tcp", AIRPLAY_RTSP_PORT, airplay_txt,
+      sizeof(airplay_txt) / sizeof(airplay_txt[0]));
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to add _airplay._tcp service: %s",
              esp_err_to_name(err));
@@ -121,27 +129,33 @@ void mdns_airplay_init(void) {
 #endif
 
   // ========================================
-  // _raop._tcp service (port 7000)
+  // _raop._tcp service
   // RAOP = Remote Audio Output Protocol
   // Service name format: <MAC>@<DeviceName>
   // ========================================
 #ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1 (classic RAOP): match squeezelite-esp32 txt record format.
-  // No features, no pk, no HAP pairing — just classic RAOP fields.
+  // AirPlay v1 (classic RAOP). This mirrors shairport-sync's classic record
+  // (bonjour_strings.c), which is the advertisement Apple Music on Windows
+  // accepts — it rejects anything carrying AirPlay 2 markers. No features, no
+  // pk, no HAP pairing.
   mdns_txt_item_t raop_txt[] = {
-      {"am", AIRPLAY_MODEL},
-      {"tp", "UDP"},                  // Transport protocol
-      {"sm", "false"},                // Sharing mode
-      {"sv", "false"},                // Server version (unused)
-      {"ek", "1"},                    // Encryption key available
-      {"et", "0,1"},                  // Encryption types: none, RSA
-      {"md", AIRPLAY_METADATA_TYPES}, // Metadata types
-      {"cn", "0,1"},                  // Audio codecs: PCM, ALAC
-      {"ch", "2"},                    // Channels
-      {"ss", "16"},                   // Sample size (bits)
-      {"sr", "44100"},                // Sample rate
-      {"vn", "3"},                    // Version number
-      {"txtvers", "1"},               // TXT record version
+      {"am", AIRPLAY_V1_MODEL},
+      {"ch", "2"},                                // Channels
+      {"cn", "0,1"},                              // Audio codecs: PCM, ALAC
+      {"da", "true"},                             // Digest auth
+      {"ek", "1"},                                // Encryption key available
+      {"et", "0,1"},                              // Encryption types: none, RSA
+      {"fv", esp_app_get_description()->version}, // Firmware version
+      {"md", AIRPLAY_METADATA_TYPES},             // Metadata types
+      {"pw", "false"},                            // No password required
+      {"sf", AIRPLAY_FLAGS},                      // Status flags
+      {"sr", "44100"},                            // Sample rate
+      {"ss", "16"},                               // Sample size (bits)
+      {"sv", "false"},                            // Server version (unused)
+      {"tp", "UDP"},                              // Transport protocol
+      {"vn", "65537"},                            // Version number
+      {"vs", AIRPLAY_V1_SOURCE_VERSION},          // Source version
+      {"txtvers", "1"},                           // TXT record version
   };
 #else
   // Dual-mode: include et=1 (RSA) so RAOP-only clients (TuneBlade, AirMusic,
@@ -166,10 +180,11 @@ void mdns_airplay_init(void) {
 #endif
 
   esp_err_t err_raop =
-      mdns_service_add(service_name, "_raop", "_tcp", 7000, raop_txt,
-                       sizeof(raop_txt) / sizeof(raop_txt[0]));
+      mdns_service_add(service_name, "_raop", "_tcp", AIRPLAY_RTSP_PORT,
+                       raop_txt, sizeof(raop_txt) / sizeof(raop_txt[0]));
   if (err_raop != ESP_OK) {
     ESP_LOGE(TAG, "Failed to add _raop._tcp service: %s",
              esp_err_to_name(err_raop));
   }
+  ESP_LOGI(TAG, "_raop._tcp advertised on port %d", AIRPLAY_RTSP_PORT);
 }

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -12,7 +12,6 @@
 
 #include "esp_log.h"
 #include "esp_mac.h"
-#include "esp_netif.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "sodium.h"
@@ -458,6 +457,8 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
     return -1;
   }
 
+  ESP_LOGD(TAG, "<- %s %s", req.method, req.path);
+
   // Extract DACP headers if present (AirPlay 1 only — modern iOS AirPlay 2
   // does not send these; it uses MRP for remote control instead).
   // parse_raw_header uses a static buffer — copy before calling again.
@@ -507,10 +508,18 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
 static void handle_options(int socket, rtsp_conn_t *conn,
                            const rtsp_request_t *req, const uint8_t *raw,
                            size_t raw_len) {
+#ifdef CONFIG_AIRPLAY_FORCE_V1
+  // A classic-only sender inspects this list; the AirPlay 2 methods are enough
+  // for Apple Music on Windows to give up straight after OPTIONS.
+  const char *public_methods =
+      "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, "
+      "GET_PARAMETER, SET_PARAMETER\r\n";
+#else
   const char *public_methods =
       "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, FLUSHBUFFERED, TEARDOWN, "
       "OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, SETPEERS, "
       "SETRATEANCHORTIME\r\n";
+#endif
 
   // AirPlay v1: handle Apple-Challenge if present. Triggered by request
   // shape, so safe unconditionally — iOS in AirPlay 2 mode does not send
@@ -518,16 +527,22 @@ static void handle_options(int socket, rtsp_conn_t *conn,
   const char *challenge = parse_raw_header(raw, raw_len, "Apple-Challenge:");
   if (challenge) {
     conn->protocol_version = 1;
-    esp_netif_ip_info_t ip_info;
-    esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-    if (netif && esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
+    // The sender verifies that the response embeds the address it connected
+    // to, so take it from the socket: hardcoding the WiFi netif yields 0.0.0.0
+    // on an Ethernet-attached board and the sender then walks away silently.
+    struct sockaddr_in local = {0};
+    socklen_t local_len = sizeof(local);
+    if (getsockname(socket, (struct sockaddr *)&local, &local_len) == 0 &&
+        local.sin_addr.s_addr != 0) {
       uint8_t mac[6];
       esp_read_mac(mac, ESP_MAC_WIFI_STA);
 
       char response_b64[512];
-      if (rsa_apple_challenge_response(challenge, ip_info.ip.addr, mac,
+      if (rsa_apple_challenge_response(challenge, local.sin_addr.s_addr, mac,
                                        response_b64,
                                        sizeof(response_b64)) == 0) {
+        ESP_LOGI(TAG, "Apple-Challenge answered for local IP %s",
+                 inet_ntoa(local.sin_addr));
         char headers[768];
         snprintf(headers, sizeof(headers), "%sApple-Response: %s\r\n",
                  public_methods, response_b64);

--- a/main/rtsp/rtsp_message.c
+++ b/main/rtsp/rtsp_message.c
@@ -11,6 +11,14 @@
 
 static const char *TAG = "rtsp_message";
 
+// A classic sender reads the source version here too, not just in the mDNS TXT
+// record, and rejects an AirPlay 2 one.
+#ifdef CONFIG_AIRPLAY_FORCE_V1
+#define RTSP_SERVER_HEADER "Server: AirTunes/105.1\r\n"
+#else
+#define RTSP_SERVER_HEADER "Server: AirTunes/377.40.00\r\n"
+#endif
+
 const uint8_t *rtsp_find_header_end(const uint8_t *data, size_t len) {
   for (size_t i = 0; i + 3 < len; i++) {
     if (data[i] == '\r' && data[i + 1] == '\n' && data[i + 2] == '\r' &&
@@ -166,34 +174,27 @@ int rtsp_send_response(int socket, rtsp_conn_t *conn, int status_code,
     header_len =
         snprintf(header, sizeof(header),
                  "RTSP/1.0 %d %s\r\n"
-                 "CSeq: %d\r\n"
-                 "Server: AirTunes/377.40.00\r\n"
-                 "%s"
+                 "CSeq: %d\r\n" RTSP_SERVER_HEADER "%s"
                  "Content-Length: %zu\r\n"
                  "\r\n",
                  status_code, status_text, cseq, extra_headers, body_len);
   } else if (extra_headers) {
     header_len = snprintf(header, sizeof(header),
                           "RTSP/1.0 %d %s\r\n"
-                          "CSeq: %d\r\n"
-                          "Server: AirTunes/377.40.00\r\n"
-                          "%s"
+                          "CSeq: %d\r\n" RTSP_SERVER_HEADER "%s"
                           "\r\n",
                           status_code, status_text, cseq, extra_headers);
   } else if (body && body_len > 0) {
-    header_len = snprintf(header, sizeof(header),
-                          "RTSP/1.0 %d %s\r\n"
-                          "CSeq: %d\r\n"
-                          "Server: AirTunes/377.40.00\r\n"
-                          "Content-Length: %zu\r\n"
-                          "\r\n",
-                          status_code, status_text, cseq, body_len);
+    header_len =
+        snprintf(header, sizeof(header),
+                 "RTSP/1.0 %d %s\r\n"
+                 "CSeq: %d\r\n" RTSP_SERVER_HEADER "Content-Length: %zu\r\n"
+                 "\r\n",
+                 status_code, status_text, cseq, body_len);
   } else {
     header_len = snprintf(header, sizeof(header),
                           "RTSP/1.0 %d %s\r\n"
-                          "CSeq: %d\r\n"
-                          "Server: AirTunes/377.40.00\r\n"
-                          "\r\n",
+                          "CSeq: %d\r\n" RTSP_SERVER_HEADER "\r\n",
                           status_code, status_text, cseq);
   }
 
@@ -233,14 +234,13 @@ int rtsp_send_http_response(int socket, rtsp_conn_t *conn, int status_code,
                             const char *status_text, const char *content_type,
                             const char *body, size_t body_len) {
   char header[512];
-  int header_len = snprintf(header, sizeof(header),
-                            "HTTP/1.1 %d %s\r\n"
-                            "Content-Type: %s\r\n"
-                            "Content-Length: %zu\r\n"
-                            "Server: AirTunes/377.40.00\r\n"
-                            "CSeq: 1\r\n"
-                            "\r\n",
-                            status_code, status_text, content_type, body_len);
+  int header_len =
+      snprintf(header, sizeof(header),
+               "HTTP/1.1 %d %s\r\n"
+               "Content-Type: %s\r\n"
+               "Content-Length: %zu\r\n" RTSP_SERVER_HEADER "CSeq: 1\r\n"
+               "\r\n",
+               status_code, status_text, content_type, body_len);
 
   // Build complete response
   size_t total_len = (size_t)header_len + body_len;

--- a/main/rtsp/rtsp_rsa.c
+++ b/main/rtsp/rtsp_rsa.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/pk.h"
@@ -52,6 +53,8 @@ static int ensure_pk_initialized(void) {
     return 0;
   }
 
+  int64_t start_us = esp_timer_get_time();
+
   // Initialize RNG (required by mbedtls 3.x for key parsing and RSA ops)
   mbedtls_entropy_init(&s_entropy);
   mbedtls_ctr_drbg_init(&s_ctr_drbg);
@@ -78,7 +81,27 @@ static int ensure_pk_initialized(void) {
   }
 
   s_pk_initialized = true;
+
+  // The first private-key op also derives the blinding pair, which costs an
+  // inv_mod and an exp_mod that later calls avoid by squaring the cached one.
+  // Throw one signature away here so a sender never waits for it.
+  mbedtls_rsa_context *rsa = mbedtls_pk_rsa(s_pk_ctx);
+  mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
+  uint8_t *warm = malloc(mbedtls_rsa_get_len(rsa));
+  if (warm) {
+    uint8_t scratch[32] = {0};
+    mbedtls_rsa_pkcs1_sign(rsa, mbedtls_ctr_drbg_random, &s_ctr_drbg,
+                           MBEDTLS_MD_NONE, sizeof(scratch), scratch, warm);
+    free(warm);
+  }
+
+  ESP_LOGI(TAG, "RSA key ready in %lld ms",
+           (esp_timer_get_time() - start_us) / 1000);
   return 0;
+}
+
+int rsa_init(void) {
+  return ensure_pk_initialized();
 }
 
 // Simple base64 decode using libsodium

--- a/main/rtsp/rtsp_rsa.c
+++ b/main/rtsp/rtsp_rsa.c
@@ -4,6 +4,8 @@
 
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/pk.h"
@@ -48,7 +50,25 @@ static mbedtls_entropy_context s_entropy;
 static mbedtls_ctr_drbg_context s_ctr_drbg;
 static bool s_pk_initialized = false;
 
-static int ensure_pk_initialized(void) {
+// MBEDTLS_THREADING_C is off, and a private-key op mutates the shared context:
+// the padding mode, and the blinding pair inside mbedtls_rsa_private. Client
+// tasks overlap during a handover, so every use of s_pk_ctx is serialised.
+static SemaphoreHandle_t s_rsa_lock;
+static StaticSemaphore_t s_rsa_lock_storage;
+static portMUX_TYPE s_rsa_lock_mux = portMUX_INITIALIZER_UNLOCKED;
+
+// Creating the lock has to be race-free too: a client task can reach a
+// private-key op without rsa_init() having run first.
+static SemaphoreHandle_t rsa_lock(void) {
+  portENTER_CRITICAL(&s_rsa_lock_mux);
+  if (s_rsa_lock == NULL) {
+    s_rsa_lock = xSemaphoreCreateMutexStatic(&s_rsa_lock_storage);
+  }
+  portEXIT_CRITICAL(&s_rsa_lock_mux);
+  return s_rsa_lock;
+}
+
+static int ensure_pk_initialized_locked(void) {
   if (s_pk_initialized) {
     return 0;
   }
@@ -80,8 +100,6 @@ static int ensure_pk_initialized(void) {
     return -1;
   }
 
-  s_pk_initialized = true;
-
   // The first private-key op also derives the blinding pair, which costs an
   // inv_mod and an exp_mod that later calls avoid by squaring the cached one.
   // Throw one signature away here so a sender never waits for it.
@@ -95,13 +113,19 @@ static int ensure_pk_initialized(void) {
     free(warm);
   }
 
+  s_pk_initialized = true;
+
   ESP_LOGI(TAG, "RSA key ready in %lld ms",
            (esp_timer_get_time() - start_us) / 1000);
   return 0;
 }
 
 int rsa_init(void) {
-  return ensure_pk_initialized();
+  SemaphoreHandle_t lock = rsa_lock();
+  xSemaphoreTake(lock, portMAX_DELAY);
+  int ret = ensure_pk_initialized_locked();
+  xSemaphoreGive(lock);
+  return ret;
 }
 
 // Simple base64 decode using libsodium
@@ -130,10 +154,6 @@ static int b64_encode(const uint8_t *data, size_t data_len, char *out,
 int rsa_apple_challenge_response(const char *challenge_b64, uint32_t ip_addr,
                                  const uint8_t mac[6], char *out_b64,
                                  size_t out_b64_size) {
-  if (ensure_pk_initialized() != 0) {
-    return -1;
-  }
-
   // Decode challenge
   uint8_t challenge[32];
   size_t challenge_len = 0;
@@ -164,17 +184,28 @@ int rsa_apple_challenge_response(const char *challenge_b64, uint32_t ip_addr,
   // RSA_private_encrypt(..., RSA_PKCS1_PADDING).
   // mbedtls_rsa_pkcs1_sign with MBEDTLS_MD_NONE applies type-1 padding
   // (0x00 0x01 0xFF..0xFF 0x00 <data>) then the private key operation.
+  SemaphoreHandle_t lock = rsa_lock();
+  xSemaphoreTake(lock, portMAX_DELAY);
+
+  if (ensure_pk_initialized_locked() != 0) {
+    xSemaphoreGive(lock);
+    return -1;
+  }
+
   mbedtls_rsa_context *rsa = mbedtls_pk_rsa(s_pk_ctx);
   mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V15, MBEDTLS_MD_NONE);
 
   size_t rsa_len = mbedtls_rsa_get_len(rsa);
   uint8_t *rsa_out = malloc(rsa_len);
   if (!rsa_out) {
+    xSemaphoreGive(lock);
     return -1;
   }
 
   int ret = mbedtls_rsa_pkcs1_sign(rsa, mbedtls_ctr_drbg_random, &s_ctr_drbg,
                                    MBEDTLS_MD_NONE, 32, data, rsa_out);
+  xSemaphoreGive(lock);
+
   if (ret != 0) {
     ESP_LOGE(TAG, "RSA sign failed: -0x%04x", -ret);
     free(rsa_out);
@@ -195,10 +226,6 @@ int rsa_apple_challenge_response(const char *challenge_b64, uint32_t ip_addr,
 
 int rsa_decrypt_aes_key(const char *encrypted_b64, uint8_t *out_key,
                         size_t out_key_size, size_t *out_key_len) {
-  if (ensure_pk_initialized() != 0) {
-    return -1;
-  }
-
   // Decode the base64 RSA-encrypted key
   uint8_t encrypted[512];
   size_t encrypted_len = 0;
@@ -212,12 +239,22 @@ int rsa_decrypt_aes_key(const char *encrypted_b64, uint8_t *out_key,
            encrypted_len);
 
   // RSA OAEP-SHA1 decrypt (RAOP uses OAEP padding for the AES key)
+  SemaphoreHandle_t lock = rsa_lock();
+  xSemaphoreTake(lock, portMAX_DELAY);
+
+  if (ensure_pk_initialized_locked() != 0) {
+    xSemaphoreGive(lock);
+    return -1;
+  }
+
   mbedtls_rsa_context *rsa = mbedtls_pk_rsa(s_pk_ctx);
   mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA1);
 
   size_t olen = 0;
   int ret = mbedtls_rsa_pkcs1_decrypt(rsa, mbedtls_ctr_drbg_random, &s_ctr_drbg,
                                       &olen, encrypted, out_key, out_key_size);
+  xSemaphoreGive(lock);
+
   if (ret != 0) {
     ESP_LOGE(TAG, "RSA AES key decrypt failed: -0x%04x", -ret);
     return -1;

--- a/main/rtsp/rtsp_rsa.h
+++ b/main/rtsp/rtsp_rsa.h
@@ -13,6 +13,17 @@
  */
 
 /**
+ * Seed the RNG and parse the private key.
+ *
+ * Optional: every entry point does this lazily. Call it up front to keep the
+ * cost off the RTSP task, where it lands in the middle of the OPTIONS response
+ * a sender is waiting on.
+ *
+ * @return 0 on success, -1 on failure
+ */
+int rsa_init(void);
+
+/**
  * Build the Apple-Challenge response.
  *
  * Decodes the base64 challenge, appends our IP + MAC, pads to 32 bytes,

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -19,6 +19,7 @@
 #include "rtsp_crypto.h"
 #include "rtsp_handlers.h"
 #include "rtsp_message.h"
+#include "rtsp_rsa.h"
 
 #include "ntp_clock.h"
 #include "ptp_clock.h"
@@ -27,7 +28,7 @@
 
 static const char *TAG = "rtsp_server";
 
-#define RTSP_PORT           7000
+#define RTSP_PORT           AIRPLAY_RTSP_PORT
 #define RTSP_BUFFER_INITIAL 4096
 #define RTSP_BUFFER_LARGE   ((size_t)256 * 1024)
 
@@ -549,6 +550,10 @@ esp_err_t rtsp_server_start(void) {
   if (task_ret != pdPASS || server_task_handle == NULL) {
     return ESP_FAIL;
   }
+
+  // Parsing the key and deriving the first blinding pair costs the best part
+  // of a second; a sender waiting on its OPTIONS response gives up before that.
+  rsa_init();
 
   return ESP_OK;
 }

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -544,16 +544,17 @@ esp_err_t rtsp_server_start(void) {
     }
   }
 
+  // Parsing the key and deriving the first blinding pair costs the best part
+  // of a second; a sender waiting on its OPTIONS response gives up before
+  // that. Do it before the listener exists so it cannot land mid-request.
+  rsa_init();
+
   BaseType_t task_ret =
       xTaskCreate(server_task, "rtsp_server", SERVER_STACK_SIZE, NULL, 5,
                   &server_task_handle);
   if (task_ret != pdPASS || server_task_handle == NULL) {
     return ESP_FAIL;
   }
-
-  // Parsing the key and deriving the first blinding pair costs the best part
-  // of a second; a sender waiting on its OPTIONS response gives up before that.
-  rsa_init();
 
   return ESP_OK;
 }

--- a/main/rtsp/rtsp_server.h
+++ b/main/rtsp/rtsp_server.h
@@ -3,8 +3,17 @@
 #include "esp_err.h"
 #include <stdint.h>
 
+// 7000 is the AirPlay 2 port; classic RAOP lives on 5000, and a sender that
+// sees 7000 in the SRV record may take the AirPlay 2 path regardless of the
+// TXT record. The mDNS advertisement must use the same number.
+#ifdef CONFIG_AIRPLAY_FORCE_V1
+#define AIRPLAY_RTSP_PORT 5000
+#else
+#define AIRPLAY_RTSP_PORT 7000
+#endif
+
 /**
- * Start the AirPlay RTSP server on port 7000
+ * Start the AirPlay RTSP server.
  * Handles initial connection requests from iOS devices
  */
 esp_err_t rtsp_server_start(void);


### PR DESCRIPTION
## Summary

`CONFIG_AIRPLAY_FORCE_V1` hid `_airplay._tcp`, but the rest of the receiver still looked like an AirPlay 2 device — so a RAOP-only sender still refused it.

Apple Music for Windows is the case that exposed this. At discovery it reported the device as *"is not compatible with this version of AMPLibraryAgent"*, and once past that it hung up partway through the RTSP handshake. Mirroring shairport-sync's classic behaviour makes it work: streaming from Apple Music on Windows to an Esparagus Audio Brick (ESP32 + W5500 Ethernet) is confirmed working.

This also fixes two bugs that are **not** specific to forced-v1 mode — both affect any AirPlay 1 sender.

## Forced-v1 mode

| | Before | After |
|---|---|---|
| `_raop._tcp` TXT | `am=AudioAccessory5,1`, `vn=3`, AirPlay 2 fields | `am=AirPort4,107`, `vs=105.1`, plus `sf` / `fv` / `da` / `pw`; no `features`/`pk` |
| RTSP `Server:` | `AirTunes/377.40.00` | `AirTunes/105.1` |
| `OPTIONS` `Public:` | includes `FLUSHBUFFERED`, `SETPEERS`, `SETRATEANCHORTIME`, … | the nine classic methods only |
| RTSP port | 7000 | 5000 |

The port matters more than it looks. On 7000 a sender can take the AirPlay 2 path regardless of what the TXT record says — and that path now dead-ends, because `_airplay._tcp` is not advertised. Observed directly: on 7000, iTunes sent a bare `OPTIONS` with no `Apple-Challenge` and disconnected; on 5000 the same client sends a full classic handshake. The listener and the mDNS advert share `AIRPLAY_RTSP_PORT` so they cannot drift apart.

Nothing outside `#ifdef CONFIG_AIRPLAY_FORCE_V1` changes behaviour for AirPlay 2.

## Fix: Apple-Challenge signed the wrong local address

`handle_options()` read the local IP from a hardcoded `WIFI_STA_DEF` netif. On an Ethernet-attached board that handle exists, so `esp_netif_get_ip_info()` returns **`ESP_OK` with `0.0.0.0`** — a silent wrong answer. The receiver then signed the wrong address and the sender walked away without a word.

Now taken from the socket with `getsockname()`, which is what shairport-sync does.

## Fix: the Apple-Challenge response took >800 ms

Long enough for a sender to give up before it arrives. Two causes, both paid on the first request:

- the 2048-bit private key was parsed lazily, inside the first `OPTIONS`;
- `mbedtls_rsa_private()` derives its blinding pair on the first private-key op — an `inv_mod` and an `exp_mod` on the modulus. Later calls only square the cached pair, so the cost is one-off but landed in the worst possible place. (It can't be skipped: mbedTLS 3.x makes the RNG mandatory for private-key ops.)

`rsa_init()` now does both when the RTSP server starts, and the per-request path only pays the CRT exponentiation.

## Verification

- Apple Music for Windows → Esparagus Audio Brick (ESP32, W5500 Ethernet): discovers, completes the handshake, plays.
- The emitted `Apple-Response` was checked against an independent `openssl rsautl -sign` over the same challenge, IP and MAC — byte-identical.
- Builds clean on `esparagus-audio-brick-bt` (forced-v1) and `esp32s3` (default AirPlay 2).
- `clang-format` clean.

## Notes for review

- Bumping the RTSP port in v1 mode changes the SRV record, so senders with a cached Bonjour entry need a flush (`net stop "Bonjour Service"` / `net start` on Windows) before they will reconnect.
- Apple Music for Windows publishes no `_dacp._tcp` service, so the existing "mDNS DACP query failed" warnings are expected with that sender and are harmless. Tidying that message up felt out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RTSP port and discovery identity in v1 mode and serializes shared RSA crypto used in the AirPlay 1 handshake; AirPlay 2 paths are ifdef-gated but handshake timing and IP signing affect every v1 client.
> 
> **Overview**
> **Forced AirPlay v1** now presents as a classic RAOP receiver so RAOP-only clients (notably **Apple Music for Windows**) accept discovery and complete the handshake. With `CONFIG_AIRPLAY_FORCE_V1`, mDNS drops AirPlay 2 markers, uses shairport-sync-style `_raop._tcp` TXT (`AirPort4,107`, `vs=105.1`, etc.), advertises RTSP on **port 5000** (not 7000), answers `OPTIONS` with only classic `Public` methods, and sends **`Server: AirTunes/105.1`** on RTSP/HTTP responses. Listener and Bonjour share **`AIRPLAY_RTSP_PORT`** so SRV and bind cannot diverge. Default AirPlay 2 behavior is unchanged outside the v1 ifdef.
> 
> **AirPlay 1 fixes (all modes):** Apple-Challenge responses now embed the **local IP from `getsockname()`** instead of hardcoded Wi‑Fi STA (fixes silent failure on Ethernet when the netif reports `0.0.0.0`). **RSA setup** is moved to **`rsa_init()`** before the RTSP listener starts (key parse + first blinding warm-up), with a **mutex** around shared mbedTLS RSA state so overlapping client tasks do not corrupt padding/blinding.
> 
> Docs and Kconfig call out Apple Music for Windows and the v1 port/advertisement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28626910c2a30ea7ada1c66d2382e5793d8973b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->