### PR TITLE
buttons: add rotary encoder volume control

### DIFF
--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -39,6 +39,7 @@ device.
 | Volume down | Decrease volume, roughly 3 dB per step, auto-repeats |
 | Next track | Skip to the next track |
 | Previous | Go to the previous track |
+| Rotary encoder | Clockwise raises the volume, anti-clockwise lowers it |
 
 Volume buttons auto-repeat: hold for 500 ms and the action repeats every 200 ms.
 
@@ -66,6 +67,36 @@ Input is interrupt-driven with a 50 ms software debounce, so there is no polling
 Actions are dispatched to whichever source is active: DACP for AirPlay v1, AVRCP
 passthrough for Bluetooth.
 
+### Rotary encoder
+
+A quadrature rotary encoder — an EC11 or similar — can be used for volume instead of, or
+alongside, the volume buttons. Wire its two signal pins to the channel A and channel B
+GPIOs and its common pin to GND.
+
+```mermaid
+flowchart LR
+    A["GPIO — channel A"]
+    B["GPIO — channel B"]
+    ENC["Rotary encoder"]
+    GND["GND"]
+
+    A --- ENC
+    B --- ENC
+    ENC --- GND
+```
+
+The same pull-up rules apply as for buttons, so GPIOs 34–39 need external pull-ups on both
+channels. The encoder is decoded in the GPIO interrupt handler with a quadrature state
+machine, and one detent — four quadrature transitions on a typical encoder — produces one
+volume step.
+
+!!! tip "Turning the wrong way?"
+
+    If clockwise lowers the volume, swap the channel A and channel B GPIOs.
+
+Many encoder modules also have a push switch. It is a plain button, so wire it to any of
+the button GPIOs above — the play/pause pin is the usual choice.
+
 ## Configuration
 
 All button GPIOs default to `-1`, meaning disabled.
@@ -89,6 +120,13 @@ pio run -e <env> -t menuconfig
 | Volume down button GPIO | -1 | GPIO for volume down, auto-repeats |
 | Next track button GPIO | -1 | GPIO for next track |
 | Previous track button GPIO | -1 | GPIO for previous track |
+| Rotary encoder channel A GPIO | -1 | GPIO for encoder channel A |
+| Rotary encoder channel B GPIO | -1 | GPIO for encoder channel B |
+
+!!! note
+
+    Both rotary GPIOs must be set. If either is left at `-1` the encoder is compiled out
+    entirely.
 
 !!! note
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -562,5 +562,25 @@ menu "Airplay ESP Configuration"
                 When enabled, a single play/pause press is deferred until the
                 double-click window expires. Two presses within that window
                 cycle the audio channel mode instead of play/pause.
+
+        config BTN_ROTARY_A_GPIO
+            int "Rotary encoder channel A GPIO (-1 to disable)"
+            default -1
+            range -1 48
+            help
+                GPIO pin for channel A of a quadrature rotary encoder
+                (active-low, internal pull-up, common pin to GND). Turning the
+                encoder clockwise raises the volume, anti-clockwise lowers it.
+                Both channel A and channel B must be set for the encoder to be
+                enabled. Set to -1 to disable.
+
+        config BTN_ROTARY_B_GPIO
+            int "Rotary encoder channel B GPIO (-1 to disable)"
+            default -1
+            range -1 48
+            help
+                GPIO pin for channel B of a quadrature rotary encoder
+                (active-low, internal pull-up, common pin to GND).
+                Set to -1 to disable.
     endmenu
 endmenu

--- a/main/buttons.c
+++ b/main/buttons.c
@@ -9,6 +9,9 @@
  * Volume buttons support auto-repeat: after REPEAT_DELAY_MS held,
  * the action repeats every REPEAT_INTERVAL_MS.
  *
+ * An optional quadrature rotary encoder is decoded in the GPIO ISR and
+ * mapped onto the same volume actions: clockwise up, anti-clockwise down.
+ *
  * Button actions are dispatched to a dedicated task via a queue so that
  * playback_control functions (which may do mDNS + HTTP) never block
  * the FreeRTOS timer daemon.
