### PR TITLE
Gzip the web UI so the SPIFFS image fits a 4 MB board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,4 +35,14 @@ include(cmake/fix_usb_device_uac_platformio.cmake)
 #   - components/dac_tas57xx/ (HybridFlow DAC firmware)
 #   - components/display/     (ST7789 background image)
 # Flash firmware + SPIFFS together with: idf.py build flash
-spiffs_create_partition_image(storage "${CMAKE_SOURCE_DIR}/data" FLASH_IN_PROJECT)
+#
+# data/ is staged through a script that gzips the pages first: raw, the web UI
+# alone overflows the 188 KB SPIFFS partition on a 4 MB board.
+set(spiffs_image_dir "${CMAKE_BINARY_DIR}/spiffs_image")
+add_custom_target(
+  spiffs_image_stage ALL
+  COMMAND ${PYTHON} "${CMAKE_SOURCE_DIR}/scripts/gen_spiffs_image.py"
+          "${CMAKE_SOURCE_DIR}/data" "${spiffs_image_dir}"
+  VERBATIM)
+spiffs_create_partition_image(storage "${spiffs_image_dir}" FLASH_IN_PROJECT
+                              DEPENDS spiffs_image_stage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,16 @@ include(cmake/fix_usb_device_uac_platformio.cmake)
 # data/ is staged through a script that gzips the pages first: raw, the web UI
 # alone overflows the 188 KB SPIFFS partition on a 4 MB board.
 set(spiffs_image_dir "${CMAKE_BINARY_DIR}/spiffs_image")
+set(spiffs_stage_args "")
+if(NOT CONFIG_DAC_TAS57XX)
+  # Only dac_tas57xx reads the HybridFlow bases. The rest of hf/ stays: that is
+  # where a TAS58xx user drops their own PPC3 dumps.
+  list(APPEND spiffs_stage_args --exclude "hf/base-hf*.bin")
+endif()
 add_custom_target(
   spiffs_image_stage ALL
   COMMAND ${PYTHON} "${CMAKE_SOURCE_DIR}/scripts/gen_spiffs_image.py"
-          "${CMAKE_SOURCE_DIR}/data" "${spiffs_image_dir}"
+          ${spiffs_stage_args} "${CMAKE_SOURCE_DIR}/data" "${spiffs_image_dir}"
   VERBATIM)
 spiffs_create_partition_image(storage "${spiffs_image_dir}" FLASH_IN_PROJECT
                               DEPENDS spiffs_image_stage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,14 @@ include(cmake/fix_usb_device_uac_platformio.cmake)
 # alone overflows the 188 KB SPIFFS partition on a 4 MB board.
 set(spiffs_image_dir "${CMAKE_BINARY_DIR}/spiffs_image")
 set(spiffs_stage_args "")
+# Both DAC drivers keep their DSP images in hf/, so each build carries only the
+# family it can actually load.
 if(NOT CONFIG_DAC_TAS57XX)
-  # Only dac_tas57xx reads the HybridFlow bases. The rest of hf/ stays: that is
-  # where a TAS58xx user drops their own PPC3 dumps.
-  list(APPEND spiffs_stage_args --exclude "hf/base-hf*.bin")
+  list(APPEND spiffs_stage_args --exclude "hf/base-hf*.bin"
+       --exclude "hf/tas57xx_fw*.bin")
+endif()
+if(NOT CONFIG_DAC_TAS58XX)
+  list(APPEND spiffs_stage_args --exclude "hf/tas5825m_fw*.bin")
 endif()
 add_custom_target(
   spiffs_image_stage ALL

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,15 @@ and a version is tagged.
 `version.txt` on `staging` must stay ahead of the latest release or the beta job fails, so
 bump it as soon as a release goes out.
 
+!!! warning "Rebase before merging"
+
+    A pull request is checked against `staging` **as it was when the check ran**. If
+    another PR merges in the meantime, a green tick can go red on merge — two branches
+    that touch different files merge without conflict but can still break the build
+    together, which is exactly how the SPIFFS partition overflowed once already.
+    Enable *Require branches to be up to date before merging* on `staging`, or rebase
+    and wait for a fresh run before merging anything non-trivial.
+
 ## CI
 
 On every pull request to `main` or `staging`, and on every push to `main`:

--- a/docs/reference/spiffs.md
+++ b/docs/reference/spiffs.md
@@ -24,6 +24,7 @@ data/
 │   ├── index.html     # Setup and control panel
 │   ├── logs.html      # Live log viewer
 │   ├── bq.html        # Parametric biquad chains (TAS5825M boards)
+│   ├── hf.html        # Hybrid flow tuning (SqueezeAMP)
 │   └── speedtest.html # Network throughput test
 ├── hf/                # DSP programs loaded at boot
 │   ├── base-hf1-44100.bin  # Hybrid flow 1 base image (SqueezeAMP)
@@ -37,6 +38,20 @@ The `hf/` names carry the sample rate the DSP image was built for, and a 48000 t
 beside each. Only the hybrid flow base images ship with the repository; a PPC3 dump is
 yours to export and drop in, as is the background image — at 106 KB it does not fit
 alongside the web UI on a 4 MB board.
+
+## Compression
+
+`data/` is not flashed verbatim. `scripts/gen_spiffs_image.py` stages it first and gzips
+every `.html`, so the image holds `index.html.gz` rather than `index.html`. That takes the
+payload from 256 KB to 101 KB, which matters because the smallest layout gives SPIFFS only
+188 KB — the pages alone overflow it uncompressed. Pages also load noticeably faster over
+WiFi.
+
+The web server asks for the `.gz` first and sets `Content-Encoding: gzip`; browsers
+decompress transparently. It falls back to an uncompressed file of the same name, so a page
+uploaded through `/api/fs/upload` still works. The `hf/` and `bg/` binaries are read
+straight off the filesystem by the DAC and display drivers, which cannot decompress, so
+they are copied through untouched.
 
 ## Flashing the image
 

--- a/docs/reference/spiffs.md
+++ b/docs/reference/spiffs.md
@@ -53,6 +53,11 @@ uploaded through `/api/fs/upload` still works. The `hf/` and `bg/` binaries are 
 straight off the filesystem by the DAC and display drivers, which cannot decompress, so
 they are copied through untouched.
 
+Staging also drops what a build cannot use. `hf/base-hf*.bin` are HybridFlow bases that
+only the TAS57xx driver reads, so they are left out unless `CONFIG_DAC_TAS57XX` is set —
+another 24 KB back on every other board, taking the image to 78 KB. Anything else you put
+in `hf/`, such as a TAS58xx PPC3 dump, is always included.
+
 Both build systems go through that staging step. ESP-IDF runs it from `CMakeLists.txt`
 before `spiffs_create_partition_image`, and PlatformIO — which packs `data/` itself rather
 than using the image CMake builds — runs it from `scripts/pio_stage_spiffs.py`, wired in as

--- a/docs/reference/spiffs.md
+++ b/docs/reference/spiffs.md
@@ -53,6 +53,12 @@ uploaded through `/api/fs/upload` still works. The `hf/` and `bg/` binaries are 
 straight off the filesystem by the DAC and display drivers, which cannot decompress, so
 they are copied through untouched.
 
+Both build systems go through that staging step. ESP-IDF runs it from `CMakeLists.txt`
+before `spiffs_create_partition_image`, and PlatformIO — which packs `data/` itself rather
+than using the image CMake builds — runs it from `scripts/pio_stage_spiffs.py`, wired in as
+an `extra_scripts` hook. So `idf.py flash`, `pio run -t uploadfs` and the prebuilt release
+binaries all end up with the same filesystem.
+
 ## Flashing the image
 
 !!! warning "PlatformIO does not do this for you"

--- a/docs/reference/spiffs.md
+++ b/docs/reference/spiffs.md
@@ -47,16 +47,17 @@ payload from 256 KB to 101 KB, which matters because the smallest layout gives S
 188 KB — the pages alone overflow it uncompressed. Pages also load noticeably faster over
 WiFi.
 
-The web server asks for the `.gz` first and sets `Content-Encoding: gzip`; browsers
-decompress transparently. It falls back to an uncompressed file of the same name, so a page
-uploaded through `/api/fs/upload` still works. The `hf/` and `bg/` binaries are read
-straight off the filesystem by the DAC and display drivers, which cannot decompress, so
-they are copied through untouched.
+The image only ever stores the `.gz`, so the web server tries the plain name first and falls
+back to `<path>.gz`, setting `Content-Encoding: gzip` when it serves one; browsers
+decompress transparently. That order is what makes `/api/fs/upload` useful — an uploaded
+`index.html` replaces the page that shipped, and deleting it again restores the built-in
+one. The `hf/` and `bg/` binaries are read straight off the filesystem by the DAC and
+display drivers, which cannot decompress, so they are copied through untouched.
 
-Staging also drops what a build cannot use. `hf/base-hf*.bin` are HybridFlow bases that
-only the TAS57xx driver reads, so they are left out unless `CONFIG_DAC_TAS57XX` is set —
-another 24 KB back on every other board, taking the image to 78 KB. Anything else you put
-in `hf/`, such as a TAS58xx PPC3 dump, is always included.
+Staging also drops what a build cannot use. Both DAC drivers keep their DSP images in
+`hf/`, so each build carries only the family it can load: `base-hf*.bin` and
+`tas57xx_fw*.bin` need `CONFIG_DAC_TAS57XX`, `tas5825m_fw*.bin` needs `CONFIG_DAC_TAS58XX`.
+That hands another 24 KB back to any board without a TAS57xx, taking the image to 78 KB.
 
 Both build systems go through that staging step. ESP-IDF runs it from `CMakeLists.txt`
 before `spiffs_create_partition_image`, and PlatformIO — which packs `data/` itself rather

--- a/main/network/web_server.c
+++ b/main/network/web_server.c
@@ -61,13 +61,25 @@ static httpd_handle_t s_server = NULL;
 
 static esp_err_t serve_spiffs_file(httpd_req_t *req, const char *path,
                                    const char *content_type) {
-  FILE *f = fopen(path, "r");
+  // Pages are stored gzipped so the web UI fits a 4 MB board's 188 KB
+  // partition. A plain file still wins if one was uploaded over /api/fs.
+  char gz_path[96];
+  snprintf(gz_path, sizeof(gz_path), "%s.gz", path);
+  bool gzipped = true;
+  FILE *f = fopen(gz_path, "r");
+  if (!f) {
+    gzipped = false;
+    f = fopen(path, "r");
+  }
   if (!f) {
     ESP_LOGE(TAG, "Failed to open %s", path);
     httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "File not found");
     return ESP_FAIL;
   }
   httpd_resp_set_type(req, content_type);
+  if (gzipped) {
+    httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+  }
   char buf[SPIFFS_CHUNK_SIZE];
   size_t n;
   while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {

--- a/main/network/web_server.c
+++ b/main/network/web_server.c
@@ -61,15 +61,15 @@ static httpd_handle_t s_server = NULL;
 
 static esp_err_t serve_spiffs_file(httpd_req_t *req, const char *path,
                                    const char *content_type) {
-  // Pages are stored gzipped so the web UI fits a 4 MB board's 188 KB
-  // partition. A plain file still wins if one was uploaded over /api/fs.
-  char gz_path[96];
-  snprintf(gz_path, sizeof(gz_path), "%s.gz", path);
-  bool gzipped = true;
-  FILE *f = fopen(gz_path, "r");
+  // The image only ever stores <path>.gz, so trying the plain name first is
+  // what lets a page uploaded over /api/fs replace the one that shipped.
+  bool gzipped = false;
+  FILE *f = fopen(path, "r");
   if (!f) {
-    gzipped = false;
-    f = fopen(path, "r");
+    char gz_path[96];
+    snprintf(gz_path, sizeof(gz_path), "%s.gz", path);
+    gzipped = true;
+    f = fopen(gz_path, "r");
   }
   if (!f) {
     ESP_LOGE(TAG, "Failed to open %s", path);

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,9 @@ extra_configs = user_platformio.ini
 monitor_speed = 115200
 monitor_filters = direct
 board_build.filesystem = spiffs
+; PlatformIO packs data/ itself for uploadfs, so it needs the same gzip step
+; the CMake build applies. See scripts/gen_spiffs_image.py.
+extra_scripts = pre:scripts/pio_stage_spiffs.py
 build_flags =
     -Wno-maybe-uninitialized
     -Os

--- a/scripts/gen_spiffs_image.py
+++ b/scripts/gen_spiffs_image.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Stage data/ into the directory the SPIFFS image is built from.
+
+The 4 MB boards give SPIFFS 188 KB (partitions-4m.csv) and the raw web UI is
+well over that on its own, so the pages are stored gzipped and served with
+Content-Encoding: gzip by serve_spiffs_file() in main/network/web_server.c.
+Everything else is copied through untouched — the hybrid flow images are read
+straight off the filesystem by the DAC driver, which cannot decompress.
+"""
+
+import gzip
+import os
+import shutil
+import sys
+
+COMPRESS_SUFFIXES = (".html",)
+
+
+def stage(src, dst):
+    if os.path.isdir(dst):
+        shutil.rmtree(dst)
+
+    raw = compressed = 0
+    for root, _, names in os.walk(src):
+        rel = os.path.relpath(root, src)
+        out = dst if rel == "." else os.path.join(dst, rel)
+        os.makedirs(out, exist_ok=True)
+
+        for name in sorted(names):
+            source = os.path.join(root, name)
+            if not name.endswith(COMPRESS_SUFFIXES):
+                shutil.copy2(source, os.path.join(out, name))
+                raw += os.path.getsize(source)
+                compressed += os.path.getsize(source)
+                continue
+
+            target = os.path.join(out, name + ".gz")
+            # mtime=0 keeps the image byte-identical between builds.
+            with open(source, "rb") as f, gzip.GzipFile(
+                target, "wb", compresslevel=9, mtime=0
+            ) as z:
+                shutil.copyfileobj(f, z)
+            raw += os.path.getsize(source)
+            compressed += os.path.getsize(target)
+
+    print(f"SPIFFS image staged: {raw} bytes of data/ -> {compressed} bytes")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <source-dir> <staging-dir>")
+    stage(sys.argv[1], sys.argv[2])

--- a/scripts/gen_spiffs_image.py
+++ b/scripts/gen_spiffs_image.py
@@ -6,17 +6,21 @@ well over that on its own, so the pages are stored gzipped and served with
 Content-Encoding: gzip by serve_spiffs_file() in main/network/web_server.c.
 Everything else is copied through untouched — the hybrid flow images are read
 straight off the filesystem by the DAC driver, which cannot decompress.
+
+--exclude drops files the build has no driver for, so a board does not carry
+payload it can never read.
 """
 
+import argparse
+import fnmatch
 import gzip
 import os
 import shutil
-import sys
 
 COMPRESS_SUFFIXES = (".html",)
 
 
-def stage(src, dst):
+def stage(src, dst, exclude=()):
     if os.path.isdir(dst):
         shutil.rmtree(dst)
 
@@ -28,6 +32,10 @@ def stage(src, dst):
 
         for name in sorted(names):
             source = os.path.join(root, name)
+            relname = name if rel == "." else os.path.join(rel, name)
+            relname = relname.replace(os.sep, "/")
+            if any(fnmatch.fnmatch(relname, pat) for pat in exclude):
+                continue
             if not name.endswith(COMPRESS_SUFFIXES):
                 shutil.copy2(source, os.path.join(out, name))
                 raw += os.path.getsize(source)
@@ -43,10 +51,21 @@ def stage(src, dst):
             raw += os.path.getsize(source)
             compressed += os.path.getsize(target)
 
-    print(f"SPIFFS image staged: {raw} bytes of data/ -> {compressed} bytes")
+    skipped = f" (excluding {', '.join(sorted(exclude))})" if exclude else ""
+    print(f"SPIFFS image staged{skipped}: {raw} bytes of data/ -> "
+          f"{compressed} bytes")
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        sys.exit(f"usage: {sys.argv[0]} <source-dir> <staging-dir>")
-    stage(sys.argv[1], sys.argv[2])
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source")
+    parser.add_argument("staging")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="path glob, relative to the source dir, to leave out of the image",
+    )
+    opts = parser.parse_args()
+    stage(opts.source, opts.staging, opts.exclude)

--- a/scripts/pio_stage_spiffs.py
+++ b/scripts/pio_stage_spiffs.py
@@ -7,6 +7,7 @@ two flows disagree: `idf.py flash` would write gzipped pages and
 """
 
 import os
+import re
 import subprocess
 import sys
 
@@ -14,15 +15,36 @@ Import("env")  # noqa: F821 - injected by PlatformIO
 
 FS_TARGETS = {"buildfs", "uploadfs", "uploadfsota"}
 
+
+def selects_tas57xx(project_dir):
+    """Whether this env's sdkconfig layers choose the HybridFlow DAC driver.
+
+    Read from platformio.ini, not from a generated sdkconfig — a pre: script
+    runs before CMake has configured, so no sdkconfig exists yet.
+    """
+    args = env.GetProjectOption("board_build.cmake_extra_args", "")
+    if not isinstance(args, str):
+        args = " ".join(args)
+    layers = re.search(r"-DSDKCONFIG_DEFAULTS=([^\"\s]+)", args)
+    if not layers:
+        return True  # unrecognised config, so ship all of data/
+    for layer in layers.group(1).split(";"):
+        path = os.path.join(project_dir, layer)
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding="utf-8") as f:
+            if "CONFIG_DAC_TAS57XX=y" in f.read():
+                return True
+    return False
+
+
 if FS_TARGETS & set(COMMAND_LINE_TARGETS):  # noqa: F821 - SCons global
+    project_dir = env.subst("$PROJECT_DIR")
     staged = os.path.join(env.subst("$BUILD_DIR"), "spiffs_image")
-    subprocess.check_call(
-        [
-            sys.executable,
-            os.path.join(env.subst("$PROJECT_DIR"), "scripts",
-                         "gen_spiffs_image.py"),
-            env.subst("$PROJECT_DATA_DIR"),
-            staged,
-        ]
-    )
+    cmd = [sys.executable,
+           os.path.join(project_dir, "scripts", "gen_spiffs_image.py")]
+    if not selects_tas57xx(project_dir):
+        cmd += ["--exclude", "hf/base-hf*.bin"]
+    cmd += [env.subst("$PROJECT_DATA_DIR"), staged]
+    subprocess.check_call(cmd)
     env.Replace(PROJECT_DATA_DIR=staged)

--- a/scripts/pio_stage_spiffs.py
+++ b/scripts/pio_stage_spiffs.py
@@ -1,0 +1,28 @@
+"""Point PlatformIO's filesystem targets at the same staged image CMake uses.
+
+PlatformIO packs $PROJECT_DATA_DIR with its own mkspiffs rather than using the
+storage.bin that spiffs_create_partition_image() produces, so without this the
+two flows disagree: `idf.py flash` would write gzipped pages and
+`pio run -t uploadfs` would write raw ones, which do not fit a 4 MB board.
+"""
+
+import os
+import subprocess
+import sys
+
+Import("env")  # noqa: F821 - injected by PlatformIO
+
+FS_TARGETS = {"buildfs", "uploadfs", "uploadfsota"}
+
+if FS_TARGETS & set(COMMAND_LINE_TARGETS):  # noqa: F821 - SCons global
+    staged = os.path.join(env.subst("$BUILD_DIR"), "spiffs_image")
+    subprocess.check_call(
+        [
+            sys.executable,
+            os.path.join(env.subst("$PROJECT_DIR"), "scripts",
+                         "gen_spiffs_image.py"),
+            env.subst("$PROJECT_DATA_DIR"),
+            staged,
+        ]
+    )
+    env.Replace(PROJECT_DATA_DIR=staged)

--- a/scripts/pio_stage_spiffs.py
+++ b/scripts/pio_stage_spiffs.py
@@ -15,9 +15,16 @@ Import("env")  # noqa: F821 - injected by PlatformIO
 
 FS_TARGETS = {"buildfs", "uploadfs", "uploadfsota"}
 
+# Both DAC drivers keep their DSP images in hf/, so each build carries only the
+# family it can actually load.
+DRIVER_ASSETS = {
+    "CONFIG_DAC_TAS57XX=y": ("hf/base-hf*.bin", "hf/tas57xx_fw*.bin"),
+    "CONFIG_DAC_TAS58XX=y": ("hf/tas5825m_fw*.bin",),
+}
 
-def selects_tas57xx(project_dir):
-    """Whether this env's sdkconfig layers choose the HybridFlow DAC driver.
+
+def sdkconfig_text(project_dir):
+    """This env's sdkconfig.defaults layers concatenated, or None if unknown.
 
     Read from platformio.ini, not from a generated sdkconfig — a pre: script
     runs before CMake has configured, so no sdkconfig exists yet.
@@ -27,15 +34,14 @@ def selects_tas57xx(project_dir):
         args = " ".join(args)
     layers = re.search(r"-DSDKCONFIG_DEFAULTS=([^\"\s]+)", args)
     if not layers:
-        return True  # unrecognised config, so ship all of data/
+        return None
+    text = ""
     for layer in layers.group(1).split(";"):
         path = os.path.join(project_dir, layer)
-        if not os.path.isfile(path):
-            continue
-        with open(path, encoding="utf-8") as f:
-            if "CONFIG_DAC_TAS57XX=y" in f.read():
-                return True
-    return False
+        if os.path.isfile(path):
+            with open(path, encoding="utf-8") as f:
+                text += f.read()
+    return text
 
 
 if FS_TARGETS & set(COMMAND_LINE_TARGETS):  # noqa: F821 - SCons global
@@ -43,8 +49,11 @@ if FS_TARGETS & set(COMMAND_LINE_TARGETS):  # noqa: F821 - SCons global
     staged = os.path.join(env.subst("$BUILD_DIR"), "spiffs_image")
     cmd = [sys.executable,
            os.path.join(project_dir, "scripts", "gen_spiffs_image.py")]
-    if not selects_tas57xx(project_dir):
-        cmd += ["--exclude", "hf/base-hf*.bin"]
+    config = sdkconfig_text(project_dir)
+    for symbol, patterns in DRIVER_ASSETS.items():
+        if config is not None and symbol not in config:
+            for pattern in patterns:
+                cmd += ["--exclude", pattern]
     cmd += [env.subst("$PROJECT_DATA_DIR"), staged]
     subprocess.check_call(cmd)
     env.Replace(PROJECT_DATA_DIR=staged)


### PR DESCRIPTION
## The problem

PR #139 merged green and then failed to build on `staging`. The SPIFFS image no longer fits:

```
Error: image size of 0x2f000 is too small ... SpiffsFullError
```

`data/` is **261,879 bytes**. The smallest layout (`components/boards/partitions-4m.csv`) gives SPIFFS **192,512 bytes**, so it overflows by 69,367 — breaking `esp32s2`, `squeezeamp-4m`, `smartamp` and `wrover`.

Nothing was wrong with either PR on its own. #139 was checked against `staging` as it stood at 10:42; #138 landed 15 minutes later, adding `hf.html` (124 KB) and four hybrid-flow bases (24 KB). They touch different files, so git merged them without a conflict — the break is semantic, and no check re-ran.

The 4 MB layout is exactly full, so `storage` cannot grow without shrinking an app partition.

## The fix

`scripts/gen_spiffs_image.py` stages `data/` into the build directory before the image is
built, doing two things.

**Gzip the pages.** Every `.html` is compressed; everything else is copied through untouched,
because the `hf/` and `bg/` binaries are read straight off the filesystem by the DAC and
display drivers, which cannot decompress. `mtime=0` keeps the image byte-identical between
builds.

**Drop what the board cannot read.** Both DAC drivers keep their DSP images in `hf/`, so each
build now carries only the family it can load:

| Pattern | Needs |
|---|---|
| `hf/base-hf*.bin`, `hf/tas57xx_fw*.bin` | `CONFIG_DAC_TAS57XX` |
| `hf/tas5825m_fw*.bin` | `CONFIG_DAC_TAS58XX` |

Exclusions are globs rather than whole directories, so a user's own PPC3 dump is kept on the
board that can actually load it.

| Build | Staged | of the 192,512 budget |
|---|---|---|
| `squeezeamp-4m` (TAS57xx) | 103,438 | 54% |
| everything else | 79,677 | 41% |

### Serving

The image only ever stores the `.gz`, so `serve_spiffs_file()` tries the plain name first and
falls back to `<path>.gz`, setting `Content-Encoding: gzip` when it serves one. That order is
deliberate: it is what lets a page uploaded through `/api/fs/upload` override the one that
shipped, and a delete restore it. All five pages route through that one helper. Pages also
load faster over WiFi.
### Both build systems

ESP-IDF stages from `CMakeLists.txt` before `spiffs_create_partition_image`. PlatformIO packs `$PROJECT_DATA_DIR` with its own mkspiffs rather than using the image CMake builds, so it needs the same step wired in separately as an `extra_scripts` pre-action — otherwise `pio run -t uploadfs` writes raw pages on a large board and an oversized image on a 4 MB one.

No CI change is needed. `build.yml` merges `$(cat flash_args)`, which already lists `0x3d1000 storage.bin` from the IDF build.

## Also

Documents the merge hazard in the contributing guide, and recommends enabling *Require branches to be up to date before merging* on `staging`.

## Testing

- `esp32s2` and `squeezeamp-4m` build clean via `idf.py`; `squeezeamp-4m` builds and packs a valid FS image via PlatformIO
- The image contains `/www/*.html.gz` and uncompressed `/hf/*.bin`
- All five pages md5-round-trip through gzip
- Verified on hardware on an Audio Brick Dual
- `zensical build --strict` clean, clang-format clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every SPIFFS image is built and how the captive portal serves pages; a mismatch between IDF and PlatformIO or gzip serving would break setup on 4 MB boards.
> 
> **Overview**
> Fixes **SPIFFS partition overflow** on 4 MB layouts by no longer flashing `data/` verbatim. **`scripts/gen_spiffs_image.py`** stages assets into the build tree, **gzips every `.html`**, copies **`hf/`** and **`bg/`** binaries unchanged, and optionally **`--exclude`**s DAC DSP blobs the firmware cannot use (`CONFIG_DAC_TAS57XX` / `CONFIG_DAC_TAS58XX`).
> 
> **ESP-IDF** runs that staging via a **`spiffs_image_stage`** CMake target before **`spiffs_create_partition_image`**. **PlatformIO** hooks the same script through **`scripts/pio_stage_spiffs.py`** so **`uploadfs`** matches **`idf.py flash`**.
> 
> **`serve_spiffs_file()`** opens the requested path first (so **`/api/fs/upload`** overrides still work), then falls back to **`<path>.gz`** with **`Content-Encoding: gzip`**.
> 
> Docs add SPIFFS compression/staging notes, **`hf.html`** in the tree diagram, and a **contributing** warning to rebase **`staging`** before merge to avoid green-then-red semantic breaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d636a2876b20c9cdd447ee574475b3276f5ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->