### PR TITLE
Publish the site: bring main's docs up to date with staging

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
   # twenty-second build, and running it everywhere also catches a firmware
   # change that invalidates a link in the docs.
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   # Republish after a release so the browser installer picks up new binaries.
   release:
     types: [published]
@@ -49,35 +49,56 @@ jobs:
       # ESP Web Tools fetches firmware from JavaScript, and GitHub release
       # assets send no Access-Control-Allow-Origin header. Serving the binaries
       # from the docs site itself keeps them same-origin.
+      #
+      # Two channels: the stable manifests sit in site/firmware/ next to the
+      # latest release's binaries, and a copy of each lands in
+      # site/firmware/beta/ next to the rolling beta's. Manifest paths are
+      # relative, so the same JSON resolves to whichever binary sits beside it.
       - name: Bundle firmware for the browser installer
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName 2>/dev/null || true)"
-          if [ -z "$tag" ]; then
+
+          # Drops manifests whose binary is missing from a release, and stamps
+          # the real version in so the installer can report it.
+          bundle() {
+            local dir="$1" tag="$2" version="$3"
+            gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+              --pattern '*.bin' --dir "$dir"
+            for manifest in "$dir"/*.json; do
+              bin="$(jq -r '.builds[0].parts[0].path' "$manifest")"
+              if [ ! -f "$dir/$bin" ]; then
+                echo "::warning::No $bin in $tag, removing $(basename "$manifest")"
+                rm "$manifest"
+                continue
+              fi
+              jq --arg v "$version" '.version = $v' "$manifest" > "$manifest.tmp"
+              mv "$manifest.tmp" "$manifest"
+            done
+            ls -la "$dir"
+          }
+
+          stable="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName 2>/dev/null || true)"
+          if [ -z "$stable" ]; then
             echo "::warning::No published release; the browser installer will be unavailable"
             rm -f site/firmware/*.json
-            exit 0
+          else
+            echo "Bundling stable firmware from release $stable"
+            bundle site/firmware "$stable" "${stable#v}"
           fi
-          echo "Bundling firmware from release $tag"
-          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-            --pattern '*.bin' --dir site/firmware
 
-          # Stamp the real version into each manifest so the installer can
-          # report it, and drop manifests whose binary is not in this release.
-          for manifest in site/firmware/*.json; do
-            bin="$(jq -r '.builds[0].parts[0].path' "$manifest")"
-            if [ ! -f "site/firmware/$bin" ]; then
-              echo "::warning::No $bin in release $tag, removing $(basename "$manifest")"
-              rm "$manifest"
-              continue
-            fi
-            jq --arg v "${tag#v}" '.version = $v' "$manifest" > "$manifest.tmp"
-            mv "$manifest.tmp" "$manifest"
-          done
-
-          ls -la site/firmware
+          # `gh release view beta` succeeds for a pre-release; `gh release view`
+          # with no tag above never returns one, which is why they differ.
+          beta="$(gh release view beta --repo "$GITHUB_REPOSITORY" --json name --jq .name 2>/dev/null || true)"
+          if [ -z "$beta" ]; then
+            echo "::warning::No beta pre-release; the beta channel will be hidden"
+          else
+            echo "Bundling beta firmware from release beta ($beta)"
+            mkdir -p site/firmware/beta
+            cp docs/firmware/*.json site/firmware/beta/
+            bundle site/firmware/beta beta "$beta"
+          fi
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -17,3 +17,38 @@
 [data-md-color-scheme="slate"] .md-header__button.md-logo img {
   content: url("../logo_mark_dark.png");
 }
+
+/* A board can be listed here before any published release carries a build for
+   it, and the beta channel is missing entirely until a beta exists.
+   assets/js/install-buttons.js marks each button once it knows which. */
+.install-missing {
+  display: none;
+}
+
+/* Beta starts hidden: usually there is no beta, and revealing one late beats
+   showing a button that turns out to 404. */
+.install-beta {
+  display: none;
+}
+
+.install-beta.install-available {
+  display: inline-block;
+}
+
+/* Dashed and drawn in the accent colour, so it reads as the deliberately
+   riskier of the two buttons rather than a second equal choice. The theme's
+   buttons are borderless pills, so this uses an outline — a real border would
+   make the beta button taller than the release one sitting beside it. */
+.md-button.md-button--beta {
+  margin-left: 0.4rem;
+  background-color: transparent;
+  color: var(--md-accent-fg-color);
+  outline: 1px dashed var(--md-accent-fg-color);
+  outline-offset: -1px;
+}
+
+.md-button.md-button--beta:hover,
+.md-button.md-button--beta:focus {
+  background-color: var(--md-accent-fg-color);
+  color: var(--md-primary-bg-color);
+}

--- a/docs/assets/js/install-buttons.js
+++ b/docs/assets/js/install-buttons.js
@@ -1,0 +1,33 @@
+/*
+ * Hides install buttons whose manifest is not on the site. The docs workflow
+ * drops a manifest whenever the release it bundles has no matching binary, so
+ * a board can appear on this page before any release carries a build for it,
+ * and the beta channel is missing entirely until a beta is published.
+ */
+(() => {
+  async function isPublished(url) {
+    try {
+      const response = await fetch(url, { method: "HEAD", cache: "no-store" });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  function setup() {
+    document.querySelectorAll("esp-web-install-button[manifest]").forEach(
+      async (button) => {
+        const published = await isPublished(button.getAttribute("manifest"));
+        button.classList.add(published ? "install-available" : "install-missing");
+      },
+    );
+  }
+
+  // Instant navigation swaps the body without a page load, so the theme's
+  // document observable is the only reliable re-entry point when it is active.
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(setup);
+  } else {
+    document.addEventListener("DOMContentLoaded", setup);
+  }
+})();

--- a/docs/boards/esparagus-audio-brick-dual-dac.md
+++ b/docs/boards/esparagus-audio-brick-dual-dac.md
@@ -1,0 +1,168 @@
+# Esparagus Audio Brick Dual
+
+The **Audio Brick Dual** is an **ESP32-S3** [Esparagus Audio Brick](esparagus-audio-brick.md)
+carrying **two** Class-D amplifiers on one I2S bus. As on every brick, each is either a
+TAS5825M or a TAS5805M and the driver detects which at startup.
+
+Two amplifiers give you a genuine active crossover: satellites on one chip, 
+a bridged subwoofer or a second stereo pair on the other, split in the DSP 
+rather than by a passive network.
+
+## Features
+
+- Two amplifiers, detected at I2C **0x4C** and **0x4D**
+- 15 biquad sections per output, per amplifier — 60 in total across the four outputs
+- Second amplifier wired as a bridged mono subwoofer or as a second stereo pair,
+  switchable from the web interface
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover
+- Optional [USB audio](../features/usb-audio.md) — the S3's native USB makes the dual-DAC board 
+  a USB speaker as well as an AirPlay one
+- I2C and SPI exposed for external displays, sensors and GPIO expanders
+- 8 MB flash, octal PSRAM
+- No Bluetooth: A2DP needs Bluetooth Classic, which the ESP32-S3 does not have
+
+## Flashing
+
+```bash
+# AirPlay + Ethernet
+pio run -e esparagus-audio-brick-dual-dac -t upload
+pio run -e esparagus-audio-brick-dual-dac -t uploadfs
+
+# The same board, also enumerating as a USB speaker
+pio run -e esparagus-audio-brick-dual-uac -t upload
+pio run -e esparagus-audio-brick-dual-uac -t uploadfs
+```
+
+Under ESP-IDF:
+
+```bash
+idf.py set-target esp32s3
+idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.esparagus-audio-brick-dual-dac" build
+idf.py -p /dev/ttyUSB0 flash
+```
+
+Both variants also have a prebuilt binary in the
+[browser installer](../getting-started/flashing.md).
+
+## Default GPIO assignments
+
+The dual-DAC board shares the S3 revision's I2S, I2C, SPI and display pins, and differs in what it
+does with the two pins the single-DAC board spends on FAULTZ and PWDN.
+
+| Function | GPIO | Notes |
+| --- | :-: | --- |
+| I2S BCK | 14 | Bit clock |
+| I2S WS | 15 | Word select (LRCLK) |
+| I2S DO | 16 | Serial audio data, both amplifiers |
+| I2C SDA | 8 | Control port, both amplifiers |
+| I2C SCL | 9 | Control port, both amplifiers |
+| DAC 1 enable | 18 | PDN for the amplifier at 0x4C |
+| DAC 2 enable | 17 | PDN for the amplifier at 0x4D |
+| Status LED | 21 | Addressable RGB |
+| SPI SCLK | 12 | Shared by Ethernet and display |
+| SPI MOSI | 11 | Shared by Ethernet and display |
+| SPI MISO | 13 | Ethernet only |
+| Ethernet CS | 10 | W5500 |
+| Ethernet INT | 6 | W5500 |
+| Ethernet RST | 5 | W5500 |
+| Display CS | 47 | SH1106 OLED |
+| Display DC | 38 | SH1106 OLED |
+| Display RST | 48 | SH1106 OLED |
+
+!!! note "No fault line"
+
+    GPIO 18 and 17 are the two DAC enables, so neither amplifier's FAULTZ pin
+    reaches the MCU (`CONFIG_SPKFAULT_GPIO=-1`). The driver polls both parts' fault
+    registers every two seconds instead, which catches over-current and thermal
+    shutdown a little later than an interrupt would but reports the same detail.
+
+## Amplifier roles
+
+Roles follow detection order, which follows I2C address:
+
+| Index | Address | Role |
+| --- | --- | --- |
+| 0 | 0x4C | Stereo satellites, always a BTL pair |
+| 1 | 0x4D | Second amplifier — bridged mono, or a second stereo pair |
+
+Both are fed the same I2S stream; what each one does with it is set by its own DSP input
+mixer, so no external wiring decides the routing.
+
+### Second amplifier wiring
+
+**Second Amplifier** on the main web page chooses between the two:
+
+- **Bridged mono (PBTL)** — OUT_A and OUT_B are paralleled into one driver, for a
+  subwoofer. The amplifier is fed `(L+R)/2` by default, since a single voice coil has no
+  stereo to reproduce.
+- **Stereo (BTL)** — two separate speakers, as on the first amplifier.
+
+!!! danger "Rewire before restarting"
+
+    PBTL is a control-port setting written while the part is still in HiZ, so the change
+    takes effect on the next boot, not immediately. **Match the speaker wiring to the
+    setting before you restart.** Leaving OUT_A and OUT_B shorted together while the part
+    comes up as a stereo BTL pair drives the two outputs against each other and can
+    damage the amplifier and its output filters. The web interface asks you to confirm
+    for this reason.
+
+The setting is stored in NVS and read back before the DAC is initialised, because PBTL
+has to be established before the output stage ever drives the load.
+
+## Crossovers and EQ
+
+The [Equaliser](esparagus-audio-brick.md#equaliser) page treats both amplifiers as one
+system. **Build crossover** offers the layouts the dual-DAC board makes possible — tweeters on one
+amplifier and woofers on the other, or satellites plus a subwoofer — and writes the
+filters, ganging and input routing into every output the split touches. Apply always
+pushes both amplifiers together, so a crossover spanning the pair can never go live by
+halves.
+
+Per-output channel selection disappears from the main page once two amplifiers are
+found: with a crossover in the DSP the routing is already decided, so choosing it again
+per output would mean nothing.
+
+## PPC3 dumps
+
+TAS5825M DACs are used, so [full PPC3 tunings](esparagus-audio-brick.md#full-ppc3-tuning)
+apply — one file per amplifier, indexed by detection order:
+
+| File | Applies to |
+| --- | --- |
+| `/spiffs/hf/tas5825m_fw0-44100.bin` | amplifier at 0x4C, at 44.1 kHz |
+| `/spiffs/hf/tas5825m_fw1-44100.bin` | amplifier at 0x4D, at 44.1 kHz |
+| `/spiffs/hf/tas5825m_fw0-48000.bin` | amplifier at 0x4C, at 48 kHz |
+| `/spiffs/hf/tas5825m_fw1-48000.bin` | amplifier at 0x4D, at 48 kHz |
+
+A PPC3 log that drives both amplifiers carries the writes for each, so convert it twice,
+picking the device with `--dev 98` or `--dev 9a`:
+
+```bash
+python3 components/dac_tas58xx/ppc3_convert.py both_amps.cfg --dev 98 -o tas5825m_fw0-48000.bin
+python3 components/dac_tas58xx/ppc3_convert.py both_amps.cfg --dev 9a -o tas5825m_fw1-48000.bin
+```
+
+The unindexed `tas5825m_fw-<rate>.bin` stands in for the first amplifier only, so on rev
+D it is worth using the indexed names throughout to avoid confusion.
+
+## USB audio
+
+`esparagus-audio-brick-dual-uac` is the same board with
+[USB audio](../features/usb-audio.md) layered on. The host sees a stereo USB speaker
+feeding the same DSP, crossover and volume control AirPlay uses, and AirPlay is suspended
+while the host is streaming.
+
+USB audio runs at **48 kHz** — see [the sample rate warning](../features/usb-audio.md#sample-rate)
+for why 44.1 kHz does not work on this path. AirPlay's 44.1 kHz stream is resampled on
+the way out, so a 48 kHz PPC3 dump is the one that matters on a UAC build.
+
+TinyUSB claims the USB PHY, so USB-Serial-JTAG cannot also be a console on this build.
+Logs stay on UART0, and reflashing over USB needs BOOT held during reset;
+[OTA updates](../reference/ota.md) sidestep it.
+
+## Related
+
+- [Esparagus Audio Brick](esparagus-audio-brick.md) — the single-DAC ESP32 and S3 boards
+- [USB audio (UAC)](../features/usb-audio.md)
+- [Ethernet (W5500)](../features/ethernet.md)
+- [Build environments](../reference/build-environments.md)

--- a/docs/boards/esparagus-audio-brick.md
+++ b/docs/boards/esparagus-audio-brick.md
@@ -1,8 +1,16 @@
 # Esparagus Audio Brick
 
 The [Esparagus Audio Brick](https://github.com/sonocotta/esparagus-media-center/?tab=readme-ov-file#esparagus-audio-brick-prototype)
-is an ESP32 board built around a TI **TAS5825M** Class-D DAC and amplifier. Like the
-SqueezeAMP, it needs no external DAC — connect speakers directly.
+is built around a TI **TAS5825M** Class-D DAC and amplifier. Like the SqueezeAMP, it
+needs no external DAC — connect speakers directly.
+
+The board exists as an **ESP32** revision and an **ESP32-S3** revision. The audio design
+is the same; the pinout is not, and neither is what the two chips can do — see
+[Default GPIO assignments](#default-gpio-assignments) and [Variants](#variants).
+
+Some bricks are fitted with a TI **TAS5805M** rather than the TAS5825M. It is the same
+family and the same driver, but it is not the same part: see
+[TAS5805M boards](#tas5805m-boards) for what it does and does not do here.
 
 ## Features
 
@@ -11,8 +19,10 @@ SqueezeAMP, it needs no external DAC — connect speakers directly.
 - Speaker fault detection with automatic mute and recovery
 - Automatic power state management (deep sleep / standby / play) driven by AirPlay session state
 - 8 MB flash
-- Optional [Bluetooth A2DP](../features/bluetooth.md)
-- Optional [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover
+- [Bluetooth A2DP](../features/bluetooth.md) on the **ESP32 revision only** — the S3 has no
+  Bluetooth Classic radio, so there is no `-bt` build for it
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover, on both
+  revisions
 
 ## Flashing
 
@@ -25,13 +35,17 @@ SqueezeAMP, it needs no external DAC — connect speakers directly.
 === "PlatformIO"
 
     ```bash
-    # AirPlay only
+    # ESP32 — AirPlay + Ethernet
     pio run -e esparagus-audio-brick -t upload
     pio run -e esparagus-audio-brick -t uploadfs
 
-    # AirPlay + Bluetooth + Ethernet
+    # ESP32 — AirPlay + Bluetooth + Ethernet
     pio run -e esparagus-audio-brick-bt -t upload
     pio run -e esparagus-audio-brick-bt -t uploadfs
+
+    # ESP32-S3 — AirPlay + Ethernet (no Bluetooth on this chip)
+    pio run -e esparagus-audio-brick-s3 -t upload
+    pio run -e esparagus-audio-brick-s3 -t uploadfs
 
     # Serial monitor
     pio run -e esparagus-audio-brick -t monitor
@@ -40,55 +54,265 @@ SqueezeAMP, it needs no external DAC — connect speakers directly.
 === "ESP-IDF"
 
     ```bash
+    # ESP32 revision
     idf.py set-target esp32
     idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.esparagus-audio-brick" build
+
+    # ESP32-S3 revision
+    idf.py set-target esp32s3
+    idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.esparagus-audio-brick-s3" build
+
     idf.py -p /dev/ttyUSB0 flash
     ```
 
 ## Default GPIO assignments
 
-| Function | GPIO | Notes |
-| --- | --- | --- |
-| I2S BCK | 26 | Bit clock |
-| I2S WS | 25 | Word select (LRCLK) |
-| I2S DO | 22 | Serial audio data |
-| I2C SDA | 21 | DAC control (TAS5825M) |
-| I2C SCL | 27 | DAC control (TAS5825M) |
-| Jack detect | 34 | Headphone jack insertion, input |
-| DAC warning | 36 | TAS5825M warning output, input |
-| Speaker fault | 39 | TAS5825M fault output, input |
+The two revisions share no pinout, so pick the column matching your board. The ESP32
+column is `config/sdkconfig.defaults.esparagus-audio-brick`, the S3 column
+`config/sdkconfig.defaults.esparagus-audio-brick-s3`.
 
-!!! note "GPIOs 34–39 are input-only"
+| Function | ESP32 | ESP32-S3 | Notes |
+| --- | :-: | :-: | --- |
+| I2S BCK | 26 | 14 | Bit clock |
+| I2S WS | 25 | 15 | Word select (LRCLK) |
+| I2S DO | 22 | 16 | Serial audio data |
+| I2C SDA | 21 | 8 | DAC control (TAS5825M) |
+| I2C SCL | 27 | 9 | DAC control (TAS5825M) |
+| DAC warning | 36 | 4 | TAS5825M warning output, input |
+| Speaker fault | 39 | 18 | TAS5825M FAULTZ, input |
+| Status LED | 12 | 21 | Addressable RGB |
+| SPI SCLK | 18 | 12 | Shared by Ethernet and display |
+| SPI MOSI | 23 | 11 | Shared by Ethernet and display |
+| SPI MISO | 19 | 13 | Ethernet only |
+| Ethernet CS | 5 | 10 | W5500 |
+| Ethernet INT | 35 | 6 | W5500 |
+| Ethernet RST | 14 | 5 | W5500 |
+| Display CS | 15 | 47 | SH1106 OLED |
+| Display DC | 4 | 38 | SH1106 OLED |
+| Display RST | 32 | 48 | SH1106 OLED |
 
-    On the ESP32, GPIOs 34–39 are input-only and have no internal pull-up. The board
-    provides external pull-ups on the fault and warning lines.
+!!! note "GPIOs 34–39 are input-only on the ESP32"
+
+    On the ESP32 revision the fault, warning and Ethernet interrupt lines land on
+    GPIOs 35–39, which are input-only and have no internal pull-up. The board provides
+    external pull-ups. The S3 revision has no such restriction on the pins it uses.
+
+The Audio Brick Dual is an S3 board with a third pinout: it has two amplifiers and no
+FAULTZ line back to the MCU, spending GPIO 18 and 17 on the two DAC enables instead. See
+[Esparagus Audio Brick Dual](esparagus-audio-brick-dual-dac.md).
 
 The build selects the TAS58xx driver automatically (`CONFIG_DAC_TAS58XX`). The driver
-auto-detects the TAS5825M I2C address in the range 0x4C–0x4F at startup.
+auto-detects the amplifier at startup: 0x4C–0x4F for a TAS5825M, 0x2C–0x2F for a
+TAS5805M. It then confirms the guess against the die ID and warns if the two disagree.
+
+## TAS5805M boards
+
+Some bricks carry a **TAS5805M** instead. The driver detects it, drives it and gives it
+its own init sequence, so the board plays and its volume, mute and 15-band biquad chain
+all work through the [Equaliser](#equaliser) page exactly as on a TAS5825M.
+
+Two things do not carry over:
+
+!!! warning "No PPC3 dumps on a TAS5805M"
+
+    A dump replays a *process flow*, which is a TAS5825M feature — the TAS5805M has no
+    flow-select register and lays its coefficients out differently, so a dump exported
+    for one part would write garbage into the other. The driver checks the model and
+    skips the file rather than risk it. There is no equivalent to load, so
+    [Full PPC3 tuning](#full-ppc3-tuning) simply does not apply: the
+    [Equaliser](#equaliser) page is the whole of the tuning available, which for most
+    builds is the whole signal path anyway.
+
+The **input mixer** is TAS5825M-only too. Summing to mono or feeding one channel to both
+outputs is done in the DSP mixer, and only the TAS5825M's mixer is implemented here, so
+a TAS5805M passes the stereo pair straight through and logs a warning if asked for
+anything else. That also means no crossover layout needing a summed or single-channel
+feed — the ones that route the pair as-is still work.
 
 ## Equaliser
 
-TAS5825M boards expose a 15-band parametric EQ through the device's web interface at
-`/eq.html`. Changes are applied to the DAC's on-chip DSP in real time and persisted to
-NVS.
+TAS5825M boards expose the DAC's 15 cascaded biquad sections through the device's web
+interface at `/bq`, one filter per section, per output and per amplifier. Each
+section can be a peaking filter, a shelf, a low or high pass in six alignments, a band
+pass, a notch, a phase shift, or five raw coefficients. The filter models match
+PurePath Console 3, and coefficients are recomputed whenever the I2S sample rate
+changes. The chip's two outputs are named A and B — which of them carries left, right
+or a sum is the routing setting, not a fixed assignment. A and B can be ganged or
+tuned separately. Editing only redraws the response graph: **Apply** sends the filters
+to the amplifiers so you can hear them, and **Commit to flash** makes them survive a
+reboot. **Revert** goes back to what is in flash. For plain tone shaping, **Load
+15-band EQ** fills the chain with a flat graphic equaliser — one peaking section per
+band from 20 Hz to 16 kHz — leaving only the gains to set. It fills in the form and
+nothing more, so the amplifier hears it only once applied.
+
+Crossovers are built from these same sections, so a two-way or subwoofer split is just
+a high pass on one amplifier and a low pass on the other. **Build crossover** does that
+for you: pick how the drivers are wired — both bands on one amplifier, one amplifier per
+speaker, tweeters on one amplifier and woofers on the other, or satellites plus a
+subwoofer — then a crossover frequency and an alignment: Linkwitz-Riley at 12 or
+24 dB per octave, Butterworth at 6, 12 or 24, or Bessel at 12. It writes the filters
+into every output the split touches, sets ganging and input routing to match, and
+leaves the filters staged so nothing is heard until applied. Apply always pushes all
+amplifiers, so a crossover spanning both can never go live by halves. Layouts the
+wiring rules out are not offered — a bridged amplifier has no separate A and B to
+split across.
+
+Steeper alignments cost more slots, because sections cascade. A Linkwitz-Riley is two
+cascaded Butterworths of half its order, so LR2 is two 1st-order Butterworths — real
+poles, which collapse into a single biquad at Q 0.5 — while LR4 is two Butterworth 2
+sections at Q 0.707 and cannot be folded into one. That is why a 24 dB per octave
+split shows two Butterworth 2 sections rather than one Linkwitz-Riley 2: both would
+slope at 24 dB per octave, but only the Butterworth pair sits 6 dB down at the corner,
+which is what lets the two branches sum flat. Two Linkwitz-Riley 2 sections would be
+12 dB down there and sum 6 dB short.
+
+Each section also has an **Inv** box that flips its polarity. The builder sets this
+itself and does not offer it as a choice, because the alignment decides it: at the
+corner the branches sit 180° apart at 12 dB per octave and need opposite polarity to
+sum flat, but they are back in phase at 24, where inverting would instead dig a notch.
+Only one section of a branch ever carries it — polarity belongs to the chain, and
+since sections multiply, inverting an even number of them cancels back to none. The
+box is still there by hand for drivers wired out of phase. A section left on Bypass
+with Inv ticked is a plain polarity flip and costs nothing else.
+
+### Fitting to a measurement
+
+**Fit to a measurement…** turns a measured response into a correction. Load a frequency
+response export — REW text, or any file with a frequency and a level in its first two
+columns — and the fitter searches for the peaking filters and shelves that flatten it,
+then writes them into the chain. Only the shape is fitted, never the absolute level. The
+response graph gains two overlays, the measurement as it was and as it would be once
+corrected, so the fit can be judged before anything is applied.
+
+Three settings matter more than the rest. The fit range decides where the effort goes: a
+driver rolls off at its ends by more than any filter can undo, and leaving the range
+wide spends filters fighting that instead of correcting the band the driver covers — the
+page says so when the measurement is already well down at the low limit. Smoothing sets
+how much detail is chased, and a sixth of an octave keeps the room modes while ignoring
+the fine structure that moves when the microphone does. The boost and cut limits apply
+to the summed correction rather than to any one filter, and the result reports how much
+boost was used, so the same amount can come off that output's level to keep the
+headroom.
+
+**Keep first N sections** protects the head of the chain. The fit replaces everything
+past that count, so on a bi-amped speaker keep the crossover, measure each way through
+it, and fit into what is left; the count is filled in from any low or high passes
+already sitting at the top of the chain. Kept sections are slots the fitter cannot have,
+so **Filters to use** caps itself at what remains — a 24 dB per octave crossover leaves
+13 of the 15. Fitted filters are staged like any other edit — nothing is heard until
+applied and nothing survives a reboot until committed.
+
+Each amplifier carries its own input routing: the stereo pair as-is, summed to
+`(L+R)/2`, or one channel fed to both outputs. A bridged amplifier drives a single voice
+coil, so it is always fed a single channel and defaults to the sum; ganging is implicit
+and the stereo option is not offered. A combined response graph at the top of the page
+plots every active output together, so a crossover spread across both amplifiers can be
+read as one picture.
+
+**Show what the outputs sum to** adds one more trace to that graph. Outputs feeding
+separate drivers add as vectors and not as curves, so two branches that each look right
+alone can still cancel where they overlap — and the two curves look identical either
+way round, which is what makes it easy to miss. The sum is taken on the complex
+response instead: a crossover is right when it runs flat through the corner, and a dip
+there means the branches are fighting, so one of them needs **Inv**. The trace knows
+only the filters, never the drivers, their spacing or the room, so it shows what the
+crossover is aiming at rather than what a microphone would hear.
+
+Levels are set in the Volume section. Master is the AirPlay volume and moves
+everything together. Below it each output has its own level and mute, applied in the
+DSP input mixer ahead of the filters — so they only ever attenuate and cost no filter
+headroom. Use them to match drivers of differing sensitivity. Levels and mutes take
+effect immediately and are stored in NVS, independently of the filter commit.
+
+## Full PPC3 tuning
+
+!!! info "TAS5825M only"
+
+    This whole section applies to boards fitted with a TAS5825M. A TAS5805M brick has no
+    process flow to replay and ignores these files \u2014 see
+    [TAS5805M boards](#tas5805m-boards).
+
+The Equaliser page covers the fifteen biquads per channel, the crossover and the levels,
+which is the whole signal path for most builds. A tuned dump from TI PurePath Console 3
+goes further: it is the complete device configuration — clocking, I2S format, the process
+flow select and every coefficient — so it reaches blocks the web interface does not
+expose. That includes flows whose coefficient map TI never published, because a dump
+replays TI's own register writes rather than addresses we would have to know.
+
+At boot the driver looks for a dump on SPIFFS and, if one is present, replays it *instead
+of* the built-in init sequence. PPC3 bakes every coefficient at the rate the flow was
+exported for, so a 48 kHz tuning played at 44.1 kHz puts every corner about 8% low: name
+the file for its rate and the driver picks the one matching what it is playing.
+
+| File | Applies to |
+| --- | --- |
+| `/spiffs/hf/tas5825m_fw-44100.bin` | the only amplifier, or the first of two, at 44.1 kHz |
+| `/spiffs/hf/tas5825m_fw-48000.bin` | the same, at 48 kHz |
+| `/spiffs/hf/tas5825m_fw0-44100.bin` | first amplifier on a dual-DAC board, at 44.1 kHz |
+| `/spiffs/hf/tas5825m_fw1-44100.bin` | second amplifier on a dual-DAC board, at 44.1 kHz |
+
+Drop the `-<rate>` suffix — `tas5825m_fw.bin`, `tas5825m_fw0.bin` — for a dump that
+should serve every rate. Those names are the fallback, searched only once no
+rate-specific file matches, so a single-rate install keeps working untouched. A process
+flow is a TAS5825M feature, so the driver only looks for any of these on that part —
+see [TAS5805M boards](#tas5805m-boards).
+
+To install one:
+
+1. Tune the part in PPC3 and export either the I2C log (`.cfg`) or the C header, at each
+   sample rate you want covered.
+2. Convert it:
+   ```bash
+   python3 components/dac_tas58xx/ppc3_convert.py my_tuning_44k1.cfg -o tas5825m_fw-44100.bin
+   ```
+   A log that drives both amplifiers carries writes for each, so pick one with
+   `--dev 98` or `--dev 9a` and convert it twice.
+3. Copy the result to `data/hf/` for a serial flash, or upload it over WiFi:
+   ```bash
+   curl -X POST "http://<device-ip>/api/fs/upload?path=/spiffs/hf/tas5825m_fw-44100.bin" \
+        --data-binary @tas5825m_fw-44100.bin
+   ```
+4. Reboot.
+
+Delete the file to go back to the built-in flow.
+
+!!! warning
+
+    A dump owns the configuration, so the driver stops writing its own signal-path
+    defaults and trusts the tuning instead. Get the clocking or the I2S format wrong
+    and the part will not play — keep a serial console attached the first time.
+
+The biquad addresses are identical in every documented flow on both the TAS5825M and the
+TAS5805M, so the Equaliser page keeps working on top of a dump. A dump that selects an
+undocumented flow is the exception: nothing guarantees its coefficients live where the
+page expects them.
 
 ## Variants
 
-| Environment | Chip | Notes |
-| --- | --- | --- |
-| `esparagus-audio-brick` | ESP32 | AirPlay only |
-| `esparagus-audio-brick-bt` | ESP32 | Bluetooth + Ethernet, prebuilt binary published |
-| `esparagus-audio-brick-s3` | ESP32-S3 | S3-based revision, no Bluetooth |
-| `esparagus-audio-brick-dual-dac` | ESP32-S3 | Rev D with two TAS5825M: stereo at 0x4C, PBTL mono subwoofer at 0x4D |
+| Environment | Chip | Bluetooth | Prebuilt | Notes |
+| --- | --- | :-: | :-: | --- |
+| `esparagus-audio-brick` | ESP32 | — | — | AirPlay + Ethernet |
+| `esparagus-audio-brick-bt` | ESP32 | yes | yes | Adds Bluetooth A2DP |
+| `esparagus-audio-brick-s3` | ESP32-S3 | — | yes | S3 pinout, PSRAM, no Bluetooth Classic on this chip |
+| `esparagus-audio-brick-dual-dac` | ESP32-S3 | — | yes | [Dual](esparagus-audio-brick-dual-dac.md), two amplifiers: stereo at 0x4C, second at 0x4D |
+| `esparagus-audio-brick-dual-uac` | ESP32-S3 | — | yes | [Dual](esparagus-audio-brick-dual-dac.md) as a USB audio device |
+
+The ones marked prebuilt are in the
+[browser installer](../getting-started/flashing.md). On the ESP32 the published binary is
+the Bluetooth one, so build `esparagus-audio-brick` yourself if you want that RAM back.
+
+Bluetooth Classic exists only on the original ESP32, so the `-bt` build has no S3
+equivalent; an S3 brick reaches the network over Ethernet or WiFi. The Dual has two
+amplifiers and a pinout of its own, and gets [its own page](esparagus-audio-brick-dual-dac.md).
 
 ### Esparagus Louder
 
-The Esparagus Louder is the same TAS5825M design with additional gain.
+The Esparagus Louder is the same amplifier design on a board of its own.
 
 | Environment | Chip | Bluetooth | Prebuilt |
 | --- | --- | :-: | :-: |
 | `esparagus-louder` | ESP32 | — | — |
-| `esparagus-louder-bt` | ESP32 | yes | — |
+| `esparagus-louder-bt` | ESP32 | yes | yes |
 | `esparagus-louder-s3` | ESP32-S3 | — | yes |
 
 ```bash

--- a/docs/boards/index.md
+++ b/docs/boards/index.md
@@ -34,8 +34,9 @@ original ESP32.
 | [ESP32-S3 + PCM5102A](esp32s3-pcm5102a.md) | ESP32-S3 | External I2S | — | — | yes |
 | [Waveshare ESP32-S3](esp32s3-pcm5102a.md#waveshare-esp32-s3) | ESP32-S3 | External I2S | — | — | yes |
 | [SqueezeAMP](squeezeamp.md) | ESP32 | TAS5756 | yes | — | yes |
-| [Esparagus Audio Brick](esparagus-audio-brick.md) | ESP32 | TAS5825M | yes | yes | yes |
-| [Esparagus Louder](esparagus-audio-brick.md#esparagus-louder) | ESP32 / S3 | TAS5825M + gain | yes | — | S3 only |
+| [Esparagus Audio Brick](esparagus-audio-brick.md) | ESP32 / S3 | TAS58xx | ESP32 only | yes | yes |
+| [Esparagus Audio Brick Dual](esparagus-audio-brick-dual-dac.md) | ESP32-S3 | 2× TAS58xx | — | yes | yes |
+| [Esparagus Louder](esparagus-audio-brick.md#esparagus-louder) | ESP32 / S3 | TAS58xx | ESP32 only | — | yes |
 | [Seeed XIAO ESP32-C5](xiao-esp32c5.md) | ESP32-C5 | External I2S | — | — | — |
 | [Custom board](custom.md) | any | any | — | — | — |
 

--- a/docs/boards/squeezeamp.md
+++ b/docs/boards/squeezeamp.md
@@ -1,7 +1,7 @@
 # SqueezeAMP
 
 The [SqueezeAMP](https://github.com/philippe44/SqueezeAMP) is an ESP32 board with a
-TAS5756 DAC and a built-in Class-D amplifier. No external DAC is needed — connect speakers
+TAS575xx (combined DAC and Class-D amplifier). Connect speakers
 directly to the board.
 
 ## Flashing
@@ -53,35 +53,24 @@ from 5000 to 2500 frames to fit the original ESP32's more limited PSRAM bandwidt
 
 ## Hybrid flow DSP
 
-The TAS575xM supports **hybrid flow** DSP programs that run on the chip's miniDSP core. At
-boot the driver looks for `/spiffs/hf/tas57xx_fw.bin` and loads it automatically if
-present. There is no menuconfig setting — place the file and reboot.
+The SqueezeAMP's TAS5754M has a miniDSP core, so it can run a TI **HybridFlow** process
+flow: a full-range stereo chain with EQ, bass enhancement and a compander, or a two-way
+bi-amp crossover. The firmware ships the base flows and tunes them live from the
+`/hf` page.
 
-To add or update a hybrid flow:
-
-1. Export a `.cfg` file from TI PurePath Console.
-2. Convert it to binary:
-   ```bash
-   python3 components/dac_tas57xx/hybridflows/convert_cfg.py --bin my_flow.cfg
-   ```
-3. Rename the output to `tas57xx_fw.bin`.
-4. Copy it to `data/hf/` for a serial flash, or upload it over WiFi:
-   ```bash
-   curl -X POST "http://<device-ip>/api/fs/upload?path=/spiffs/hf/tas57xx_fw.bin" \
-        --data-binary @tas57xx_fw.bin
-   ```
-5. Reboot the device.
-
-Delete the file to disable the hybrid flow.
+The TAS5754M is the part all of this has been tested on. See
+[HybridFlow DSP](../features/hybridflow.md) for the flows, the tuning workflow and the
+file layout.
 
 !!! note
 
-    Hybrid flows are only supported on TAS575xM chips. The driver detects the chip family
-    at boot and skips hybrid flow loading on TAS578x devices.
+    HybridFlow needs a TAS57xx with a miniDSP. The driver detects the chip family at boot
+    and skips flow loading on TAS578x devices, which have no DSP core.
 
 See [SPIFFS filesystem](../reference/spiffs.md) for the file management API.
 
 ## Related
 
+- [HybridFlow DSP](../features/hybridflow.md)
 - [Bluetooth A2DP](../features/bluetooth.md)
 - [Build environments](../reference/build-environments.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,9 +37,34 @@ A hook auto-formats staged C and H files and runs clang-tidy. Enable it once per
 git config core.hooksPath .githooks
 ```
 
+## Branches
+
+**Open pull requests against `staging`, not `main`.**
+
+`staging` is the integration branch. Every push to it rebuilds the firmware matrix and
+replaces the rolling `beta` pre-release, so anything merged there is immediately
+installable from the [browser installer](getting-started/flashing.md#beta-builds) and can
+be tried on real hardware before it reaches anyone running a release.
+
+`main` carries stable releases. It is what the documentation site is published from and
+what the release install buttons serve, and it moves only when `staging` has proved itself
+and a version is tagged.
+
+`version.txt` on `staging` must stay ahead of the latest release or the beta job fails, so
+bump it as soon as a release goes out.
+
+!!! warning "Rebase before merging"
+
+    A pull request is checked against `staging` **as it was when the check ran**. If
+    another PR merges in the meantime, a green tick can go red on merge — two branches
+    that touch different files merge without conflict but can still break the build
+    together, which is exactly how the SPIFFS partition overflowed once already.
+    Enable *Require branches to be up to date before merging* on `staging`, or rebase
+    and wait for a fresh run before merging anything non-trivial.
+
 ## CI
 
-On every push and pull request to `main`:
+On every pull request to `main` or `staging`, and on every push to `main`:
 
 | Job | What it does |
 | --- | --- |
@@ -47,6 +72,9 @@ On every push and pull request to `main`:
 | `lint-check` | `clang-tidy` against the build output |
 | `output-backends` | Builds the S/PDIF and USB output backends so every backend keeps linking |
 | `build` | Builds the full target matrix |
+
+A pull request that touches only Markdown skips the firmware jobs, so a docs typo does not
+cost an ESP-IDF toolchain build.
 
 Tagging `vMAJOR.MINOR.PATCH` triggers a release, which validates the tag against
 `version.txt` and publishes merged firmware binaries.

--- a/docs/features/airplay-tuning.md
+++ b/docs/features/airplay-tuning.md
@@ -49,9 +49,29 @@ If you still hear drop-outs on AirPlay 1 / realtime playback, increase
 
 ## Forcing AirPlay v1
 
-`CONFIG_AIRPLAY_FORCE_V1=y` makes the receiver advertise itself as a classic AirPlay
-receiver. The main reason to do this is to get working
-[hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement), since iOS only
-sends DACP headers in v1 mode.
+Classic AirPlay v1 makes the receiver advertise itself as a plain RAOP receiver. There are
+two reasons to do this:
+
+- **Hardware buttons.** iOS only sends DACP headers in v1 mode, so this is what makes
+  [hardware buttons](buttons.md#read-this-first-the-airplay-v1-requirement) work.
+- **Apple Music for Windows.** It is a RAOP-only sender and refuses any device that
+  advertises the `_airplay._tcp` service, reporting that the device "is not compatible
+  with this version of AMPLibraryAgent". The device still appears in its picker and it
+  still opens an RTSP connection — it sends `OPTIONS` with an `Apple-Challenge` and then
+  walks away.
+
+The mode lives in NVS, so no rebuild is needed. Open the web interface and pick
+**Device Settings → AirPlay Mode**, then restart the device. The mDNS records and the RTSP
+listening port are both built at startup, so the change only takes effect on the next boot.
+
+In v1 mode the receiver mirrors a classic RAOP advertisement: no `_airplay._tcp`
+service, a shairport-sync-style `_raop._tcp` TXT record, `Server: AirTunes/105.1` on RTSP
+responses, and RTSP on port 5000 instead of 7000.
 
 It costs you AirPlay 2 features: HomeKit pairing, encrypted transport and multi-room sync.
+
+There is no setting that keeps both senders happy. The deciding factor for Apple Music is
+the presence of `_airplay._tcp` alone — a receiver publishing a fully classic `_raop._tcp`
+TXT record on port 5000 is still refused while that service is up, and starts working the
+moment it is withdrawn. iOS needs the same service to negotiate AirPlay 2, and a device
+publishes one advertisement, so the mode is a real either/or.

--- a/docs/features/bluetooth.md
+++ b/docs/features/bluetooth.md
@@ -41,7 +41,7 @@ number, and that is not implemented yet.
 | Environment | Board | Features |
 | --- | --- | --- |
 | `squeezeamp-bt` | SqueezeAMP | AirPlay + Bluetooth |
-| `esparagus-audio-brick-bt` | Esparagus Audio Brick | AirPlay + Bluetooth + Ethernet |
+| `esparagus-audio-brick-bt` | Esparagus Audio Brick, ESP32 revision | AirPlay + Bluetooth + Ethernet |
 | `esparagus-louder-bt` | Esparagus Louder | AirPlay + Bluetooth |
 | `esp32wrover-dev` | Freenove ESP32-WROVER | AirPlay + Bluetooth, 4 MB flash |
 | `smartamp` | SmartAmp | AirPlay + Bluetooth, 4 MB flash |
@@ -49,6 +49,10 @@ number, and that is not implemented yet.
 Bluetooth is enabled by layering `config/sdkconfig.defaults.bt` onto a board's defaults. To add it
 to a [custom board](../boards/custom.md), include that file in your
 `SDKCONFIG_DEFAULTS` chain.
+
+Boards sold in both an ESP32 and an ESP32-S3 revision — the
+[Esparagus Audio Brick](../boards/esparagus-audio-brick.md) and Louder — have a `-bt`
+environment for the ESP32 one only. There is nothing to enable on the S3 revision.
 
 ## Buttons over Bluetooth
 

--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -20,19 +20,9 @@ In practice:
 | **AirPlay v1** (forced) | Works | Works fully via DACP |
 | **Bluetooth** | Works | Works fully via AVRCP passthrough |
 
-To get full button control over AirPlay, force v1 mode:
-
-```bash
-idf.py menuconfig
-# AirPlay Receiver → AirPlay Protocol
-# Enable "Force AirPlay v1 (classic) protocol"
-```
-
-Or in your sdkconfig defaults:
-
-```ini
-CONFIG_AIRPLAY_FORCE_V1=y
-```
+To get full button control over AirPlay, switch the receiver to v1 mode in the web
+interface: **Device Settings → AirPlay Mode → Legacy (v1)**, then restart the
+device.
 
 !!! warning "Trade-off"
 

--- a/docs/features/ethernet.md
+++ b/docs/features/ethernet.md
@@ -33,23 +33,25 @@ Bluetooth behave identically on either.
 
 ## Wiring
 
-The W5500 connects over SPI, sharing the bus with the OLED display.
+The W5500 connects over SPI, sharing the clock and MOSI lines with the OLED display. The
+ESP32 and ESP32-S3 revisions of the Brick use different pins.
 
-| W5500 pin | ESP32 GPIO | Function |
-| --- | --- | --- |
-| CLK | 18 | SPI clock |
-| MOSI | 23 | SPI data out |
-| MISO | 19 | SPI data in |
-| CS | 5 | Chip select |
-| INT | 35 | Interrupt |
-| RST | 14 | Hardware reset |
-| 3V3 | 3.3 V | Power |
-| GND | GND | Ground |
+| W5500 pin | ESP32 | ESP32-S3 | Function |
+| --- | :-: | :-: | --- |
+| CLK | 18 | 12 | SPI clock |
+| MOSI | 23 | 11 | SPI data out |
+| MISO | 19 | 13 | SPI data in |
+| CS | 5 | 10 | Chip select |
+| INT | 35 | 6 | Interrupt |
+| RST | 14 | 5 | Hardware reset |
+| 3V3 | 3.3 V | 3.3 V | Power |
+| GND | GND | GND | Ground |
 
 ## Configuration
 
-Ethernet is enabled by default in the `esparagus-audio-brick-bt` build. GPIOs can be
-changed under **Board Configuration → SPI and Ethernet Configuration** in `menuconfig`.
+Ethernet is enabled by default in every Esparagus Audio Brick build, on both revisions.
+GPIOs can be changed under **Board Configuration → SPI and Ethernet Configuration** in
+`menuconfig`.
 
 To disable it, set:
 

--- a/docs/features/hybridflow.md
+++ b/docs/features/hybridflow.md
@@ -1,0 +1,162 @@
+# HybridFlow DSP (TAS57xx)
+
+Some TAS57xx amplifiers carry a small DSP core — TI calls it the miniDSP — that can run a
+signal chain in front of the output stage. TI ships those chains as **HybridFlow** process
+flows, and the firmware can load one, tune it live from a web page, and keep the tuning
+across reboots.
+
+The tuning page is at `http://<device-ip>/hf`, or **HybridFlow Tuning** on the settings
+page. It only appears on a build with `CONFIG_DAC_TAS57XX`.
+
+## Hardware requirement
+
+!!! warning "You need a TAS57xx that has a miniDSP"
+
+    Not every part in the family has one. The DSP-capable devices are the "M" variants —
+    TAS5754M, TAS5756M and their relatives — and only those can run a HybridFlow. A
+    TAS578x has no miniDSP at all: the driver detects it at boot and skips flow loading
+    entirely, leaving the part on its built-in stereo program.
+
+!!! note "Only tested on the TAS5754M"
+
+    All of this has been developed and tested against a **TAS5754M** (the SqueezeAMP's
+    amplifier). Other DSP-capable parts in the family are register-compatible on paper and
+    are expected to work, but nobody has run them. Treat them as unverified: check the boot
+    log for the flow verification, and be ready for the tuning page to report that no flow
+    is available.
+
+Check what the part is doing from the boot log or from the API:
+
+```bash
+curl "http://<device-ip>/api/hf/flow"
+# {"active":1,"sample_rate":44100,"available":[1,3],"success":true}
+```
+
+`active` is `0` when no flow is loaded, and `available` lists the flows this device has a
+base image for.
+
+## The two flows
+
+Both are stereo in, two channels out, and only one can be resident at a time — they map
+coefficient RAM differently.
+
+=== "HybridFlow 1 — full range"
+
+    A conventional stereo chain, the same processing on both channels:
+
+    ```
+    In → Biquad EQ (10 bands) → PBE → DBE → Compander → Volume → Smooth clip → Out
+    ```
+
+    PBE is psychoacoustic bass, DBE dynamic bass, and the compander is a three-band
+    compressor/expander. Tune in that order: volume ceiling first, then EQ for the baseline
+    response, then the compander and smooth clipper for power limiting, then DBE and PBE.
+
+=== "HybridFlow 3 — bi-amp"
+
+    The two amplifier outputs stop being left and right. The input feeds two ways in
+    parallel, each with a crossover leg and four EQ bands, and they are recombined into a
+    shared compander and clipper:
+
+    ```
+    In ─┬→ Low way  → PBE → DBE ─┬→ Compander → Smooth clip → Volume → Out
+        └→ High way → Delay ─────┘
+    ```
+
+    Channel A drives the woofer, channel B the tweeter. The high way's delay aligns its
+    acoustic centre with the low way's. Only the low way gets the bass enhancers.
+
+=== "No processing"
+
+    Flow `0` removes the working flow and hands playback back to the part's ROM stereo
+    program: plain left and right with digital volume, no crossover, EQ or dynamics. This
+    is the only setting available on a part without a usable HybridFlow, and it discards
+    nothing but the flow file — saved tunings stay.
+
+!!! danger "Switching to bi-amp changes what your speakers see"
+
+    A tweeter wired to an output that suddenly carries full-range bass will not survive it.
+    The firmware drops the volume to minimum on any flow change and leaves it there, so
+    confirm the wiring before turning it back up.
+
+## Base flows and sample rates
+
+The flow images live in SPIFFS under `/spiffs/hf/`. The repository tracks four pristine
+base images:
+
+```
+base-hf1-44100.bin   base-hf1-48000.bin
+base-hf3-44100.bin   base-hf3-48000.bin
+```
+
+Coefficients are designed for one sample rate, so each flow has a 44.1 kHz and a 48 kHz
+twin. The driver picks the one matching the running output rate and swaps to the other if
+the rate changes, replaying the saved tuning onto it. The bases are copied to the working
+flow rather than played from directly, so a commit can never scribble on them.
+
+Selecting a flow rewrites the working flow and re-downloads it:
+
+```bash
+curl -X POST "http://<device-ip>/api/hf/flow" \
+     -H 'Content-Type: application/json' -d '{"flow":3}'
+```
+
+## Apply, Commit and Revert
+
+The tuning page distinguishes three things, and the difference matters:
+
+| Action | What it does | Survives |
+| --- | --- | --- |
+| **Apply** | Writes the tuning into the DSP's coefficient RAM so you can hear it | Playback, standby, a Bluetooth handover |
+| **Commit** | Bakes the tuning into the flow image and writes it to SPIFFS | Reboots and flow reloads |
+| **Revert** | Reloads the committed flow from SPIFFS, dropping the audition | — |
+
+Auditioning is free: nothing is written to flash until you commit, and a reboot always
+brings back the last committed tuning.
+
+Master volume and the per-channel trims sit *outside* this. They are the part's own
+registers, the same ones AirPlay drives, so they apply immediately and are saved
+separately — they work even with no flow loaded. The fine volume trim is the exception: it
+is a gain inside the flow, so it belongs to the tuning and only Commit persists it.
+
+## Where the files live
+
+| Path | Contents |
+| --- | --- |
+| `/spiffs/hf/base-hf<n>-<rate>.bin` | Pristine base flow, never written to |
+| `/spiffs/hf/tas57xx_fw.bin` | The working flow, rewritten by Commit |
+| `/spiffs/hf/hf1.cfg` | Committed HF1 tuning |
+| `/spiffs/hf/hf3.cfg` | Committed HF3 tuning |
+
+A `.cfg` records the parameters the flow image cannot — filter shapes, band types — so the
+page can show a peaking filter as a peaking filter rather than as six raw coefficients. It
+is only trusted while it still reproduces the flow byte for byte; if the flow has been
+replaced since, the flow wins and the page says so.
+
+Uploading a flow by hand still works, if you have a PurePath Console export:
+
+```bash
+curl -X POST "http://<device-ip>/api/fs/upload?path=/spiffs/hf/tas57xx_fw.bin" \
+     --data-binary @my_flow.bin
+```
+
+See [SPIFFS filesystem](../reference/spiffs.md) for the rest of the file API.
+
+## Troubleshooting
+
+**The page says "No processing" and the flow selector is empty.** No base image for the
+current sample rate is present. Check `curl "http://<device-ip>/api/fs/list?dir=/spiffs/hf"`
+and re-flash SPIFFS with `pio run -e <env> -t uploadfs` if it is empty.
+
+**The page loads but every control is disabled.** The part has no usable miniDSP, or the
+flow failed verification. The boot log reports both.
+
+**A tuning stopped matching after a firmware update.** SPIFFS is not touched by an OTA app
+update, so the old `.cfg` is still there. If the flow image changed, the driver falls back
+to reading the tuning out of the flow itself and logs a warning.
+
+## Related
+
+- [SqueezeAMP](../boards/squeezeamp.md)
+- [SPIFFS filesystem](../reference/spiffs.md)
+- [AirPlay tuning](airplay-tuning.md)

--- a/docs/features/tft-display.md
+++ b/docs/features/tft-display.md
@@ -64,7 +64,9 @@ At startup the driver loads a full-screen background from `/spiffs/bg/background
 PSRAM and draws all widgets on top of it. With no file present the screen falls back to
 solid black and everything still renders correctly.
 
-To replace it:
+No background ships with the firmware — one costs 106 KB of SPIFFS, which does not fit
+alongside the web UI on a 4 MB board, and most supported boards have no display at all.
+To add one:
 
 1. Design your image and export a PNG. Any size works — it gets resized.
 2. Convert it from the project root:

--- a/docs/features/usb-audio.md
+++ b/docs/features/usb-audio.md
@@ -1,0 +1,74 @@
+# USB audio (UAC)
+
+Boards with a USB OTG port can present themselves to an attached computer as a **stereo USB
+speaker**. Audio sent by the host plays through the same output path AirPlay uses, sharing
+the DAC's DSP, EQ and volume control.
+
+!!! warning "Needs USB OTG and a device-role port"
+
+    Only the ESP32-S2, S3 and P4 have a USB OTG peripheral. The D+/D- pins must also be
+    routed to a connector wired for device role (CC pulldowns). The original ESP32 cannot
+    do this at all.
+
+The board enumerates as a composite device: a USB Audio Class speaker plus an HID
+consumer-control interface that sends media keys back to the host.
+
+## How it works
+
+- AirPlay and USB audio are **mutually exclusive at runtime**, much like
+  [Bluetooth](bluetooth.md)
+- AirPlay is suspended as soon as the host starts streaming
+- The output is handed back once the host stream has been idle for
+  `CONFIG_USB_AUDIO_SINK_IDLE_MS`, 2000 ms by default
+- Host volume and mute are applied to the DAC, so the computer's own volume slider works
+- [Hardware buttons](buttons.md) send play/pause, track skip, volume and mute to the host
+  over HID, since UAC itself carries no transport controls
+
+## Sample rate
+
+USB audio runs at **48 kHz**. `CONFIG_UAC_SAMPLE_RATE` must equal
+`CONFIG_OUTPUT_SAMPLE_RATE_HZ`, because nothing resamples on this path and the descriptor
+advertises a single fixed rate.
+
+!!! danger "44100 Hz does not work"
+
+    `usb_device_uac` derives its FIFO drain rate from `sample_rate / 1000`, an integer
+    division. At 44100 that truncates 44.1 frames per millisecond to 44. The feedback
+    endpoint uses `AUDIO_FEEDBACK_METHOD_FIFO_COUNT`, so that FIFO is the control variable
+    and the host settles at 44000 frames/s while I2S consumes 44100. The resulting deficit
+    of roughly 100 frames per second slowly drains the buffer and then glitches
+    continuously. 48000 divides into 1 ms frames exactly.
+
+TAS58xx boards default to 48 kHz for this reason, and because the driver's EQ coefficients
+are computed for 48 kHz. AirPlay's 44.1 kHz stream is resampled on the way out.
+
+## Build environments
+
+| Environment | Board |
+| --- | --- |
+| `esp32s3-uac` | ESP32-S3 + PCM5102A |
+| `esparagus-audio-brick-dual-uac` | [Esparagus Audio Brick Dual](../boards/esparagus-audio-brick-dual-dac.md) |
+
+USB audio is enabled by layering `config/sdkconfig.defaults.uac` onto a board's defaults. To
+add it to a [custom board](../boards/custom.md), put that file **last** in your
+`SDKCONFIG_DEFAULTS` chain so it can override the sample rate.
+
+## Device name
+
+`CONFIG_USB_AUDIO_SINK_PRODUCT` sets the name the host displays. It is used both for the
+product string and for the audio interface, which is what Windows Device Manager shows for
+a composite function.
+
+!!! tip "Windows caches the name"
+
+    Windows stores descriptor strings per VID/PID/revision, so after changing the name it
+    may keep showing the old one. Bump `bcdDevice` in `main/usb/usb_descriptors.c` to force
+    a re-read.
+
+## Caveats
+
+- **macOS** needs `CONFIG_UAC_SUPPORT_MACOS=y`. A single descriptor cannot satisfy macOS and
+  Windows/Linux simultaneously, so this is a build-time choice.
+- **No USB console.** TinyUSB claims the USB PHY, so USB-Serial-JTAG cannot also act as a
+  console. Logs stay on UART0, and you must hold BOOT while resetting to reflash over USB.
+  [OTA updates](../reference/ota.md) avoid the problem entirely.

--- a/docs/firmware/esparagus-audio-brick-dual-dac.json
+++ b/docs/firmware/esparagus-audio-brick-dual-dac.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Esparagus Audio Brick Dual)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-esparagus-audio-brick-dual-dac.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/esparagus-audio-brick-dual-uac.json
+++ b/docs/firmware/esparagus-audio-brick-dual-uac.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Esparagus Audio Brick Dual + USB audio)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-esparagus-audio-brick-dual-uac.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/esparagus-audio-brick-s3.json
+++ b/docs/firmware/esparagus-audio-brick-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Esparagus Audio Brick S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-esparagus-audio-brick-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/esparagus-louder-bt.json
+++ b/docs/firmware/esparagus-louder-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Esparagus Louder)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-esparagus-louder-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/getting-started/first-boot.md
+++ b/docs/getting-started/first-boot.md
@@ -26,8 +26,8 @@ its IP address in your router's list of connected clients, or via the serial mon
 | Page | Purpose |
 | --- | --- |
 | `/` | Setup and control panel — device name, WiFi, volume |
-| `/logs.html` | Live log viewer |
-| `/eq.html` | 15-band equaliser, on TAS5825M boards |
+| `/logs` | Live log viewer |
+| `/bq` | Per-section biquad EQ and crossovers, on TAS5825M boards |
 
 The same interface is used for [OTA firmware updates](../reference/ota.md), so USB is only
 needed for the very first flash.

--- a/docs/getting-started/flashing.md
+++ b/docs/getting-started/flashing.md
@@ -19,6 +19,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
     Safari and Firefox do not implement, and which is unavailable on iOS and Android.
     Plug the board in over USB before clicking Install.
 
+Each board has an **Install** button for the latest release and, beside it, a dashed
+**Install beta** button for a build of the current `staging` branch. Read
+[beta builds](#beta-builds) before using the second one.
+
 ### Generic boards
 
 <div class="grid cards" markdown>
@@ -31,6 +35,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esp32s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 -   __ESP32-S2 + external DAC__
@@ -41,6 +49,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esp32s2.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 -   __Waveshare ESP32-S3__
@@ -51,6 +63,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/waveshare-esp32s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 </div>
@@ -67,6 +83,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/squeezeamp-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 -   __SqueezeAMP (4 MB flash)__
@@ -77,26 +97,10 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
-    </esp-web-install-button>
-
--   __Esparagus Audio Brick__
-
-    ESP32 + TAS5825M. Includes Bluetooth A2DP and W5500 Ethernet.
-
-    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-audio-brick-bt.json">
-      <button slot="activate" class="md-button md-button--primary">Install</button>
-      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
-      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
-    </esp-web-install-button>
-
--   __Esparagus Louder S3__
-
-    ESP32-S3 + TAS5825M with extra gain.
-
-    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-louder-s3.json">
-      <button slot="activate" class="md-button md-button--primary">Install</button>
-      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
-      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/squeezeamp-4m.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 -   __SmartAmp__
@@ -107,6 +111,104 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
       <button slot="activate" class="md-button md-button--primary">Install</button>
       <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
       <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/smartamp.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+</div>
+
+### Esparagus boards
+
+Every Esparagus board is fitted with a **TAS58xx** amplifier — a TAS5825M or a TAS5805M,
+detected at startup, so one binary covers both. The Audio Bricks also have W5500
+Ethernet. Bluetooth A2DP only exists on the original ESP32.
+
+<div class="grid cards" markdown>
+
+-   __Esparagus Audio Brick__
+
+    ESP32 + TAS58xx. Includes Bluetooth A2DP and W5500 Ethernet.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-audio-brick-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-audio-brick-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Audio Brick S3__
+
+    ESP32-S3 + TAS58xx, with W5500 Ethernet.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-audio-brick-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-audio-brick-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Audio Brick Dual__
+
+    ESP32-S3 + two amplifiers: stereo plus a bridged mono subwoofer.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-audio-brick-dual-dac.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-audio-brick-dual-dac.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Audio Brick Dual + USB audio__
+
+    The Dual, also enumerating as a USB speaker. See [USB audio](../features/usb-audio.md).
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-audio-brick-dual-uac.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-audio-brick-dual-uac.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Louder__
+
+    ESP32 + TAS58xx. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-louder-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-louder-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Louder S3__
+
+    ESP32-S3 + TAS58xx.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-louder-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-louder-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
     </esp-web-install-button>
 
 </div>
@@ -114,16 +216,31 @@ Pick your board and click Install. Nothing to download, no toolchain, no command
 Once the install finishes, unplug and re-plug the board. It boots into setup mode — carry
 on to [First boot](first-boot.md).
 
+### Beta builds
+
+The dashed **Install beta** buttons flash a build of the tip of the `staging` branch,
+rebuilt on every push. That is where fixes land before a release, so a beta is the way to
+try one — or to confirm a bug you reported is gone.
+
+It is also unreleased code. Betas come off the same CI as a release, but nobody has run
+them on hardware, so treat a failure to boot as expected rather than surprising and
+[report it](https://github.com/rbouteiller/airplay-esp32/issues). Installing the release
+build again always recovers the board.
+
+A button only appears when the build behind it exists, so the beta buttons are absent
+between `staging` pushes, and a board added since the last release shows its beta button
+alone until a release carries a build for it.
+
 !!! note "Prefer to flash manually?"
 
-    Every build above is also published as a merged `.bin` on the
-    [releases page](https://github.com/rbouteiller/airplay-esp32/releases/latest).
-    Merged images are flashed at offset **`0x0`** with `esptool` or the
-    [esptool-js web tool](https://espressif.github.io/esptool-js/).
+    Every build above is also published as a merged `.bin`, on the
+    [releases page](https://github.com/rbouteiller/airplay-esp32/releases/latest) for
+    releases and under the [`beta` tag](https://github.com/rbouteiller/airplay-esp32/releases/tag/beta)
+    for the current staging build. Merged images are flashed at offset **`0x0`** with
+    `esptool` or the [esptool-js web tool](https://espressif.github.io/esptool-js/).
 
-    Note that only the build variants listed above are published. There is no separate
-    non-Bluetooth SqueezeAMP or Esparagus Audio Brick binary — build those yourself with
-    PlatformIO if you want them.
+    Only the variants listed above are published — anything else in
+    [build environments](../reference/build-environments.md) you build yourself.
 
 ## Option B — PlatformIO
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,8 @@ plain dev boards paired with an external I2S DAC, and several integrated
 amplifier boards:
 
 - [SqueezeAMP](boards/squeezeamp.md) — ESP32 + TAS5756 DAC and Class-D amplifier
-- [Esparagus Audio Brick](boards/esparagus-audio-brick.md) — ESP32 + TAS5825M DAC/amp, on-chip DSP, optional Ethernet
+- [Esparagus Audio Brick](boards/esparagus-audio-brick.md) — ESP32 or ESP32-S3 + TAS58xx DAC/amp, on-chip DSP, Ethernet
+- [Esparagus Audio Brick Dual](boards/esparagus-audio-brick-dual-dac.md) — ESP32-S3 + two amplifiers, active crossover, USB audio
 - [ESP32-S3 + PCM5102A](boards/esp32s3-pcm5102a.md) — the cheapest route, no soldering required
 
 ESP32-based boards additionally support **Bluetooth A2DP**, so anything that can pair with

--- a/docs/reference/build-environments.md
+++ b/docs/reference/build-environments.md
@@ -19,17 +19,24 @@ Every PlatformIO environment defined in `platformio.ini`. The default is `esp32s
 | `squeezeamp` | ESP32 | TAS5756 | 8 MB | — |
 | `squeezeamp-bt` | ESP32 | TAS5756 | 8 MB | yes |
 | `squeezeamp-4m` | ESP32 | TAS5756 | 4 MB | — |
-| `esparagus-audio-brick` | ESP32 | TAS5825M | 8 MB | — |
-| `esparagus-audio-brick-bt` | ESP32 | TAS5825M | 8 MB | yes |
-| `esparagus-audio-brick-s3` | ESP32-S3 | TAS5825M | 8 MB | — |
-| `esparagus-audio-brick-dual-dac` | ESP32-S3 | 2× TAS5825M | 8 MB | — |
-| `esparagus-louder` | ESP32 | TAS5825M + gain | 8 MB | — |
-| `esparagus-louder-bt` | ESP32 | TAS5825M + gain | 8 MB | yes |
-| `esparagus-louder-s3` | ESP32-S3 | TAS5825M + gain | 8 MB | — |
+| `esparagus-audio-brick` | ESP32 | TAS58xx | 8 MB | — |
+| `esparagus-audio-brick-bt` | ESP32 | TAS58xx | 8 MB | yes |
+| `esparagus-audio-brick-s3` | ESP32-S3 | TAS58xx | 8 MB | — |
+| `esparagus-audio-brick-dual-dac` | ESP32-S3 | 2× TAS58xx | 8 MB | — |
+| `esparagus-audio-brick-dual-uac` | ESP32-S3 | 2× TAS58xx | 8 MB | — |
+| `esparagus-louder` | ESP32 | TAS58xx | 8 MB | — |
+| `esparagus-louder-bt` | ESP32 | TAS58xx | 8 MB | yes |
+| `esparagus-louder-s3` | ESP32-S3 | TAS58xx | 8 MB | — |
 | `smartamp` | ESP32 | — | 4 MB | yes |
 
-The dual-DAC environment drives a rev D board with two TAS5825M chips: stereo at I2C
-address 0x4C and a PBTL mono subwoofer at 0x4D.
+Every Esparagus board is fitted with a TAS58xx amplifier, either a TAS5825M or a TAS5805M.
+The driver reads the die ID at startup and configures whichever it finds, so the
+environment does not have to know which part is on the board.
+
+The dual-DAC environments drive an [Audio Brick Dual](../boards/esparagus-audio-brick-dual-dac.md)
+with two amplifiers: stereo at I2C address 0x4C and a second at 0x4D, wired either as a
+bridged (PBTL) mono output or as a second stereo pair. `-dual-uac` adds USB audio to the
+same board.
 
 ## Targets without a PlatformIO environment
 
@@ -50,11 +57,17 @@ idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults
 CI builds a subset of environments on every push and attaches them to each release. These
 are the ones available in the [browser installer](../getting-started/flashing.md):
 
-`esp32s3`, `waveshare-esp32s3`, `esp32s2`, `squeezeamp-bt`, `squeezeamp-4m`,
-`esparagus-audio-brick-bt`, `smartamp`, `esparagus-louder-s3`.
+`esp32s3`, `waveshare-esp32s3`, `esp32s2`, `squeezeamp-bt`, `squeezeamp-4m`, `smartamp`,
+`esparagus-audio-brick-bt`, `esparagus-audio-brick-s3`, `esparagus-audio-brick-dual-dac`,
+`esparagus-audio-brick-dual-uac`, `esparagus-louder-bt`, `esparagus-louder-s3`.
 
-Everything else you build yourself. Notably there is **no** prebuilt non-Bluetooth
-SqueezeAMP or Esparagus Audio Brick binary.
+Everything else you build yourself. On an ESP32 board that can do Bluetooth the published
+binary always includes it, so there is no prebuilt `squeezeamp`, `esparagus-audio-brick` or
+`esparagus-louder` — build one of those yourself if you want the RAM and flash back.
+
+The same matrix also runs on every push to `staging` and publishes a rolling
+[beta](../getting-started/flashing.md#beta-builds) pre-release, so each of these boards
+has an untested build of the current development tip available too.
 
 ## How sdkconfig layering works
 

--- a/docs/reference/spiffs.md
+++ b/docs/reference/spiffs.md
@@ -23,13 +23,47 @@ data/
 ├── www/               # Web interface pages
 │   ├── index.html     # Setup and control panel
 │   ├── logs.html      # Live log viewer
-│   ├── eq.html        # Equaliser (TAS5825M boards)
+│   ├── bq.html        # Parametric biquad chains (TAS5825M boards)
+│   ├── hf.html        # Hybrid flow tuning (SqueezeAMP)
 │   └── speedtest.html # Network throughput test
-├── hf/                # Hybrid flow DSP programs (SqueezeAMP)
-│   └── tas57xx_fw.bin
+├── hf/                # DSP programs loaded at boot
+│   ├── base-hf1-44100.bin  # Hybrid flow 1 base image (SqueezeAMP)
+│   ├── base-hf3-44100.bin  # Hybrid flow 3 base image (SqueezeAMP)
+│   └── tas5825m_fw-44100.bin # PPC3 dump, if you supply one (TAS5825M boards)
 └── bg/                # ST7789 background image
-    └── background.bin
+    └── background.bin  # if you supply one
 ```
+
+The `hf/` names carry the sample rate the DSP image was built for, and a 48000 twin sits
+beside each. Only the hybrid flow base images ship with the repository; a PPC3 dump is
+yours to export and drop in, as is the background image — at 106 KB it does not fit
+alongside the web UI on a 4 MB board.
+
+## Compression
+
+`data/` is not flashed verbatim. `scripts/gen_spiffs_image.py` stages it first and gzips
+every `.html`, so the image holds `index.html.gz` rather than `index.html`. That takes the
+payload from 256 KB to 101 KB, which matters because the smallest layout gives SPIFFS only
+188 KB — the pages alone overflow it uncompressed. Pages also load noticeably faster over
+WiFi.
+
+The image only ever stores the `.gz`, so the web server tries the plain name first and falls
+back to `<path>.gz`, setting `Content-Encoding: gzip` when it serves one; browsers
+decompress transparently. That order is what makes `/api/fs/upload` useful — an uploaded
+`index.html` replaces the page that shipped, and deleting it again restores the built-in
+one. The `hf/` and `bg/` binaries are read straight off the filesystem by the DAC and
+display drivers, which cannot decompress, so they are copied through untouched.
+
+Staging also drops what a build cannot use. Both DAC drivers keep their DSP images in
+`hf/`, so each build carries only the family it can load: `base-hf*.bin` and
+`tas57xx_fw*.bin` need `CONFIG_DAC_TAS57XX`, `tas5825m_fw*.bin` needs `CONFIG_DAC_TAS58XX`.
+That hands another 24 KB back to any board without a TAS57xx, taking the image to 78 KB.
+
+Both build systems go through that staging step. ESP-IDF runs it from `CMakeLists.txt`
+before `spiffs_create_partition_image`, and PlatformIO — which packs `data/` itself rather
+than using the image CMake builds — runs it from `scripts/pio_stage_spiffs.py`, wired in as
+an `extra_scripts` hook. So `idf.py flash`, `pio run -t uploadfs` and the prebuilt release
+binaries all end up with the same filesystem.
 
 ## Flashing the image
 
@@ -85,5 +119,6 @@ maximum upload size is 64 KB.
 | Path | Used by |
 | --- | --- |
 | `/spiffs/www/` | Web server — setup portal, logs, equaliser |
-| `/spiffs/hf/tas57xx_fw.bin` | [SqueezeAMP hybrid flow DSP](../boards/squeezeamp.md#hybrid-flow-dsp) |
+| `/spiffs/hf/base-hf<n>-<rate>.bin` | [HybridFlow DSP](../features/hybridflow.md) |
+| `/spiffs/hf/tas5825m_fw-<rate>.bin` | [Full PPC3 tuning](../boards/esparagus-audio-brick.md#full-ppc3-tuning) |
 | `/spiffs/bg/background.bin` | [ST7789 background image](../features/tft-display.md#background-image) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ extra_css:
 extra_javascript:
   - path: https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module
     type: module
+  - assets/js/install-buttons.js
 
 extra:
   social:
@@ -109,14 +110,17 @@ nav:
       - ESP32-S3 + PCM5102A: boards/esp32s3-pcm5102a.md
       - SqueezeAMP: boards/squeezeamp.md
       - Esparagus Audio Brick: boards/esparagus-audio-brick.md
+      - Esparagus Audio Brick Dual: boards/esparagus-audio-brick-dual-dac.md
       - Seeed XIAO ESP32-C5: boards/xiao-esp32c5.md
       - Custom board: boards/custom.md
   - Features:
       - Bluetooth A2DP: features/bluetooth.md
+      - USB audio (UAC): features/usb-audio.md
       - Ethernet (W5500): features/ethernet.md
       - OLED display: features/oled-display.md
       - ST7789 TFT display: features/tft-display.md
       - Hardware buttons: features/buttons.md
+      - HybridFlow DSP (TAS57xx): features/hybridflow.md
       - AirPlay tuning: features/airplay-tuning.md
   - Reference:
       - Build environments: reference/build-environments.md


### PR DESCRIPTION
Docs only — no firmware changes. The code stays on `staging` until a release.

## Why

The site deploys on push to `main`, so everything merged to `staging` since the last release has been invisible: the new Esparagus boards, the HybridFlow and USB audio pages, the branch policy, the SPIFFS notes.

`.github/workflows/docs.yml` has to come along, and it is the more important half. `beta.yml` republishes the site after every beta build with `gh workflow run docs.yml --ref main`, which runs **main's** copy of the workflow — and main's copy has no beta bundling at all. So the rolling `beta` pre-release is being built and refreshed on every push to staging, but it never reaches `site/firmware/beta/` and the beta install buttons have nothing to point at. This is what gives us one site with both channels.

## What's in it

- `docs/**` and `mkdocs.yml` taken wholesale from `staging`
- `.github/workflows/docs.yml` from `staging` — bundles the stable release *and* the rolling beta, and widens the PR trigger to `[main, staging]`

Deliberately **not** included: `beta.yml`, `build.yml`, `release.yml`, `ci.yml`. They do not need to be on main — `push`-triggered workflows run from the branch pushed to, and `beta.yml` calls `build.yml` by relative path, so both resolve against `staging` where they already live.

## Boards with no stable binary

The site will now document boards that only exist in the beta release, such as `esparagus-audio-brick-dual-dac`. That is the case `install-buttons.js` was written for: the bundle step drops any manifest whose binary is missing from the release, the JS hides those buttons, and the beta button shows instead. All 12 manifests match the `build.yml` matrix, so nothing is orphaned in the other direction.

## Testing

- `zensical build --strict --clean` — no issues
- Every target in the release matrix has a manifest and every manifest has a target
- No files are deleted relative to `main`, so this is purely additive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and GitHub Pages workflow only; installer visibility depends on release assets but failures degrade to hidden buttons and workflow warnings, not firmware behavior.
> 
> **Overview**
> Brings **`staging`** documentation onto **`main`** so GitHub Pages matches what integrators already see on the integration branch, without shipping firmware changes in this PR.
> 
> The **`docs.yml`** workflow is updated so deploys serve **two installer channels**: stable binaries under `site/firmware/` from the latest release, and rolling **`beta`** assets under `site/firmware/beta/` from the `beta` pre-release. A shared **`bundle()`** step downloads `.bin` files, drops manifests with no matching binary, and stamps manifest versions. PR docs checks now run for **`main` and `staging`**.
> 
> The **browser flashing page** gains dashed **Install beta** buttons beside each release install control, new **Esparagus** board entries (S3, Dual, Dual+UAC, Louder BT), and a **beta builds** section. **`install-buttons.js`** plus CSS hide install controls when the manifest is missing (404) and only reveal beta buttons once the beta manifest exists—so boards documented before a stable binary exists still read cleanly.
> 
> Content updates include new pages for **Audio Brick Dual**, **HybridFlow DSP**, and **USB audio**; a major refresh of **Esparagus Audio Brick** (ESP32 vs S3 pinouts, TAS5805M limits, `/bq` equaliser/crossover/PPC3); **contributing** branch policy (`staging` vs `main`); AirPlay v1 via **web UI** instead of Kconfig; SPIFFS gzip staging notes; and new **firmware JSON** manifests for the expanded prebuilt matrix. **`mkdocs.yml`** nav and scripts wire the new pages and installer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e54ee5ef6ba22b9bb22c3214eb03596405670a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->