@@ -35,6 +38,18 @@ static const char *TAG = "buttons";
 #define LONG_PRESS_MS    3000 // Play/pause long press for deep sleep
 #define DOUBLE_CLICK_MS  350  // Window to detect a second play/pause press
 #define ACTION_QUEUE_LEN 8
+
+#define BTN_ROTARY_ENABLED 0
+// defined() is required: an undefined int Kconfig reads as 0 in #if, which
+// would sail past the >= 0 test and enable the encoder on GPIO 0.
+#if defined(CONFIG_BTN_ROTARY_A_GPIO) && defined(CONFIG_BTN_ROTARY_B_GPIO)
+#if CONFIG_BTN_ROTARY_A_GPIO >= 0 && CONFIG_BTN_ROTARY_B_GPIO >= 0
+#undef BTN_ROTARY_ENABLED
+#define BTN_ROTARY_ENABLED 1
+#endif
+#endif
+// A detent on a common encoder (e.g. EC11) is one full quadrature cycle
+#define ROTARY_STEPS_PER_DETENT 4
 
 typedef enum {
   BTN_PLAY_PAUSE,
@@ -71,6 +86,17 @@ static void post_button_action(button_id_t id) {
   // Non-blocking: drop if queue is full (better than blocking the timer task)
   xQueueSend(s_action_queue, &action, 0);
 }
+
+#if BTN_ROTARY_ENABLED
+static void IRAM_ATTR post_button_action_from_isr(button_id_t id,
+                                                  BaseType_t *woken) {
+  int action = (int)id;
+  if (s_action_queue == NULL) {
+    return;
+  }
+  xQueueSendFromISR(s_action_queue, &action, woken);
+}
+#endif
 
 // Dedicated task that processes button actions — has enough stack for
 // mDNS discovery + HTTP requests that DACP requires.
@@ -233,6 +259,74 @@ static void IRAM_ATTR gpio_isr_handler(void *arg) {
   }
 }
 
