### PR TITLE
Choose AirPlay version at runtime via web

### DIFF
--- a/data/www/index.html
+++ b/data/www/index.html
@@ -62,6 +62,13 @@ input:focus{outline:none;border-color:#e94560}
 <div class='form-group'><label>AirPlay Device Name</label><input type='text' id='dev-name' placeholder='My Speaker'></div>
 <button class='btn btn-primary' onclick='saveName()'>Save Name</button>
 <div id='name-msg'></div>
+<div class='form-group' style='margin-top:18px'><label for='airplay-mode'>AirPlay Mode</label>
+<select id='airplay-mode' onchange='saveAirplayMode()'>
+<option value='0'>AirPlay 2 (default)</option>
+<option value='1'>AirPlay 1 (classic RAOP)</option>
+</select></div>
+<div style='font-size:12px;opacity:0.7;margin-top:-8px;margin-bottom:6px'>Apple Music for Windows only accepts AirPlay 1. iOS still works in that mode, without AirPlay 2 features.</div>
+<div id='airplay-msg'></div>
 <div class='form-group' style='margin-top:18px'><label for='led-brightness'>LED Brightness</label>
 <div class='slider-row'><input type='range' id='led-brightness' min='0' max='255' value='128' oninput='document.getElementById("led-pct").textContent=Math.round(this.value/255*100)+"%"'>
 <span id='led-pct'>50%</span></div></div>
@@ -154,6 +161,7 @@ async function loadChannel(){
 var dualDevices=1;
 var dualPbtl=true;
 var dualLoaded=false;
+var airplayV1=false;
 var chanLocked=false;
 var chanDsp=false;
 /* When the DSP crosses the two outputs over into one speaker there is no
@@ -202,6 +210,20 @@ async function saveDual(){
     if(d.success){dualPbtl=pbtl;msg('dual-msg','Saved! Rewire the speakers, then restart to apply.','ok');}
     else{sel.value=dualPbtl?'1':'0';msg('dual-msg',d.error,'err');}}
   catch(e){sel.value=dualPbtl?'1':'0';msg('dual-msg','Error','err');console.error('saveDual failed',e);}}
+async function loadAirplayMode(){
+  try{var r=await fetch('/api/airplay/mode');if(!r.ok)return;var d=await r.json();
+    if(d.success){airplayV1=!!d.v1;
+      document.getElementById('airplay-mode').value=d.v1?'1':'0';
+      if(d.restart_required){msg('airplay-msg','Restart to apply the new mode.','err');}}}
+  catch(e){console.warn('Could not load AirPlay mode',e);}}
+async function saveAirplayMode(){
+  var sel=document.getElementById('airplay-mode');
+  var v1=sel.value==='1';
+  try{var r=await fetch('/api/airplay/mode',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({v1:v1})});
+    var d=await r.json();
+    if(d.success){airplayV1=v1;msg('airplay-msg',d.restart_required?'Saved! Restart to apply.':'Saved!','ok');}
+    else{sel.value=airplayV1?'1':'0';msg('airplay-msg',d.error,'err');}}
+  catch(e){sel.value=airplayV1?'1':'0';msg('airplay-msg','Error','err');console.error('saveAirplayMode failed',e);}}
 async function saveName(){
   var n=document.getElementById('dev-name').value.trim();if(!n){msg('name-msg','Enter a name','err');return;}
   try{var r=await fetch('/api/device/name',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:n})});
@@ -245,5 +267,5 @@ window.onload=function(){
   document.getElementById('fw-file').onchange=function(e){var f=e.target.files[0];
     document.getElementById('fw-name').textContent=f?f.name:'No file selected';
     document.getElementById('ota-btn').disabled=!f;};
-  loadInfo();loadBrightness();loadChannel();setInterval(loadInfo,30000);};
+  loadInfo();loadBrightness();loadChannel();loadAirplayMode();setInterval(loadInfo,30000);};
 </script></body></html>

--- a/data/www/index.html
+++ b/data/www/index.html
@@ -64,10 +64,10 @@ input:focus{outline:none;border-color:#e94560}
 <div id='name-msg'></div>
 <div class='form-group' style='margin-top:18px'><label for='airplay-mode'>AirPlay Mode</label>
 <select id='airplay-mode' onchange='saveAirplayMode()'>
-<option value='0'>AirPlay 2 (default)</option>
-<option value='1'>AirPlay 1 (classic RAOP)</option>
+<option value='0'>Multi-room (v2)</option>
+<option value='1'>Legacy (v1)</option>
 </select></div>
-<div style='font-size:12px;opacity:0.7;margin-top:-8px;margin-bottom:6px'>Apple Music for Windows only accepts AirPlay 1. iOS still works in that mode, without AirPlay 2 features.</div>
+<div style='font-size:12px;opacity:0.7;margin-top:-8px;margin-bottom:6px'>Some software only works with AirPlay v1.<br>Apple devices still work in that mode, but without v2 features, such as multi-speaker sync.<br>Volume / track seek hardware buttons require version 1.</div>
 <div id='airplay-msg'></div>
 <div class='form-group' style='margin-top:18px'><label for='led-brightness'>LED Brightness</label>
 <div class='slider-row'><input type='range' id='led-brightness' min='0' max='255' value='128' oninput='document.getElementById("led-pct").textContent=Math.round(this.value/255*100)+"%"'>

--- a/docs/features/airplay-tuning.md
+++ b/docs/features/airplay-tuning.md
@@ -49,8 +49,8 @@ If you still hear drop-outs on AirPlay 1 / realtime playback, increase
 
 ## Forcing AirPlay v1
 
-`CONFIG_AIRPLAY_FORCE_V1=y` makes the receiver advertise itself as a classic AirPlay
-receiver. There are two reasons to do this:
+Classic AirPlay v1 makes the receiver advertise itself as a plain RAOP receiver. There are
+two reasons to do this:
 
 - **Hardware buttons.** iOS only sends DACP headers in v1 mode, so this is what makes
   [hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement) work.
@@ -58,7 +58,14 @@ receiver. There are two reasons to do this:
   AirPlay 2 markers, reporting that the device "is not compatible with this version of
   AMPLibraryAgent".
 
-In this mode the receiver mirrors a classic RAOP advertisement: no `_airplay._tcp`
+The mode lives in NVS, so no rebuild is needed. Open the web interface and pick
+**Device Settings → AirPlay Mode**, then restart the device. The mDNS records and the RTSP
+listening port are both built at startup, so the change only takes effect on the next boot.
+
+`CONFIG_AIRPLAY_FORCE_V1=y` sets the mode a freshly flashed device starts in; after that
+the stored value wins.
+
+In v1 mode the receiver mirrors a classic RAOP advertisement: no `_airplay._tcp`
 service, a shairport-sync-style `_raop._tcp` TXT record, `Server: AirTunes/105.1` on RTSP
 responses, and RTSP on port 5000 instead of 7000.
 

--- a/docs/features/airplay-tuning.md
+++ b/docs/features/airplay-tuning.md
@@ -54,9 +54,11 @@ two reasons to do this:
 
 - **Hardware buttons.** iOS only sends DACP headers in v1 mode, so this is what makes
   [hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement) work.
-- **Apple Music for Windows.** It is a RAOP-only sender and refuses any device carrying
-  AirPlay 2 markers, reporting that the device "is not compatible with this version of
-  AMPLibraryAgent".
+- **Apple Music for Windows.** It is a RAOP-only sender and refuses any device that
+  advertises the `_airplay._tcp` service, reporting that the device "is not compatible
+  with this version of AMPLibraryAgent". The device still appears in its picker and it
+  still opens an RTSP connection — it sends `OPTIONS` with an `Apple-Challenge` and then
+  walks away.
 
 The mode lives in NVS, so no rebuild is needed. Open the web interface and pick
 **Device Settings → AirPlay Mode**, then restart the device. The mDNS records and the RTSP
@@ -67,3 +69,9 @@ service, a shairport-sync-style `_raop._tcp` TXT record, `Server: AirTunes/105.1
 responses, and RTSP on port 5000 instead of 7000.
 
 It costs you AirPlay 2 features: HomeKit pairing, encrypted transport and multi-room sync.
+
+There is no setting that keeps both senders happy. The deciding factor for Apple Music is
+the presence of `_airplay._tcp` alone — a receiver publishing a fully classic `_raop._tcp`
+TXT record on port 5000 is still refused while that service is up, and starts working the
+moment it is withdrawn. iOS needs the same service to negotiate AirPlay 2, and a device
+publishes one advertisement, so the mode is a real either/or.

--- a/docs/features/airplay-tuning.md
+++ b/docs/features/airplay-tuning.md
@@ -62,9 +62,6 @@ The mode lives in NVS, so no rebuild is needed. Open the web interface and pick
 **Device Settings → AirPlay Mode**, then restart the device. The mDNS records and the RTSP
 listening port are both built at startup, so the change only takes effect on the next boot.
 
-`CONFIG_AIRPLAY_FORCE_V1=y` sets the mode a freshly flashed device starts in; after that
-the stored value wins.
-
 In v1 mode the receiver mirrors a classic RAOP advertisement: no `_airplay._tcp`
 service, a shairport-sync-style `_raop._tcp` TXT record, `Server: AirTunes/105.1` on RTSP
 responses, and RTSP on port 5000 instead of 7000.

--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -21,7 +21,7 @@ In practice:
 | **Bluetooth** | Works | Works fully via AVRCP passthrough |
 
 To get full button control over AirPlay, switch the receiver to v1 mode in the web
-interface: **Device Settings → AirPlay Mode → AirPlay 1 (classic RAOP)**, then restart the
+interface: **Device Settings → AirPlay Mode → Legacy (v1)**, then restart the
 device.
 
 !!! warning "Trade-off"

--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -24,22 +24,6 @@ To get full button control over AirPlay, switch the receiver to v1 mode in the w
 interface: **Device Settings → AirPlay Mode → AirPlay 1 (classic RAOP)**, then restart the
 device.
 
-If you build your own firmware you can make that the starting mode instead:
-
-```bash
-idf.py menuconfig
-# AirPlay Receiver → AirPlay Protocol
-# Enable "Default to AirPlay v1 (classic) only"
-```
-
-Or in your sdkconfig defaults:
-
-```ini
-CONFIG_AIRPLAY_FORCE_V1=y
-```
-
-Either way the stored setting wins from then on.
-
 !!! warning "Trade-off"
 
     AirPlay v1 disables AirPlay 2 features: HomeKit pairing, encrypted transport and

--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -20,12 +20,16 @@ In practice:
 | **AirPlay v1** (forced) | Works | Works fully via DACP |
 | **Bluetooth** | Works | Works fully via AVRCP passthrough |
 
-To get full button control over AirPlay, force v1 mode:
+To get full button control over AirPlay, switch the receiver to v1 mode in the web
+interface: **Device Settings → AirPlay Mode → AirPlay 1 (classic RAOP)**, then restart the
+device.
+
+If you build your own firmware you can make that the starting mode instead:
 
 ```bash
 idf.py menuconfig
 # AirPlay Receiver → AirPlay Protocol
-# Enable "Force AirPlay v1 (classic) protocol"
+# Enable "Default to AirPlay v1 (classic) only"
 ```
 
 Or in your sdkconfig defaults:
@@ -33,6 +37,8 @@ Or in your sdkconfig defaults:
 ```ini
 CONFIG_AIRPLAY_FORCE_V1=y
 ```
+
+Either way the stored setting wins from then on.
 
 !!! warning "Trade-off"
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -472,9 +472,15 @@ menu "Airplay ESP Configuration"
 
     menu "AirPlay Protocol"
         config AIRPLAY_FORCE_V1
-            bool "Legacy mode: advertise AirPlay v1 (classic) only"
+            bool "Default to AirPlay v1 (classic) only"
             default n
             help
+                Sets the mode a freshly flashed device boots in. The mode
+                is stored in NVS and can be changed at any time from the
+                web interface (Device Settings -> AirPlay Mode), taking
+                effect on the next restart, so this option only picks the
+                starting point.
+
                 By default the receiver accepts BOTH AirPlay 1 (classic
                 RAOP, used by TuneBlade, AirMusic, shairtunes2, older iOS
                 fallback) and AirPlay 2 (HomeKit pairing, HAP-encrypted

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -471,42 +471,6 @@ menu "Airplay ESP Configuration"
     endmenu
 
     menu "AirPlay Protocol"
-        config AIRPLAY_FORCE_V1
-            bool "Default to AirPlay v1 (classic) only"
-            default n
-            help
-                Sets the mode a freshly flashed device boots in. The mode
-                is stored in NVS and can be changed at any time from the
-                web interface (Device Settings -> AirPlay Mode), taking
-                effect on the next restart, so this option only picks the
-                starting point.
-
-                By default the receiver accepts BOTH AirPlay 1 (classic
-                RAOP, used by TuneBlade, AirMusic, shairtunes2, older iOS
-                fallback) and AirPlay 2 (HomeKit pairing, HAP-encrypted
-                transport, used by current iOS). Protocol selection is
-                automatic based on the request shape.
-
-                Enable this option only if AirPlay 2 advertisement causes
-                problems on your network (e.g. iOS preferring AirPlay 2
-                with broken FairPlay verification), or to stream from
-                Apple Music for Windows, which refuses any device that
-                advertises AirPlay 2 markers. It hides the _airplay._tcp
-                service entirely and moves RTSP to the classic RAOP port
-                5000, leaving only _raop._tcp for classic clients. iOS
-                will fall back to AirPlay 1 with DACP remote control.
-
-                When disabled (default), the receiver advertises as an
-                AirPlay 2 device. Modern iOS uses the MRP (Media Remote
-                Protocol) for remote control in AirPlay 2 mode, which
-                is not implemented, so hardware play/pause falls back
-                to local mute.
-
-                Note: AirPlay v1 does not support RSA key exchange for
-                audio encryption in this codebase. The receiver will
-                advertise et=0 (no encryption). If iOS refuses to connect,
-                audio encryption support may need to be added.
-
         config AIRPLAY_TIMING_THRESHOLD_MS
             int "Early/late timing threshold for buffered streams (ms)"
             default 25

--- a/main/network/mdns_airplay.c
+++ b/main/network/mdns_airplay.c
@@ -20,13 +20,10 @@ static const char *TAG = "mdns_airplay";
 
 // Feature flags are defined in rtsp_handlers.h (shared with /info handler)
 
-// Protocol version
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-#define AIRPLAY_PROTOCOL_VERSION "1"
-#else
+// Only ever emitted on the AirPlay 2 records; the classic _raop._tcp TXT has
+// no vv field and _airplay._tcp is not registered at all in v1 mode.
 #define AIRPLAY_PROTOCOL_VERSION "2"
-#endif
-#define AIRPLAY_SOURCE_VERSION "377.40.00"
+#define AIRPLAY_SOURCE_VERSION   "377.40.00"
 
 // Flags: 0x4 = audio receiver
 #define AIRPLAY_FLAGS "0x4"
@@ -79,8 +76,9 @@ void mdns_airplay_init(void) {
   }
 
   // Format features as "hi,lo" hex string
-  snprintf(features_str, sizeof(features_str), "0x%X,0x%X", AIRPLAY_FEATURES_LO,
-           AIRPLAY_FEATURES_HI);
+  uint64_t features = airplay_features();
+  snprintf(features_str, sizeof(features_str), "0x%X,0x%X",
+           (unsigned)(features & 0xFFFFFFFF), (unsigned)(features >> 32));
 
   // Create service name for RAOP: <mac>@<name>
   uint8_t mac[6];
@@ -102,89 +100,95 @@ void mdns_airplay_init(void) {
              device_name);
   }
 
-#ifndef CONFIG_AIRPLAY_FORCE_V1
-  // ========================================
-  // _airplay._tcp service
-  // Only registered for AirPlay 2 mode
-  // ========================================
-  mdns_txt_item_t airplay_txt[] = {
-      {"deviceid", device_id},
-      {"features", features_str},
-      {"flags", AIRPLAY_FLAGS},
-      {"model", AIRPLAY_MODEL},
-      {"pk", pk_str},
-      {"pi", "00000000-0000-0000-0000-000000000000"}, // Pairing identity UUID
-      {"srcvers", AIRPLAY_SOURCE_VERSION},
-      {"vv", AIRPLAY_PROTOCOL_VERSION},
-      {"acl", "0"},
-  };
+  const bool airplay_v1 = settings_airplay_v1();
 
-  esp_err_t err = mdns_service_add(
-      device_name, "_airplay", "_tcp", AIRPLAY_RTSP_PORT, airplay_txt,
-      sizeof(airplay_txt) / sizeof(airplay_txt[0]));
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to add _airplay._tcp service: %s",
-             esp_err_to_name(err));
+  if (!airplay_v1) {
+    // ========================================
+    // _airplay._tcp service
+    // Only registered for AirPlay 2 mode
+    // ========================================
+    mdns_txt_item_t airplay_txt[] = {
+        {"deviceid", device_id},
+        {"features", features_str},
+        {"flags", AIRPLAY_FLAGS},
+        {"model", AIRPLAY_MODEL},
+        {"pk", pk_str},
+        {"pi", "00000000-0000-0000-0000-000000000000"}, // Pairing identity UUID
+        {"srcvers", AIRPLAY_SOURCE_VERSION},
+        {"vv", AIRPLAY_PROTOCOL_VERSION},
+        {"acl", "0"},
+    };
+
+    esp_err_t err = mdns_service_add(
+        device_name, "_airplay", "_tcp", airplay_rtsp_port(), airplay_txt,
+        sizeof(airplay_txt) / sizeof(airplay_txt[0]));
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to add _airplay._tcp service: %s",
+               esp_err_to_name(err));
+    }
   }
-#endif
 
   // ========================================
   // _raop._tcp service
   // RAOP = Remote Audio Output Protocol
   // Service name format: <MAC>@<DeviceName>
   // ========================================
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-  // AirPlay v1 (classic RAOP). This mirrors shairport-sync's classic record
-  // (bonjour_strings.c), which is the advertisement Apple Music on Windows
-  // accepts — it rejects anything carrying AirPlay 2 markers. No features, no
-  // pk, no HAP pairing.
-  mdns_txt_item_t raop_txt[] = {
-      {"am", AIRPLAY_V1_MODEL},
-      {"ch", "2"},                                // Channels
-      {"cn", "0,1"},                              // Audio codecs: PCM, ALAC
-      {"da", "true"},                             // Digest auth
-      {"ek", "1"},                                // Encryption key available
-      {"et", "0,1"},                              // Encryption types: none, RSA
-      {"fv", esp_app_get_description()->version}, // Firmware version
-      {"md", AIRPLAY_METADATA_TYPES},             // Metadata types
-      {"pw", "false"},                            // No password required
-      {"sf", AIRPLAY_FLAGS},                      // Status flags
-      {"sr", "44100"},                            // Sample rate
-      {"ss", "16"},                               // Sample size (bits)
-      {"sv", "false"},                            // Server version (unused)
-      {"tp", "UDP"},                              // Transport protocol
-      {"vn", "65537"},                            // Version number
-      {"vs", AIRPLAY_V1_SOURCE_VERSION},          // Source version
-      {"txtvers", "1"},                           // TXT record version
-  };
-#else
-  // Dual-mode: include et=1 (RSA) so RAOP-only clients (TuneBlade, AirMusic,
-  // shairtunes2, etc.) accept the advertisement, while keeping et=3,5 for
-  // AirPlay 2 FairPlay/MFi-SAP. ek=1 advertises that an RSA-encrypted key
-  // can be supplied via SDP rsaaeskey: at ANNOUNCE time.
-  mdns_txt_item_t raop_txt[] = {
-      {"am", AIRPLAY_MODEL},
-      {"cn", "0,1,2,3"},              // Audio codecs: PCM, ALAC, AAC, AAC-ELD
-      {"da", "true"},                 // Digest auth
-      {"ek", "1"},                    // Encryption key available (RSA)
-      {"et", "0,1,3,5"},              // Encryption types
-      {"ft", features_str},           // Features (same as airplay)
-      {"md", AIRPLAY_METADATA_TYPES}, // Metadata types
-      {"pk", pk_str},                 // Public key
-      {"sf", AIRPLAY_FLAGS},          // Status flags
-      {"tp", "UDP"},                  // Transport protocol
-      {"vn", "65537"},                // Version number
-      {"vs", AIRPLAY_SOURCE_VERSION},
-      {"vv", AIRPLAY_PROTOCOL_VERSION},
-  };
-#endif
-
-  esp_err_t err_raop =
-      mdns_service_add(service_name, "_raop", "_tcp", AIRPLAY_RTSP_PORT,
-                       raop_txt, sizeof(raop_txt) / sizeof(raop_txt[0]));
+  esp_err_t err_raop;
+  if (airplay_v1) {
+    // AirPlay v1 (classic RAOP). This mirrors shairport-sync's classic record
+    // (bonjour_strings.c), which is the advertisement Apple Music on Windows
+    // accepts — it rejects anything carrying AirPlay 2 markers. No features, no
+    // pk, no HAP pairing.
+    mdns_txt_item_t raop_txt[] = {
+        {"am", AIRPLAY_V1_MODEL},
+        {"ch", "2"},    // Channels
+        {"cn", "0,1"},  // Audio codecs: PCM, ALAC
+        {"da", "true"}, // Digest auth
+        {"ek", "1"},    // Encryption key available
+        {"et", "0,1"},  // Encryption types: none, RSA
+        {"fv", esp_app_get_description()->version}, // Firmware version
+        {"md", AIRPLAY_METADATA_TYPES},             // Metadata types
+        {"pw", "false"},                            // No password required
+        {"sf", AIRPLAY_FLAGS},                      // Status flags
+        {"sr", "44100"},                            // Sample rate
+        {"ss", "16"},                               // Sample size (bits)
+        {"sv", "false"},                            // Server version (unused)
+        {"tp", "UDP"},                              // Transport protocol
+        {"vn", "65537"},                            // Version number
+        {"vs", AIRPLAY_V1_SOURCE_VERSION},          // Source version
+        {"txtvers", "1"},                           // TXT record version
+    };
+    err_raop =
+        mdns_service_add(service_name, "_raop", "_tcp", airplay_rtsp_port(),
+                         raop_txt, sizeof(raop_txt) / sizeof(raop_txt[0]));
+  } else {
+    // Dual-mode: include et=1 (RSA) so RAOP-only clients (TuneBlade, AirMusic,
+    // shairtunes2, etc.) accept the advertisement, while keeping et=3,5 for
+    // AirPlay 2 FairPlay/MFi-SAP. ek=1 advertises that an RSA-encrypted key
+    // can be supplied via SDP rsaaeskey: at ANNOUNCE time.
+    mdns_txt_item_t raop_txt[] = {
+        {"am", AIRPLAY_MODEL},
+        {"cn", "0,1,2,3"},              // Audio codecs: PCM, ALAC, AAC, AAC-ELD
+        {"da", "true"},                 // Digest auth
+        {"ek", "1"},                    // Encryption key available (RSA)
+        {"et", "0,1,3,5"},              // Encryption types
+        {"ft", features_str},           // Features (same as airplay)
+        {"md", AIRPLAY_METADATA_TYPES}, // Metadata types
+        {"pk", pk_str},                 // Public key
+        {"sf", AIRPLAY_FLAGS},          // Status flags
+        {"tp", "UDP"},                  // Transport protocol
+        {"vn", "65537"},                // Version number
+        {"vs", AIRPLAY_SOURCE_VERSION},
+        {"vv", AIRPLAY_PROTOCOL_VERSION},
+    };
+    err_raop =
+        mdns_service_add(service_name, "_raop", "_tcp", airplay_rtsp_port(),
+                         raop_txt, sizeof(raop_txt) / sizeof(raop_txt[0]));
+  }
   if (err_raop != ESP_OK) {
     ESP_LOGE(TAG, "Failed to add _raop._tcp service: %s",
              esp_err_to_name(err_raop));
   }
-  ESP_LOGI(TAG, "_raop._tcp advertised on port %d", AIRPLAY_RTSP_PORT);
+  ESP_LOGI(TAG, "_raop._tcp advertised on port %d (AirPlay %s)",
+           airplay_rtsp_port(), airplay_v1 ? "1" : "2");
 }

--- a/main/network/web_server.c
+++ b/main/network/web_server.c
@@ -644,6 +644,63 @@ static esp_err_t dual_mode_post_handler(httpd_req_t *req) {
 }
 #endif /* CONFIG_DAC_TAS58XX */
 
+static esp_err_t airplay_mode_get_handler(httpd_req_t *req) {
+  cJSON *json = cJSON_CreateObject();
+  cJSON_AddBoolToObject(json, "v1", settings_airplay_v1_configured());
+  cJSON_AddNumberToObject(json, "port", airplay_rtsp_port());
+  cJSON_AddBoolToObject(json, "restart_required",
+                        settings_airplay_v1_configured() !=
+                            settings_airplay_v1());
+  cJSON_AddBoolToObject(json, "success", true);
+  char *json_str = cJSON_Print(json);
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req, json_str, HTTPD_RESP_USE_STRLEN);
+  free(json_str);
+  cJSON_Delete(json);
+  return ESP_OK;
+}
+
+static esp_err_t airplay_mode_post_handler(httpd_req_t *req) {
+  char *content = recv_body(req, 128);
+  if (!content) {
+    httpd_resp_send_500(req);
+    return ESP_FAIL;
+  }
+
+  cJSON *json = cJSON_Parse(content);
+  free(content);
+  if (!json) {
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid JSON");
+    return ESP_FAIL;
+  }
+
+  cJSON *response = cJSON_CreateObject();
+  cJSON *val = cJSON_GetObjectItem(json, "v1");
+  if (!val || !cJSON_IsBool(val)) {
+    cJSON_AddBoolToObject(response, "success", false);
+    cJSON_AddStringToObject(response, "error", "Expected {\"v1\": bool}");
+  } else {
+    const bool v1 = cJSON_IsTrue(val);
+    esp_err_t err = settings_set_airplay_v1(v1);
+    cJSON_AddBoolToObject(response, "success", err == ESP_OK);
+    if (err != ESP_OK) {
+      cJSON_AddStringToObject(response, "error", esp_err_to_name(err));
+    } else {
+      // The mDNS records and the RTSP listener are both built at startup.
+      cJSON_AddBoolToObject(response, "restart_required",
+                            v1 != settings_airplay_v1());
+    }
+  }
+
+  char *json_str = cJSON_Print(response);
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req, json_str, HTTPD_RESP_USE_STRLEN);
+  free(json_str);
+  cJSON_Delete(json);
+  cJSON_Delete(response);
+  return ESP_OK;
+}
+
 static esp_err_t ota_update_handler(httpd_req_t *req) {
   if (req->content_len == 0) {
     httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "No firmware uploaded");
@@ -1302,7 +1359,7 @@ esp_err_t web_server_start(uint16_t port) {
   // Slots are allocated up front and httpd_register_uri_handler failures are
   // unchecked, so an undercount silently drops whatever registers last, which
   // is log_stream's /ws/logs. Keep these in step with the handlers below.
-  config.max_uri_handlers = 32; // 26 here + /ws/logs, plus 5 spare
+  config.max_uri_handlers = 34; // 28 here + /ws/logs, plus 5 spare
 #ifdef DAC_HAS_SUB_OFFSET
   config.max_uri_handlers += 2; // sub level get/post
 #endif
@@ -1411,6 +1468,16 @@ esp_err_t web_server_start(uint16_t port) {
                                     .handler = dual_mode_post_handler};
   httpd_register_uri_handler(s_server, &dual_mode_post_uri);
 #endif
+
+  httpd_uri_t airplay_mode_get_uri = {.uri = "/api/airplay/mode",
+                                      .method = HTTP_GET,
+                                      .handler = airplay_mode_get_handler};
+  httpd_register_uri_handler(s_server, &airplay_mode_get_uri);
+
+  httpd_uri_t airplay_mode_post_uri = {.uri = "/api/airplay/mode",
+                                       .method = HTTP_POST,
+                                       .handler = airplay_mode_post_handler};
+  httpd_register_uri_handler(s_server, &airplay_mode_post_uri);
 
   httpd_uri_t ota_uri = {.uri = "/api/ota/update",
                          .method = HTTP_POST,

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -38,6 +38,10 @@
 
 static const char *TAG = "rtsp_handlers";
 
+uint64_t airplay_features(void) {
+  return settings_airplay_v1() ? UINT64_C(0x5C4A00) : UINT64_C(0x1C340405C4A00);
+}
+
 // ============================================================================
 // Codec Registry
 // ============================================================================
@@ -508,18 +512,15 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
 static void handle_options(int socket, rtsp_conn_t *conn,
                            const rtsp_request_t *req, const uint8_t *raw,
                            size_t raw_len) {
-#ifdef CONFIG_AIRPLAY_FORCE_V1
   // A classic-only sender inspects this list; the AirPlay 2 methods are enough
   // for Apple Music on Windows to give up straight after OPTIONS.
   const char *public_methods =
-      "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, "
-      "GET_PARAMETER, SET_PARAMETER\r\n";
-#else
-  const char *public_methods =
-      "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, FLUSHBUFFERED, TEARDOWN, "
-      "OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, SETPEERS, "
-      "SETRATEANCHORTIME\r\n";
-#endif
+      settings_airplay_v1()
+          ? "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, "
+            "GET_PARAMETER, SET_PARAMETER\r\n"
+          : "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, FLUSHBUFFERED, "
+            "TEARDOWN, OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, "
+            "SETPEERS, SETRATEANCHORTIME\r\n";
 
   // AirPlay v1: handle Apple-Challenge if present. Triggered by request
   // shape, so safe unconditionally — iOS in AirPlay 2 mode does not send
@@ -571,14 +572,9 @@ static void handle_get(int socket, rtsp_conn_t *conn, const rtsp_request_t *req,
     rtsp_get_device_id(device_id, sizeof(device_id));
     settings_get_device_name(device_name, sizeof(device_name));
     const uint8_t *pk = hap_get_public_key();
-    uint64_t features =
-        ((uint64_t)AIRPLAY_FEATURES_HI << 32) | AIRPLAY_FEATURES_LO;
+    uint64_t features = airplay_features();
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-    int64_t protocol_version = 1;
-#else
-    int64_t protocol_version = 2;
-#endif
+    int64_t protocol_version = settings_airplay_v1() ? 1 : 2;
 
     if (request_uses_rtsp(req)) {
       static uint8_t body[1024];

--- a/main/rtsp/rtsp_handlers.c
+++ b/main/rtsp/rtsp_handlers.c
@@ -512,22 +512,26 @@ int rtsp_dispatch(int socket, rtsp_conn_t *conn, const uint8_t *raw_request,
 static void handle_options(int socket, rtsp_conn_t *conn,
                            const rtsp_request_t *req, const uint8_t *raw,
                            size_t raw_len) {
-  // A classic-only sender inspects this list; the AirPlay 2 methods are enough
-  // for Apple Music on Windows to give up straight after OPTIONS.
-  const char *public_methods =
-      settings_airplay_v1()
-          ? "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, "
-            "GET_PARAMETER, SET_PARAMETER\r\n"
-          : "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, FLUSHBUFFERED, "
-            "TEARDOWN, OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, "
-            "SETPEERS, SETRATEANCHORTIME\r\n";
-
   // AirPlay v1: handle Apple-Challenge if present. Triggered by request
   // shape, so safe unconditionally — iOS in AirPlay 2 mode does not send
   // this header.
   const char *challenge = parse_raw_header(raw, raw_len, "Apple-Challenge:");
   if (challenge) {
     conn->protocol_version = 1;
+  }
+
+  // A classic-only sender inspects this list and gives up straight after
+  // OPTIONS if it sees the AirPlay 2 methods, so answer in the dialect this
+  // connection is speaking rather than the one the receiver advertises.
+  const char *public_methods =
+      (conn->protocol_version == 1 || settings_airplay_v1())
+          ? "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, TEARDOWN, OPTIONS, "
+            "GET_PARAMETER, SET_PARAMETER\r\n"
+          : "Public: ANNOUNCE, SETUP, RECORD, PAUSE, FLUSH, FLUSHBUFFERED, "
+            "TEARDOWN, OPTIONS, POST, GET, SET_PARAMETER, GET_PARAMETER, "
+            "SETPEERS, SETRATEANCHORTIME\r\n";
+
+  if (challenge) {
     // The sender verifies that the response embeds the address it connected
     // to, so take it from the socket: hardcoding the WiFi netif yields 0.0.0.0
     // on an Ethernet-attached board and the sender then walks away silently.

--- a/main/rtsp/rtsp_handlers.h
+++ b/main/rtsp/rtsp_handlers.h
@@ -13,18 +13,16 @@
  * Inspired by shairport-sync's method_handlers pattern
  */
 
-// Key bits:
-//   Bit 38: SupportsCoreUtilsPairingAndEncryption
-//   Bit 46: SupportsHKPairingAndAccessControl
-//   Bit 48: SupportsTransientPairing
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-// AirPlay v1: strip pairing/encryption bits so iOS uses classic RAOP
-#define AIRPLAY_FEATURES_HI 0x0
-#define AIRPLAY_FEATURES_LO 0x5C4A00
-#else
-#define AIRPLAY_FEATURES_HI 0x1C340
-#define AIRPLAY_FEATURES_LO 0x405C4A00
-#endif
+/**
+ * AirPlay feature bits, as (hi << 32) | lo.
+ *
+ * Key bits:
+ *   Bit 38: SupportsCoreUtilsPairingAndEncryption
+ *   Bit 46: SupportsHKPairingAndAccessControl
+ *   Bit 48: SupportsTransientPairing
+ * AirPlay 1 strips the pairing/encryption bits so iOS uses classic RAOP.
+ */
+uint64_t airplay_features(void);
 
 // Audio buffer size for buffered streams (type 103).  The sender queues this
 // much audio ahead, and on a seek/skip every queued byte is stale but still has

--- a/main/rtsp/rtsp_message.c
+++ b/main/rtsp/rtsp_message.c
@@ -13,10 +13,13 @@
 static const char *TAG = "rtsp_message";
 
 // A classic sender reads the source version here too, not just in the mDNS TXT
-// record, and rejects an AirPlay 2 one.
-static const char *rtsp_server_header(void) {
-  return settings_airplay_v1() ? "Server: AirTunes/105.1\r\n"
-                               : "Server: AirTunes/377.40.00\r\n";
+// record, and rejects an AirPlay 2 one. Answer per-connection: a v2 receiver
+// still has to speak 105.1 to a classic sender that found it anyway.
+static const char *rtsp_server_header(const rtsp_conn_t *conn) {
+  const bool classic =
+      (conn && conn->protocol_version == 1) || settings_airplay_v1();
+  return classic ? "Server: AirTunes/105.1\r\n"
+                 : "Server: AirTunes/377.40.00\r\n";
 }
 
 const uint8_t *rtsp_find_header_end(const uint8_t *data, size_t len) {
@@ -169,7 +172,7 @@ int rtsp_send_response(int socket, rtsp_conn_t *conn, int status_code,
                        size_t body_len) {
   char header[1024];
   int header_len;
-  const char *server_hdr = rtsp_server_header();
+  const char *server_hdr = rtsp_server_header(conn);
 
   if (extra_headers && body && body_len > 0) {
     header_len = snprintf(header, sizeof(header),
@@ -243,7 +246,7 @@ int rtsp_send_http_response(int socket, rtsp_conn_t *conn, int status_code,
                             "CSeq: 1\r\n"
                             "\r\n",
                             status_code, status_text, content_type, body_len,
-                            rtsp_server_header());
+                            rtsp_server_header(conn));
 
   // Build complete response
   size_t total_len = (size_t)header_len + body_len;

--- a/main/rtsp/rtsp_message.c
+++ b/main/rtsp/rtsp_message.c
@@ -8,16 +8,16 @@
 
 #include "esp_log.h"
 #include "rtsp_crypto.h"
+#include "settings.h"
 
 static const char *TAG = "rtsp_message";
 
 // A classic sender reads the source version here too, not just in the mDNS TXT
 // record, and rejects an AirPlay 2 one.
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-#define RTSP_SERVER_HEADER "Server: AirTunes/105.1\r\n"
-#else
-#define RTSP_SERVER_HEADER "Server: AirTunes/377.40.00\r\n"
-#endif
+static const char *rtsp_server_header(void) {
+  return settings_airplay_v1() ? "Server: AirTunes/105.1\r\n"
+                               : "Server: AirTunes/377.40.00\r\n";
+}
 
 const uint8_t *rtsp_find_header_end(const uint8_t *data, size_t len) {
   for (size_t i = 0; i + 3 < len; i++) {
@@ -169,33 +169,35 @@ int rtsp_send_response(int socket, rtsp_conn_t *conn, int status_code,
                        size_t body_len) {
   char header[1024];
   int header_len;
+  const char *server_hdr = rtsp_server_header();
 
   if (extra_headers && body && body_len > 0) {
-    header_len =
-        snprintf(header, sizeof(header),
-                 "RTSP/1.0 %d %s\r\n"
-                 "CSeq: %d\r\n" RTSP_SERVER_HEADER "%s"
-                 "Content-Length: %zu\r\n"
-                 "\r\n",
-                 status_code, status_text, cseq, extra_headers, body_len);
-  } else if (extra_headers) {
     header_len = snprintf(header, sizeof(header),
                           "RTSP/1.0 %d %s\r\n"
-                          "CSeq: %d\r\n" RTSP_SERVER_HEADER "%s"
+                          "CSeq: %d\r\n%s%s"
+                          "Content-Length: %zu\r\n"
                           "\r\n",
-                          status_code, status_text, cseq, extra_headers);
-  } else if (body && body_len > 0) {
+                          status_code, status_text, cseq, server_hdr,
+                          extra_headers, body_len);
+  } else if (extra_headers) {
     header_len =
         snprintf(header, sizeof(header),
                  "RTSP/1.0 %d %s\r\n"
-                 "CSeq: %d\r\n" RTSP_SERVER_HEADER "Content-Length: %zu\r\n"
+                 "CSeq: %d\r\n%s%s"
                  "\r\n",
-                 status_code, status_text, cseq, body_len);
+                 status_code, status_text, cseq, server_hdr, extra_headers);
+  } else if (body && body_len > 0) {
+    header_len = snprintf(header, sizeof(header),
+                          "RTSP/1.0 %d %s\r\n"
+                          "CSeq: %d\r\n%s"
+                          "Content-Length: %zu\r\n"
+                          "\r\n",
+                          status_code, status_text, cseq, server_hdr, body_len);
   } else {
     header_len = snprintf(header, sizeof(header),
                           "RTSP/1.0 %d %s\r\n"
-                          "CSeq: %d\r\n" RTSP_SERVER_HEADER "\r\n",
-                          status_code, status_text, cseq);
+                          "CSeq: %d\r\n%s\r\n",
+                          status_code, status_text, cseq, server_hdr);
   }
 
   // Build complete response
@@ -234,13 +236,14 @@ int rtsp_send_http_response(int socket, rtsp_conn_t *conn, int status_code,
                             const char *status_text, const char *content_type,
                             const char *body, size_t body_len) {
   char header[512];
-  int header_len =
-      snprintf(header, sizeof(header),
-               "HTTP/1.1 %d %s\r\n"
-               "Content-Type: %s\r\n"
-               "Content-Length: %zu\r\n" RTSP_SERVER_HEADER "CSeq: 1\r\n"
-               "\r\n",
-               status_code, status_text, content_type, body_len);
+  int header_len = snprintf(header, sizeof(header),
+                            "HTTP/1.1 %d %s\r\n"
+                            "Content-Type: %s\r\n"
+                            "Content-Length: %zu\r\n%s"
+                            "CSeq: 1\r\n"
+                            "\r\n",
+                            status_code, status_text, content_type, body_len,
+                            rtsp_server_header());
 
   // Build complete response
   size_t total_len = (size_t)header_len + body_len;

--- a/main/rtsp/rtsp_server.c
+++ b/main/rtsp/rtsp_server.c
@@ -24,11 +24,11 @@
 #include "ntp_clock.h"
 #include "ptp_clock.h"
 #include "rtsp_events.h"
+#include "settings.h"
 #include "dacp_client.h"
 
 static const char *TAG = "rtsp_server";
 
-#define RTSP_PORT           AIRPLAY_RTSP_PORT
 #define RTSP_BUFFER_INITIAL 4096
 #define RTSP_BUFFER_LARGE   ((size_t)256 * 1024)
 
@@ -77,6 +77,10 @@ int32_t airplay_get_volume_q15(void) {
 
 void rtsp_server_request_resume(void) {
   s_resume_requested = true;
+}
+
+uint16_t airplay_rtsp_port(void) {
+  return settings_airplay_v1() ? 5000 : 7000;
 }
 
 // Helper to grow buffer
@@ -425,7 +429,7 @@ static void server_task(void *pvParameters) {
   memset(&server_addr, 0, sizeof(server_addr));
   server_addr.sin_family = AF_INET;
   server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  server_addr.sin_port = htons(RTSP_PORT);
+  server_addr.sin_port = htons(airplay_rtsp_port());
 
   if (bind(server_socket, (struct sockaddr *)&server_addr,
            sizeof(server_addr)) < 0) {
@@ -446,7 +450,7 @@ static void server_task(void *pvParameters) {
     return;
   }
 
-  ESP_LOGI(TAG, "RTSP server listening on port %d", RTSP_PORT);
+  ESP_LOGI(TAG, "RTSP server listening on port %d", airplay_rtsp_port());
   server_running = true;
 
   while (server_running) {

--- a/main/rtsp/rtsp_server.h
+++ b/main/rtsp/rtsp_server.h
@@ -3,14 +3,14 @@
 #include "esp_err.h"
 #include <stdint.h>
 
-// 7000 is the AirPlay 2 port; classic RAOP lives on 5000, and a sender that
-// sees 7000 in the SRV record may take the AirPlay 2 path regardless of the
-// TXT record. The mDNS advertisement must use the same number.
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-#define AIRPLAY_RTSP_PORT 5000
-#else
-#define AIRPLAY_RTSP_PORT 7000
-#endif
+/**
+ * Port the RTSP server listens on, which the mDNS advertisement must match.
+ *
+ * 7000 is the AirPlay 2 port; classic RAOP lives on 5000, and a sender that
+ * sees 7000 in the SRV record may take the AirPlay 2 path regardless of the
+ * TXT record.
+ */
+uint16_t airplay_rtsp_port(void);
 
 /**
  * Start the AirPlay RTSP server.

--- a/main/settings.c
+++ b/main/settings.c
@@ -39,11 +39,7 @@ static uint8_t g_bt_volume = 64; /* default: 50 % */
 static bool g_bt_volume_loaded = false;
 #endif
 
-#ifdef CONFIG_AIRPLAY_FORCE_V1
-static bool g_airplay_v1 = true;
-#else
-static bool g_airplay_v1 = false;
-#endif
+static bool g_airplay_v1;
 static bool g_airplay_v1_configured;
 
 esp_err_t settings_init(void) {

--- a/main/settings.c
+++ b/main/settings.c
@@ -24,6 +24,7 @@ static const char *TAG = "settings";
 #define NVS_KEY_AMP_MUTE       "amp_mute"
 #define NVS_KEY_AMP_MIX        "amp_mix"
 #define NVS_KEY_SECOND_PBTL    "amp2_pbtl"
+#define NVS_KEY_AIRPLAY_V1     "ap_v1"
 
 #define MAX_WIFI_SSID_LEN     32
 #define MAX_WIFI_PASSWORD_LEN 64
@@ -38,6 +39,13 @@ static uint8_t g_bt_volume = 64; /* default: 50 % */
 static bool g_bt_volume_loaded = false;
 #endif
 
+#ifdef CONFIG_AIRPLAY_FORCE_V1
+static bool g_airplay_v1 = true;
+#else
+static bool g_airplay_v1 = false;
+#endif
+static bool g_airplay_v1_configured;
+
 esp_err_t settings_init(void) {
   // Load volume on init
   nvs_handle_t nvs;
@@ -51,8 +59,17 @@ esp_err_t settings_init(void) {
       ESP_LOGI(TAG, "Loaded volume: %.2f dB", g_volume_db);
     }
 
+    uint8_t airplay_v1;
+    if (nvs_get_u8(nvs, NVS_KEY_AIRPLAY_V1, &airplay_v1) == ESP_OK) {
+      g_airplay_v1 = airplay_v1 != 0;
+      ESP_LOGI(TAG, "Loaded AirPlay mode: %s",
+               g_airplay_v1 ? "v1 (classic RAOP)" : "v2");
+    }
+
     nvs_close(nvs);
   }
+
+  g_airplay_v1_configured = g_airplay_v1;
 
   return ESP_OK;
 }
@@ -654,6 +671,43 @@ esp_err_t settings_set_second_pbtl(bool pbtl) {
   } else {
     ESP_LOGE(TAG, "Failed to save second amplifier wiring: %s",
              esp_err_to_name(err));
+  }
+  return err;
+}
+
+/* ================================================================== */
+/*  AirPlay protocol mode                                             */
+/* ================================================================== */
+
+bool settings_airplay_v1(void) {
+  return g_airplay_v1;
+}
+
+bool settings_airplay_v1_configured(void) {
+  return g_airplay_v1_configured;
+}
+
+esp_err_t settings_set_airplay_v1(bool v1) {
+  nvs_handle_t nvs;
+  esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to open NVS: %s", esp_err_to_name(err));
+    return err;
+  }
+
+  err = nvs_set_u8(nvs, NVS_KEY_AIRPLAY_V1, v1 ? 1 : 0);
+  if (err == ESP_OK) {
+    err = nvs_commit(nvs);
+  }
+  nvs_close(nvs);
+
+  if (err == ESP_OK) {
+    // Deliberately not applied to g_airplay_v1: the running services were
+    // built around the old value and only a restart can rebuild them.
+    g_airplay_v1_configured = v1;
+    ESP_LOGI(TAG, "Saved AirPlay mode: %s", v1 ? "v1 (classic RAOP)" : "v2");
+  } else {
+    ESP_LOGE(TAG, "Failed to save AirPlay mode: %s", esp_err_to_name(err));
   }
   return err;
 }

--- a/main/settings.h
+++ b/main/settings.h
@@ -118,6 +118,34 @@ esp_err_t settings_set_device_name(const char *name);
 void settings_device_name_to_hostname(const char *name, char *out,
                                       size_t out_len);
 
+// ---- AirPlay protocol mode ----
+
+/**
+ * Whether the receiver presents itself as a classic AirPlay 1 (RAOP) device.
+ *
+ * This is the mode the running services were built around, fixed at
+ * settings_init(). The RTSP and mDNS paths must use it rather than the
+ * configured value, or a mid-session change would leave the TXT record and
+ * the listening port disagreeing. Defaults to CONFIG_AIRPLAY_FORCE_V1.
+ */
+bool settings_airplay_v1(void);
+
+/**
+ * The AirPlay mode held in storage, which takes effect on the next boot.
+ * Differs from settings_airplay_v1() only after a change that needs a restart.
+ */
+bool settings_airplay_v1_configured(void);
+
+/**
+ * Save the AirPlay protocol mode to persistent storage.
+ *
+ * Takes effect on restart: the advertised services and the RTSP port are both
+ * fixed while the receiver is running.
+ *
+ * @param v1 true for classic AirPlay 1 (RAOP), false for AirPlay 2
+ */
+esp_err_t settings_set_airplay_v1(bool v1);
+
 // ---- LED settings ----
 
 /**

--- a/main/settings.h
+++ b/main/settings.h
@@ -126,7 +126,7 @@ void settings_device_name_to_hostname(const char *name, char *out,
  * This is the mode the running services were built around, fixed at
  * settings_init(). The RTSP and mDNS paths must use it rather than the
  * configured value, or a mid-session change would leave the TXT record and
- * the listening port disagreeing. Defaults to CONFIG_AIRPLAY_FORCE_V1.
+ * the listening port disagreeing. Defaults to AirPlay 2.
  */
 bool settings_airplay_v1(void);
 


### PR DESCRIPTION
Fixes #88 for anyone running a prebuilt binary.

`CONFIG_AIRPLAY_FORCE_V1` was the only route to classic RAOP, which meant that using Apple Music for Windows — a RAOP-only sender that rejects any device carrying AirPlay 2 markers — required setting up an ESP-IDF toolchain first. The reporter on #88 is on the released `airplay2-receiver-esp32s3.bin`, so that was never a usable answer for them.

## Choose AirPlay version at runtime via web

The receiver's AirPlay protocol version is now a runtime setting instead of a
build-time one. Pick **Device Settings → AirPlay Mode** in the web interface and
restart; the mDNS records and the RTSP listening port are both built at startup,
so the change lands on the next boot.

### Why a switch is needed at all

Apple Music for Windows is a RAOP-only sender. It refuses any device that
advertises the `_airplay._tcp` service — and that service alone is the deciding
factor. Bisected on hardware:

| `_raop` TXT | RTSP port | `_airplay._tcp` | Apple Music for Windows |
| --- | --- | --- | --- |
| AirPlay 2 | 7000 | present | refused |
| AirPlay 2 | 5000 | present | refused |
| fully classic | 5000 | present | refused |
| fully classic | 5000 | **absent** | **plays** |

Every `_raop._tcp` TXT marker (`vv`, `ft`, `pk`, `am`, `vs`, `cn`, `et`) and the
RTSP port were each ruled out individually. Since iOS needs `_airplay._tcp` to
negotiate AirPlay 2, and a device publishes one advertisement, no single
configuration satisfies both senders. The mode is a genuine either/or, which is
what makes a runtime switch worthwhile.

Hardware transport buttons need v1 for a separate reason: iOS only sends DACP
headers in classic mode.

### Changes

- **Runtime mode setting.** Stored in NVS, exposed via `GET`/`POST
  /api/airplay/mode` and a dropdown in the web UI. Selects the advertised
  services, the `_raop._tcp` TXT record, the RTSP port (5000 vs 7000) and the
  `Server:` header.
- **`CONFIG_AIRPLAY_FORCE_V1` removed.** The Kconfig option only set the initial
  default and is redundant now the setting persists. No shipped
  `sdkconfig.defaults` enabled it, so stock builds are unaffected.
- **Per-connection protocol dialect.** `conn->protocol_version` was already set
  to 1 by an incoming `Apple-Challenge`, but the `Server:` header and the
  `Public:` method list were still chosen from the global mode — so a classic
  sender that reached a v2-mode receiver got `AirTunes/377.40.00` and the
  AirPlay 2 method list. Both are now answered from the connection, and the
  challenge is parsed before the method list is built so the same `OPTIONS`
  gets the classic reply.
- **Docs.** `airplay-tuning.md` records the `_airplay._tcp` finding and that the
  two senders cannot be served at once; `buttons.md` tracks the new dropdown
  label.

### Testing

Hardware-tested on an Esparagus Audio Brick (ESP32 + TAS5825M):

- **v2 mode / iPhone** — full AirPlay 2: `stream_type=103`, AAC
  (`ct=4, sr=44100, spf=1024`), PTP `LOCKED`.
- **v1 mode / Apple Music for Windows** — `ANNOUNCE` → `SETUP` → `RECORD` →
  audio, ALAC (`ct=2, sr=44100, spf=352`) with NTP timing.
- **v2 mode / Apple Music for Windows** — still refused, as expected; it
  connects, sends `OPTIONS` with an `Apple-Challenge`, and walks away.
- Mode toggle and restart exercised repeatedly via the web UI and the API.

`clang-format` clean, `esparagus-audio-brick-bt` builds, `zensical build
--strict` reports no issues.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core AirPlay discovery and RTSP advertisement paths; a bug could break pairing or leave v1/v2 clients unable to connect until restart.
> 
> **Overview**
> **AirPlay v1 vs v2 is no longer a compile-time Kconfig switch.** The `CONFIG_AIRPLAY_FORCE_V1` menu option is removed; mode is stored in NVS (`ap_v1`) and exposed on the web under **Device Settings → AirPlay Mode**, with `GET`/`POST` **`/api/airplay/mode`** returning `restart_required` when the saved value does not match what the running stack was built with.
> 
> **Runtime behavior is split on purpose:** `settings_airplay_v1()` is fixed at boot for mDNS and the RTSP listener; writes only update `settings_airplay_v1_configured()` until reboot, so advertisement port/TXT records cannot drift mid-session. Helpers **`airplay_rtsp_port()`** (5000 vs 7000) and **`airplay_features()`** replace compile-time port/feature macros across mDNS, RTSP `/info`, OPTIONS `Public` methods, and dynamic `Server: AirTunes/…` headers.
> 
> Docs for forcing v1 (hardware buttons, Apple Music for Windows) now point at the web UI instead of `menuconfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec4989103e2ee1dadfbcfd728106090020baeda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->