+#if BTN_ROTARY_ENABLED
+// Quadrature transition table indexed by (previous << 2) | current, where a
+// state is (A << 1) | B. Valid single-line changes give +/-1; an entry of 0 is
+// either no movement or an impossible both-lines-changed transition (contact
+// bounce or a missed edge), which is discarded. Positive is the direction in
+// which A leads B, i.e. clockwise on a standard encoder.
+static const int8_t rotary_delta[16] = {0,  -1, 1, 0, 1, 0, 0,  -1,
+                                        -1, 0,  0, 1, 0, 1, -1, 0};
+
+// Touched only by the ISR, so no locking is needed.
+static uint8_t s_rotary_state;
+static int8_t s_rotary_accum;
+
+static void IRAM_ATTR rotary_isr_handler(void *arg) {
+  (void)arg;
+  uint8_t state = (uint8_t)((gpio_get_level(CONFIG_BTN_ROTARY_A_GPIO) << 1) |
+                            gpio_get_level(CONFIG_BTN_ROTARY_B_GPIO));
+  int8_t delta = rotary_delta[(s_rotary_state << 2) | state];
+  s_rotary_state = state;
+  if (delta == 0) {
+    return;
+  }
+
+  // Signed accumulation, so bouncing back and forth cancels itself out.
+  s_rotary_accum += delta;
+  if (s_rotary_accum <= -ROTARY_STEPS_PER_DETENT ||
+      s_rotary_accum >= ROTARY_STEPS_PER_DETENT) {
+    BaseType_t woken = pdFALSE;
+    post_button_action_from_isr(
+        s_rotary_accum > 0 ? BTN_VOLUME_UP : BTN_VOLUME_DOWN, &woken);
+    s_rotary_accum = 0;
+    if (woken) {
+      portYIELD_FROM_ISR();
+    }
+  }
+}
+
+static void configure_rotary(void) {
+  gpio_config_t io_conf = {
+      .pin_bit_mask = (1ULL << CONFIG_BTN_ROTARY_A_GPIO) |
+                      (1ULL << CONFIG_BTN_ROTARY_B_GPIO),
+      .mode = GPIO_MODE_INPUT,
+      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_down_en = GPIO_PULLDOWN_DISABLE,
+      .intr_type = GPIO_INTR_ANYEDGE,
+  };
+  gpio_config(&io_conf);
+
+  // Seed the state machine from the resting position, or the first edge
+  // decodes against a phantom transition.
+  s_rotary_state = (uint8_t)((gpio_get_level(CONFIG_BTN_ROTARY_A_GPIO) << 1) |
+                             gpio_get_level(CONFIG_BTN_ROTARY_B_GPIO));
+  s_rotary_accum = 0;
+
+  gpio_isr_handler_add(CONFIG_BTN_ROTARY_A_GPIO, rotary_isr_handler, NULL);
+  gpio_isr_handler_add(CONFIG_BTN_ROTARY_B_GPIO, rotary_isr_handler, NULL);
+
+#if CONFIG_BTN_ROTARY_A_GPIO >= 34 || CONFIG_BTN_ROTARY_B_GPIO >= 34
+  ESP_LOGW(TAG,
+           "Rotary encoder on GPIO %d/%d: GPIOs 34-39 have no internal "
+           "pull-up, external ones are required",
+           CONFIG_BTN_ROTARY_A_GPIO, CONFIG_BTN_ROTARY_B_GPIO);
+#endif
+  ESP_LOGI(TAG, "Rotary encoder on GPIO %d (A) / %d (B)",
+           CONFIG_BTN_ROTARY_A_GPIO, CONFIG_BTN_ROTARY_B_GPIO);
+}
+#endif // BTN_ROTARY_ENABLED
+
 static void configure_button(button_id_t id, int gpio, bool repeatable) {
   buttons[id].gpio = gpio;
   buttons[id].repeatable = repeatable;
@@ -299,7 +393,7 @@ esp_err_t buttons_init(void) {
 
   if (CONFIG_BTN_PLAY_PAUSE_GPIO < 0 && CONFIG_BTN_VOLUME_UP_GPIO < 0 &&
       CONFIG_BTN_VOLUME_DOWN_GPIO < 0 && CONFIG_BTN_NEXT_GPIO < 0 &&
-      CONFIG_BTN_PREV_GPIO < 0) {
+      CONFIG_BTN_PREV_GPIO < 0 && !BTN_ROTARY_ENABLED) {
     ESP_LOGI(TAG, "No buttons configured");
     return ESP_OK;
   }
@@ -325,6 +419,10 @@ esp_err_t buttons_init(void) {
   configure_button(BTN_VOLUME_DOWN, CONFIG_BTN_VOLUME_DOWN_GPIO, true);
   configure_button(BTN_NEXT, CONFIG_BTN_NEXT_GPIO, false);
   configure_button(BTN_PREV, CONFIG_BTN_PREV_GPIO, false);
+
+#if BTN_ROTARY_ENABLED
+  configure_rotary();
+#endif
 
   ESP_LOGI(TAG, "Buttons initialized (interrupt-driven)");
   return ESP_OK;

--- a/main/buttons.c
+++ b/main/buttons.c
@@ -311,16 +311,32 @@ static void IRAM_ATTR rotary_isr_handler(void *arg) {
   }
 }
 
-static void configure_rotary(void) {
+// Configured a pin at a time, since the two channels may not agree on whether
+// an internal pull-up is available.
+static void configure_rotary_pin(int gpio) {
+  bool has_internal_pullup = (gpio < 34);
   gpio_config_t io_conf = {
-      .pin_bit_mask = (1ULL << CONFIG_BTN_ROTARY_A_GPIO) |
-                      (1ULL << CONFIG_BTN_ROTARY_B_GPIO),
+      .pin_bit_mask = (1ULL << gpio),
       .mode = GPIO_MODE_INPUT,
-      .pull_up_en = GPIO_PULLUP_ENABLE,
+      .pull_up_en =
+          has_internal_pullup ? GPIO_PULLUP_ENABLE : GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
       .intr_type = GPIO_INTR_ANYEDGE,
   };
   gpio_config(&io_conf);
+  gpio_isr_handler_add(gpio, rotary_isr_handler, NULL);
+
+  if (!has_internal_pullup) {
+    ESP_LOGW(TAG,
+             "Rotary encoder on GPIO %d: no internal pull-up, needs "
+             "external",
+             gpio);
+  }
+}
+
+static void configure_rotary(void) {
+  configure_rotary_pin(CONFIG_BTN_ROTARY_A_GPIO);
+  configure_rotary_pin(CONFIG_BTN_ROTARY_B_GPIO);
 
   // Seed the state machine from the resting position, or the first edge
   // decodes against a phantom transition.
@@ -328,15 +344,6 @@ static void configure_rotary(void) {
                              gpio_get_level(CONFIG_BTN_ROTARY_B_GPIO));
   s_rotary_accum = 0;
 
-  gpio_isr_handler_add(CONFIG_BTN_ROTARY_A_GPIO, rotary_isr_handler, NULL);
-  gpio_isr_handler_add(CONFIG_BTN_ROTARY_B_GPIO, rotary_isr_handler, NULL);
-
-#if CONFIG_BTN_ROTARY_A_GPIO >= 34 || CONFIG_BTN_ROTARY_B_GPIO >= 34
-  ESP_LOGW(TAG,
-           "Rotary encoder on GPIO %d/%d: GPIOs 34-39 have no internal "
-           "pull-up, external ones are required",
-           CONFIG_BTN_ROTARY_A_GPIO, CONFIG_BTN_ROTARY_B_GPIO);
-#endif
   ESP_LOGI(TAG, "Rotary encoder on GPIO %d (A) / %d (B)",
            CONFIG_BTN_ROTARY_A_GPIO, CONFIG_BTN_ROTARY_B_GPIO);
 }

--- a/main/buttons.c
+++ b/main/buttons.c
@@ -272,27 +272,42 @@ static const int8_t rotary_delta[16] = {0,  -1, 1, 0, 1, 0, 0,  -1,
 static uint8_t s_rotary_state;
 static int8_t s_rotary_accum;
 
-static void IRAM_ATTR rotary_isr_handler(void *arg) {
-  (void)arg;
-  uint8_t state = (uint8_t)((gpio_get_level(CONFIG_BTN_ROTARY_A_GPIO) << 1) |
-                            gpio_get_level(CONFIG_BTN_ROTARY_B_GPIO));
+// Feeds one new (A << 1) | B reading in. Returns +1 for a clockwise detent,
+// -1 for anti-clockwise, 0 while still mid-detent.
+static int IRAM_ATTR rotary_feed(uint8_t state) {
   int8_t delta = rotary_delta[(s_rotary_state << 2) | state];
   s_rotary_state = state;
   if (delta == 0) {
-    return;
+    return 0;
   }
 
   // Signed accumulation, so bouncing back and forth cancels itself out.
   s_rotary_accum += delta;
-  if (s_rotary_accum <= -ROTARY_STEPS_PER_DETENT ||
-      s_rotary_accum >= ROTARY_STEPS_PER_DETENT) {
-    BaseType_t woken = pdFALSE;
-    post_button_action_from_isr(
-        s_rotary_accum > 0 ? BTN_VOLUME_UP : BTN_VOLUME_DOWN, &woken);
+  if (s_rotary_accum >= ROTARY_STEPS_PER_DETENT) {
     s_rotary_accum = 0;
-    if (woken) {
-      portYIELD_FROM_ISR();
-    }
+    return 1;
+  }
+  if (s_rotary_accum <= -ROTARY_STEPS_PER_DETENT) {
+    s_rotary_accum = 0;
+    return -1;
+  }
+  return 0;
+}
+
+static void IRAM_ATTR rotary_isr_handler(void *arg) {
+  (void)arg;
+  uint8_t state = (uint8_t)((gpio_get_level(CONFIG_BTN_ROTARY_A_GPIO) << 1) |
+                            gpio_get_level(CONFIG_BTN_ROTARY_B_GPIO));
+  int step = rotary_feed(state);
+  if (step == 0) {
+    return;
+  }
+
+  BaseType_t woken = pdFALSE;
+  post_button_action_from_isr(step > 0 ? BTN_VOLUME_UP : BTN_VOLUME_DOWN,
+                              &woken);
+  if (woken) {
+    portYIELD_FROM_ISR();
   }
 }
 


### PR DESCRIPTION
## Summary

Adds optional quadrature rotary encoder support to the button driver. Turning
clockwise raises the volume, anti-clockwise lowers it, reusing the existing
`BTN_VOLUME_UP` / `BTN_VOLUME_DOWN` actions so it works for AirPlay (DACP) and
Bluetooth (AVRCP passthrough) alike.

Two new Kconfig options, both defaulting to `-1`:

- `CONFIG_BTN_ROTARY_A_GPIO`
- `CONFIG_BTN_ROTARY_B_GPIO`

Both must be set or the encoder is compiled out entirely, so existing boards are
unaffected — the added code is behind `#if BTN_ROTARY_ENABLED` and does not link
into a build that leaves the defaults alone.

## Implementation

Decoding is a 16-entry quadrature transition table driven from the GPIO ISR,
indexed by `(previous << 2) | current` where a state is `(A << 1) | B`. Valid
single-line changes give ±1; both-lines-changed entries are 0 and get discarded,
which absorbs contact bounce and missed edges. Deltas accumulate signed, so
jitter around a detent cancels itself out, and one full cycle of four
transitions emits one volume step.

PCNT was the obvious alternative but its availability varies across the targets
this firmware supports (ESP32/S2/S3/C5/P4), so a GPIO state machine keeps one
code path everywhere.

Notes on the details that are easy to get wrong:

- `xQueueSend` is not ISR-safe, so the encoder posts through a new
  `post_button_action_from_isr()` wrapper around `xQueueSendFromISR`.
- `board_gpio_isr_init()` installs the shared ISR service with flags `0`, not
  `ESP_INTR_FLAG_IRAM`, so handlers are masked during flash operations and the
  flash-resident transition table is safe to read.
- `BTN_ROTARY_ENABLED` is resolved with `defined()` guards rather than a bare
  comparison: an undefined int Kconfig evaluates to `0` in `#if`, which would
  sail past a `>= 0` test and silently enable the encoder on GPIO 0.
- The state machine is seeded from the resting pin levels at init, otherwise the
  first edge decodes against a phantom transition.
- A build-time warning fires if either channel is on GPIO 34–39, which have no
  internal pull-up.

The second commit splits `rotary_feed()` out of the ISR — it takes a raw
`(A << 1) | B` reading and returns +1, −1 or 0, leaving the handler to do nothing
but sample the pins and post an action. No behavioural change, but it makes the
direction mapping testable without hardware.

## Testing

- Builds clean on `waveshare-esp32s3` (encoder both enabled and disabled) and on
  an ESP32 SqueezeAMP-derived target with the encoder on GPIO 22/19.
- Direction mapping verified on hardware by feeding `rotary_feed()` a synthetic
  quadrature sequence on-device: three clockwise detents and three
  anti-clockwise gave 3 volume-up, 3 volume-down and 0 spurious steps.
- `zensical build --strict` passes.

## Docs

`docs/features/buttons.md` gains a rotary encoder section with a wiring diagram,
the pull-up caveat, a note that the module's push switch is a plain button, and
the fix if clockwise turns out to lower the volume (swap the two GPIOs).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in Kconfig and compile-time gating limit exposure; changes extend existing volume actions rather than altering playback or network logic.
> 
> **Overview**
> Adds **optional quadrature rotary encoder** volume input alongside the existing volume buttons. Clockwise and anti-clockwise turns map to the same **`BTN_VOLUME_UP` / `BTN_VOLUME_DOWN`** actions, so AirPlay DACP and Bluetooth AVRCP behavior stays unchanged.
> 
> Enablement is via two new menuconfig options — **`CONFIG_BTN_ROTARY_A_GPIO`** and **`CONFIG_BTN_ROTARY_B_GPIO`** (both default `-1`). **Both pins must be set** or the feature is compiled out with **`BTN_ROTARY_ENABLED`**, leaving default builds untouched.
> 
> The driver decodes the encoder in a **GPIO interrupt handler** using a quadrature transition table and signed step accumulation (four transitions per detent), then queues volume actions through a new **`post_button_action_from_isr()`** path. **`buttons_init()`** also treats a configured encoder as “buttons present” so init runs when only the rotary is wired.
> 
> **`docs/features/buttons.md`** documents wiring, pull-up rules, direction swap, and the optional encoder push switch as a normal button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b6c93bc26309c6e18fdf2c664841f5a58e78ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->