### PR TITLE
docs: publish the site to main for the Esparagus boards

### DIFF
--- a/docs/boards/amped-esp32.md
+++ b/docs/boards/amped-esp32.md
@@ -1,0 +1,108 @@
+# Amped-ESP32 and Amped-Esparagus
+
+The Sonocotta [Amped-ESP32](https://github.com/sonocotta/esp32-audio-dock) boards put a
+**PCM5100** I2S DAC in front of a **TPA3110** or **TPA3128** Class-D amplifier. Speakers
+connect directly to the board, but unlike the [Loud](loud-esp32.md) boards the signal
+passes through a real DAC first.
+
+Neither part has an I2C control port. The amplifier's only control line is an active-high
+`UNMUTE` pin, driven from RTSP playback events by the same board support code the Loud
+boards use: muted until a client presses play, standby on pause, off on disconnect.
+
+## Variants
+
+| Environment | Chip | Ethernet | Display | Controls | Bluetooth | Prebuilt |
+| --- | --- | :-: | :-: | --- | :-: | :-: |
+| `amped-esp32` | ESP32 | yes | SH1106 OLED | — | — | — |
+| `amped-esp32-bt` | ESP32 | yes | SH1106 OLED | — | yes | yes |
+| `amped-esparagus` | ESP32 | yes | — | rotary encoder | — | — |
+| `amped-esparagus-bt` | ESP32 | yes | — | rotary encoder | yes | yes |
+| `amped-esp32-s3` | ESP32-S3 | yes | SH1106 OLED | — | — | yes |
+
+Bluetooth Classic exists only on the original ESP32, so there is no `-bt` build for the
+S3 board. On an ESP32 the published binary is the Bluetooth one.
+
+!!! warning "Amped-Esparagus is rev M only"
+
+    `config/sdkconfig.defaults.amped-esparagus` describes **rev M** hardware. Earlier
+    revisions use a different pinout.
+
+    Its ILI9342 TFT is not a supported driver — the firmware speaks
+    [SSD1306/SH1106/SSD1309 OLED](../features/oled-display.md) and
+    [ST7789 TFT](../features/tft-display.md) — so display support is commented out in the
+    board configuration and the board ships without a screen. The rotary encoder works:
+    turning it changes volume, clicking it toggles play/pause.
+
+## Features
+
+- PCM5100 DAC into a TPA3110 or TPA3128 Class-D amplifier
+- Amplifier held muted until playback starts, standby on pause, off on disconnect
+- Software volume control — neither part has a volume register
+- 8 MB flash
+- [Bluetooth A2DP](../features/bluetooth.md) on the ESP32 variants
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover
+- [SH1106 OLED](../features/oled-display.md) over SPI on Amped-ESP32 and Amped-ESP32-S3;
+  a [rotary encoder](../features/buttons.md) on Amped-Esparagus
+
+## Flashing
+
+=== "Browser"
+
+    Use the Amped installer for your board on the
+    [flashing page](../getting-started/flashing.md).
+
+=== "PlatformIO"
+
+    ```bash
+    # ESP32 — AirPlay + Bluetooth + Ethernet + OLED
+    pio run -e amped-esp32-bt -t upload
+    pio run -e amped-esp32-bt -t uploadfs
+
+    # ESP32 — Esparagus rev M, rotary encoder
+    pio run -e amped-esparagus-bt -t upload
+    pio run -e amped-esparagus-bt -t uploadfs
+
+    # ESP32-S3
+    pio run -e amped-esp32-s3 -t upload
+    pio run -e amped-esp32-s3 -t uploadfs
+    ```
+
+=== "ESP-IDF"
+
+    ```bash
+    idf.py set-target esp32
+    idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.amped-esp32;config/sdkconfig.defaults.bt" build
+    idf.py -p /dev/ttyUSB0 flash
+    ```
+
+    Swap in `config/sdkconfig.defaults.amped-esp32-s3` after `idf.py set-target esp32s3`
+    for the S3 revision.
+
+## Default GPIO assignments
+
+| Function | Amped-ESP32 | Amped-Esparagus | Amped-ESP32-S3 |
+| --- | :-: | :-: | :-: |
+| I2S BCK | 26 | 26 | 14 |
+| I2S WS | 25 | 25 | 15 |
+| I2S DO | 22 | 22 | 16 |
+| Amp `UNMUTE` | 13 | 13 | 17 |
+| Status LED | — | 12 | — |
+| Rotary A | — | 33 | — |
+| Rotary B | — | 27 | — |
+| Encoder click | — | 34 | — |
+| SPI SCLK | 18 | 18 | 12 |
+| SPI MOSI | 23 | 23 | 11 |
+| SPI MISO | 19 | 19 | 13 |
+| Ethernet CS | 5 | 5 | 10 |
+| Ethernet INT | 35 | 35 | 6 |
+| Ethernet RST | 14 | 14 | 5 |
+| Display CS | 15 | — | 47 |
+| Display DC | 4 | — | 38 |
+| Display RST | 32 | — | 48 |
+
+## Related
+
+- [Loud-ESP32](loud-esp32.md) — MAX98357A amplifiers, no DAC in front
+- [HiFi-ESP32](hifi-esp32.md) — the same PCM5100 at line level, no amplifier
+- [Buttons and rotary encoders](../features/buttons.md)
+- [Build environments](../reference/build-environments.md)

--- a/docs/boards/hifi-esp32.md
+++ b/docs/boards/hifi-esp32.md
@@ -1,0 +1,105 @@
+# HiFi-ESP32 and HiFi-Esparagus
+
+The Sonocotta [HiFi-ESP32](https://github.com/sonocotta/esp32-audio-dock) boards pair an
+ESP32 or ESP32-S3 with a TI **PCM5100** I2S DAC and a line-level output. There is no
+amplifier on board, so these feed an existing amp or a pair of active speakers.
+
+The PCM5100 is a plain I2S DAC: no I2C control port, no mute pin and no hardware volume
+register. The firmware therefore does volume in software and the board support code has
+nothing to do beyond bringing up the SPI bus that Ethernet and the display share.
+
+## Variants
+
+| Environment | Chip | Ethernet | Display | Bluetooth | Prebuilt |
+| --- | --- | :-: | :-: | :-: | :-: |
+| `hifi-esp32` | ESP32 | yes | SH1106 OLED | — | — |
+| `hifi-esp32-bt` | ESP32 | yes | SH1106 OLED | yes | yes |
+| `hifi-esparagus` | ESP32 | — | — | — | — |
+| `hifi-esparagus-bt` | ESP32 | — | — | yes | yes |
+| `hifi-esp32-s3` | ESP32-S3 | yes | SH1106 OLED | — | yes |
+| `hifi-esparagus-s3` | ESP32-S3 | — | — | — | yes |
+
+The **Esparagus** variants are the same audio design without the Ethernet jack and the
+display header; they carry a WS2812 status LED instead. Bluetooth Classic exists only on
+the original ESP32, so there is no `-bt` build for either S3 variant.
+
+On an ESP32 the published binary is the Bluetooth one. Build `hifi-esp32` or
+`hifi-esparagus` yourself if you would rather have the RAM and flash back.
+
+## Features
+
+- PCM5100 line-level DAC, all 8 MB flash
+- Software volume control — the DAC has no volume register
+- [Bluetooth A2DP](../features/bluetooth.md) on the ESP32 variants
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover, on the
+  non-Esparagus variants
+- [SH1106 OLED](../features/oled-display.md) over SPI, sharing the Ethernet bus, on the
+  non-Esparagus variants
+
+## Flashing
+
+=== "Browser"
+
+    Use the HiFi installer for your board on the
+    [flashing page](../getting-started/flashing.md).
+
+=== "PlatformIO"
+
+    ```bash
+    # ESP32 — AirPlay + Bluetooth + Ethernet + OLED
+    pio run -e hifi-esp32-bt -t upload
+    pio run -e hifi-esp32-bt -t uploadfs
+
+    # ESP32 — Esparagus variant, AirPlay + Bluetooth over WiFi
+    pio run -e hifi-esparagus-bt -t upload
+    pio run -e hifi-esparagus-bt -t uploadfs
+
+    # ESP32-S3 — AirPlay + Ethernet + OLED
+    pio run -e hifi-esp32-s3 -t upload
+    pio run -e hifi-esp32-s3 -t uploadfs
+
+    # ESP32-S3 — Esparagus variant
+    pio run -e hifi-esparagus-s3 -t upload
+    pio run -e hifi-esparagus-s3 -t uploadfs
+    ```
+
+=== "ESP-IDF"
+
+    ```bash
+    idf.py set-target esp32
+    idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.hifi-esp32;config/sdkconfig.defaults.bt" build
+    idf.py -p /dev/ttyUSB0 flash
+    ```
+
+    Swap in `config/sdkconfig.defaults.hifi-esp32-s3` after `idf.py set-target esp32s3`
+    for the S3 revision, and drop `config/sdkconfig.defaults.bt` for a build without
+    Bluetooth.
+
+## Default GPIO assignments
+
+| Function | ESP32 | ESP32-S3 | Notes |
+| --- | :-: | :-: | --- |
+| I2S BCK | 26 | 14 | Bit clock |
+| I2S WS | 25 | 15 | Word select (LRCLK) |
+| I2S DO | 22 | 16 | Serial audio data |
+| I2S MCLK | — | — | Not used; the PCM5100 recovers its own clock |
+| Status LED | 33 | 9 | Addressable RGB, Esparagus variants only |
+| SPI SCLK | 18 | 12 | Shared by Ethernet and display |
+| SPI MOSI | 23 | 11 | Shared by Ethernet and display |
+| SPI MISO | 19 | 13 | Ethernet only |
+| Ethernet CS | 5 | 10 | W5500 |
+| Ethernet INT | 35 | 6 | W5500 |
+| Ethernet RST | 14 | 5 | W5500 |
+| Display CS | 15 | 39 | SH1106 OLED |
+| Display DC | 4 | 40 | SH1106 OLED |
+| Display RST | 32 | 38 | SH1106 OLED |
+
+The Esparagus variants use the same I2S pins and leave the SPI block unconfigured.
+
+## Related
+
+- [Loud-ESP32](loud-esp32.md) — the same layout with MAX98357A amplifiers on board
+- [Amped-ESP32](amped-esp32.md) — a PCM5100 with a TPA31xx amplifier behind it
+- [Bluetooth A2DP](../features/bluetooth.md)
+- [Ethernet (W5500)](../features/ethernet.md)
+- [Build environments](../reference/build-environments.md)

--- a/docs/boards/index.md
+++ b/docs/boards/index.md
@@ -14,8 +14,8 @@ flowchart TD
     AMP{"Want a built-in<br/>amplifier?"}
 
     S3["ESP32-S3 + PCM5102A<br/><small>cheapest, about $10</small>"]
-    AMPBOARD["Esparagus Audio Brick<br/>or SqueezeAMP<br/><small>speakers connect directly</small>"]
-    ESP32["ESP32 + PCM5102A<br/><small>use your own amp</small>"]
+    AMPBOARD["Esparagus Audio Brick, SqueezeAMP,<br/>Louder / Loud / Amped<br/><small>speakers connect directly</small>"]
+    ESP32["ESP32 + PCM5102A<br/>or HiFi-ESP32<br/><small>use your own amp</small>"]
 
     BT -->|no| S3
     BT -->|yes| AMP
@@ -36,7 +36,16 @@ original ESP32.
 | [SqueezeAMP](squeezeamp.md) | ESP32 | TAS5756 | yes | — | yes |
 | [Esparagus Audio Brick](esparagus-audio-brick.md) | ESP32 / S3 | TAS58xx | ESP32 only | yes | yes |
 | [Esparagus Audio Brick Dual](esparagus-audio-brick-dual-dac.md) | ESP32-S3 | 2× TAS58xx | — | yes | yes |
-| [Esparagus Louder](esparagus-audio-brick.md#esparagus-louder) | ESP32 / S3 | TAS58xx | ESP32 only | — | yes |
+| [Esparagus Louder](esparagus-audio-brick.md#esparagus-louder) | ESP32 / S3 | TAS58xx | ESP32 only | yes | yes |
+| [HiFi-ESP32](hifi-esp32.md) | ESP32 / S3 | PCM5100, line level | ESP32 only | yes | yes |
+| [HiFi-Esparagus](hifi-esp32.md) | ESP32 / S3 | PCM5100, line level | ESP32 only | — | yes |
+| [Loud-ESP32](loud-esp32.md) | ESP32 / S3 | MAX98357A | ESP32 only | yes | yes |
+| [Loud-Esparagus](loud-esp32.md) | ESP32 | 2× MAX98357A | yes | — | yes |
+| [Esparagus Echo](loud-esp32.md) | ESP32-S3 | 2× MAX98357A | — | yes | yes |
+| [Amped-ESP32](amped-esp32.md) | ESP32 / S3 | PCM5100 + TPA31xx | ESP32 only | yes | yes |
+| [Amped-Esparagus](amped-esp32.md) | ESP32 | PCM5100 + TPA31xx | yes | yes | yes |
+| [Louder-ESP32](louder-esp32.md) | ESP32 / S3 | TAS5805M | ESP32 only | yes | yes |
+| [Louder-ESP32-Plus](louder-esp32.md) | ESP32 / S3 | TAS5825M | ESP32 only | yes | yes |
 | [Seeed XIAO ESP32-C5](xiao-esp32c5.md) | ESP32-C5 | External I2S | — | — | — |
 | [Custom board](custom.md) | any | any | — | — | — |
 

--- a/docs/boards/loud-esp32.md
+++ b/docs/boards/loud-esp32.md
@@ -1,0 +1,113 @@
+# Loud-ESP32, Loud-Esparagus and Esparagus Echo
+
+The Sonocotta [Loud-ESP32](https://github.com/sonocotta/esp32-audio-dock) boards drive
+**MAX98357A** I2S amplifiers directly — no DAC in front, no I2C control port. Speakers
+connect straight to the board.
+
+A MAX98357A has exactly one control line: an active-high `SD_MODE` enable. The firmware
+registers a minimal DAC driver whose only job is to drive that pin from RTSP playback
+events, so the amplifier is held muted until a client actually presses play and drops
+back to standby on pause. That is the same power-state handling the
+[Esparagus Audio Brick](esparagus-audio-brick.md) does over I2C, reduced to one GPIO.
+
+## Variants
+
+| Environment | Chip | Amps | Ethernet | Display | Bluetooth | Prebuilt |
+| --- | --- | :-: | :-: | :-: | :-: | :-: |
+| `loud-esp32` | ESP32 | 1 | yes | SH1106 OLED | — | — |
+| `loud-esp32-bt` | ESP32 | 1 | yes | SH1106 OLED | yes | yes |
+| `loud-esparagus` | ESP32 | 2 | — | — | — | — |
+| `loud-esparagus-bt` | ESP32 | 2 | — | — | yes | yes |
+| `loud-esp32-s3` | ESP32-S3 | 2 | yes | SH1106 OLED | — | yes |
+| `esparagus-echo` | ESP32-S3 | 2 | yes | — | — | yes |
+
+Both amplifiers share the one enable pin, so a dual-amp board mutes and unmutes as a
+unit. Bluetooth Classic exists only on the original ESP32, so neither S3 board has a
+`-bt` build; on an ESP32 the published binary is the Bluetooth one.
+
+[Esparagus Echo](https://github.com/sonocotta/esparagus-echo) is the same amplifier
+arrangement on the Echo's S3 board — Ethernet, an RGB status LED and no display header.
+
+## Features
+
+- One or two MAX98357A Class-D amplifiers, speakers connected directly
+- Amplifier held muted until playback starts, standby on pause, off on disconnect
+- Software volume control — the MAX98357A has no volume register
+- 8 MB flash
+- [Bluetooth A2DP](../features/bluetooth.md) on the ESP32 variants
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover, except on
+  Loud-Esparagus
+- [SH1106 OLED](../features/oled-display.md) over SPI, sharing the Ethernet bus, on
+  Loud-ESP32 and Loud-ESP32-S3
+
+## Flashing
+
+=== "Browser"
+
+    Use the Loud or Esparagus Echo installer on the
+    [flashing page](../getting-started/flashing.md).
+
+=== "PlatformIO"
+
+    ```bash
+    # ESP32 — AirPlay + Bluetooth + Ethernet + OLED
+    pio run -e loud-esp32-bt -t upload
+    pio run -e loud-esp32-bt -t uploadfs
+
+    # ESP32 — Esparagus variant, dual amp over WiFi
+    pio run -e loud-esparagus-bt -t upload
+    pio run -e loud-esparagus-bt -t uploadfs
+
+    # ESP32-S3 — dual amp, Ethernet + OLED
+    pio run -e loud-esp32-s3 -t upload
+    pio run -e loud-esp32-s3 -t uploadfs
+
+    # ESP32-S3 — Esparagus Echo
+    pio run -e esparagus-echo -t upload
+    pio run -e esparagus-echo -t uploadfs
+    ```
+
+=== "ESP-IDF"
+
+    ```bash
+    idf.py set-target esp32
+    idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.loud-esp32;config/sdkconfig.defaults.bt" build
+    idf.py -p /dev/ttyUSB0 flash
+    ```
+
+    Swap in `config/sdkconfig.defaults.loud-esp32-s3` or
+    `config/sdkconfig.defaults.esparagus-echo` after `idf.py set-target esp32s3` for the
+    S3 boards.
+
+## Default GPIO assignments
+
+| Function | Loud-ESP32 | Loud-Esparagus | Loud-ESP32-S3 | Esparagus Echo |
+| --- | :-: | :-: | :-: | :-: |
+| I2S BCK | 26 | 26 | 14 | 18 |
+| I2S WS | 25 | 25 | 15 | 8 |
+| I2S DO | 22 | 22 | 16 | 17 |
+| Amp enable (`SD_MODE`) | 13 | 13 | 17 | 9 |
+| Status LED | — | 33 | — | 42 |
+| SPI SCLK | 18 | — | 12 | 12 |
+| SPI MOSI | 23 | — | 11 | 11 |
+| SPI MISO | 19 | — | 13 | 13 |
+| Ethernet CS | 5 | — | 10 | 10 |
+| Ethernet INT | 35 | — | 6 | 6 |
+| Ethernet RST | 14 | — | 5 | 5 |
+| Display CS | 15 | — | 39 | — |
+| Display DC | 4 | — | 40 | — |
+| Display RST | 32 | — | 38 | — |
+
+!!! warning "The Loud-ESP32-S3 enable pin moved"
+
+    `CONFIG_DAC_ENABLE_GPIO` is GPIO 17 for rev G and later hardware. Rev F used GPIO 8.
+    On a rev F board, override it in a
+    [custom configuration](custom.md) or nothing will ever unmute.
+
+## Related
+
+- [HiFi-ESP32](hifi-esp32.md) — the same layout with a line-level PCM5100 instead
+- [Amped-ESP32](amped-esp32.md) — PCM5100 with a TPA31xx amplifier
+- [Bluetooth A2DP](../features/bluetooth.md)
+- [Ethernet (W5500)](../features/ethernet.md)
+- [Build environments](../reference/build-environments.md)

--- a/docs/boards/louder-esp32.md
+++ b/docs/boards/louder-esp32.md
@@ -1,0 +1,121 @@
+# Louder-ESP32 and Louder-ESP32-Plus
+
+The Sonocotta [Louder-ESP32](https://github.com/sonocotta/esp32-audio-dock) boards carry a
+TI **TAS58xx** combined DAC and Class-D amplifier, the same family the
+[Esparagus Audio Brick](esparagus-audio-brick.md) uses. Speakers connect directly.
+
+The **Plus** boards are fitted with a **TAS5825M**; the plain boards with a **TAS5805M**.
+Both are driven by the same driver, which reads the die ID at startup, so the difference
+is what the part can do rather than which build you flash:
+
+- Volume, mute and the 15-band parametric [Equaliser](esparagus-audio-brick.md#equaliser)
+  work on both parts.
+- Process flows and full PPC3 dumps are a **TAS5825M** feature. A TAS5805M has no
+  flow-select register, so the driver skips a dump rather than write it to the wrong
+  place. See [TAS5805M boards](esparagus-audio-brick.md#tas5805m-boards).
+
+Volume is done in the amplifier (`CONFIG_DAC_CONTROLS_VOLUME`) rather than in software.
+
+## Variants
+
+| Environment | Chip | Amplifier | Bluetooth | Prebuilt |
+| --- | --- | --- | :-: | :-: |
+| `louder-esp32` | ESP32 | TAS5805M | — | — |
+| `louder-esp32-bt` | ESP32 | TAS5805M | yes | yes |
+| `louder-esp32-plus` | ESP32 | TAS5825M | — | — |
+| `louder-esp32-plus-bt` | ESP32 | TAS5825M | yes | yes |
+| `louder-esp32-s3` | ESP32-S3 | TAS5805M | — | yes |
+| `louder-esp32-s3-plus` | ESP32-S3 | TAS5825M | — | yes |
+
+Bluetooth Classic exists only on the original ESP32, so neither S3 board has a `-bt`
+build. On an ESP32 the published binary is the Bluetooth one.
+
+!!! note "Esparagus Louder is a separate board"
+
+    The [Esparagus Louder](esparagus-audio-brick.md#esparagus-louder) is the same
+    amplifier family on Sonocotta's Esparagus form factor and has its own environments
+    (`esparagus-louder`, `-bt`, `-s3`). Its ESP32 build differs from `louder-esp32` in
+    pinout: it has a FAULTZ line and an RGB LED, and no `PDN` pin.
+
+## Features
+
+- TAS5825M or TAS5805M with on-chip DSP and a 15-band parametric EQ (25 Hz – 16 kHz)
+- Hardware volume control with a configurable maximum level
+- Automatic power state management driven by AirPlay session state
+- 8 MB flash
+- [Bluetooth A2DP](../features/bluetooth.md) on the ESP32 variants
+- [W5500 SPI Ethernet](../features/ethernet.md) with automatic WiFi failover
+- [SH1106 OLED](../features/oled-display.md) over SPI, sharing the Ethernet bus
+
+## Flashing
+
+=== "Browser"
+
+    Use the Louder installer for your board on the
+    [flashing page](../getting-started/flashing.md).
+
+=== "PlatformIO"
+
+    ```bash
+    # ESP32 + TAS5805M
+    pio run -e louder-esp32-bt -t upload
+    pio run -e louder-esp32-bt -t uploadfs
+
+    # ESP32 + TAS5825M
+    pio run -e louder-esp32-plus-bt -t upload
+    pio run -e louder-esp32-plus-bt -t uploadfs
+
+    # ESP32-S3 + TAS5805M
+    pio run -e louder-esp32-s3 -t upload
+    pio run -e louder-esp32-s3 -t uploadfs
+
+    # ESP32-S3 + TAS5825M
+    pio run -e louder-esp32-s3-plus -t upload
+    pio run -e louder-esp32-s3-plus -t uploadfs
+    ```
+
+=== "ESP-IDF"
+
+    ```bash
+    idf.py set-target esp32
+    idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults.louder-esp32-plus;config/sdkconfig.defaults.bt" build
+    idf.py -p /dev/ttyUSB0 flash
+    ```
+
+    Swap in `config/sdkconfig.defaults.louder-esp32-s3-plus` after
+    `idf.py set-target esp32s3` for the S3 revision.
+
+## Default GPIO assignments
+
+The ESP32 and S3 revisions share no pinout. The Plus boards differ from the plain ones
+only in the Ethernet chip select and the OLED chip select.
+
+| Function | Louder-ESP32 | Louder-ESP32-Plus | ESP32-S3 (both) |
+| --- | :-: | :-: | :-: |
+| I2S BCK | 26 | 26 | 14 |
+| I2S WS | 25 | 25 | 15 |
+| I2S DO | 22 | 22 | 16 |
+| I2C SDA | 21 | 21 | 8 |
+| I2C SCL | 27 | 27 | 9 |
+| Amplifier `PDN` | 33 | 33 | 17 |
+| SPI SCLK | 18 | 18 | 12 |
+| SPI MOSI | 23 | 23 | 11 |
+| SPI MISO | 19 | 19 | 13 |
+| Ethernet CS | 5 | 15 | 10 |
+| Ethernet INT | 35 | 35 | 6 |
+| Ethernet RST | 14 | 14 | 5 |
+| Display CS | 15 | 5 | 47 |
+| Display DC | 4 | 4 | 38 |
+| Display RST | 32 | 32 | 48 |
+
+`PDN` is driven high once at boot and then left alone — it is the amplifier's power-down
+pin, not the per-track mute the [Loud](loud-esp32.md) and [Amped](amped-esp32.md) boards
+toggle from playback events.
+
+## Related
+
+- [Esparagus Audio Brick](esparagus-audio-brick.md) — the same TAS58xx driver, EQ and PPC3 workflow
+- [HybridFlow DSP](../features/hybridflow.md)
+- [Bluetooth A2DP](../features/bluetooth.md)
+- [Ethernet (W5500)](../features/ethernet.md)
+- [Build environments](../reference/build-environments.md)

--- a/docs/boards/xiao-esp32c5.md
+++ b/docs/boards/xiao-esp32c5.md
@@ -26,9 +26,9 @@ There is no prebuilt binary for this board — build it yourself.
 === "PlatformIO"
 
     The official `platformio/espressif32` platform does **not** support the ESP32-C5, so
-    the `esp32c5-xiao` environment uses the community
+    every environment uses the community
     [pioarduino](https://github.com/pioarduino/platform-espressif32) platform, pinned in
-    `platformio.ini`. It bundles ESP-IDF 5.5.x and PlatformIO downloads it automatically
+    `platformio.ini`. It bundles ESP-IDF 5.5.5 and PlatformIO downloads it automatically
     on the first build — no extra setup needed.
 
     ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,11 @@
 
 ## Requirements
 
-ESP-IDF **v5.5 or newer**, tested against v5.5.2. Clone with submodules:
+ESP-IDF **v5.5.5 or newer**. Sendspin, which is built into almost every image by default,
+needs the WebSocket post-handshake callback that landed in v5.5.5; on an older 5.5.x
+release build with `CONFIG_SENDSPIN_ENABLE=n`. PlatformIO gets a matching toolchain from
+the pioarduino platform pinned in `platformio.ini`, so no manual ESP-IDF install is needed
+for that route. Clone with submodules:
 
 ```bash
 git clone --recursive https://github.com/rbouteiller/airplay-esp32
@@ -71,10 +75,22 @@ On every pull request to `main` or `staging`, and on every push to `main`:
 | `format-check` | `clang-format` dry run over all C/H files, excluding `components/u8g2` |
 | `lint-check` | `clang-tidy` against the build output |
 | `output-backends` | Builds the S/PDIF and USB output backends so every backend keeps linking |
-| `build` | Builds the full target matrix |
+| `build` | Builds the target matrix |
 
 A pull request that touches only Markdown skips the firmware jobs, so a docs typo does not
 cost an ESP-IDF toolchain build.
+
+The target list lives in `.github/workflows/targets.json`. A pull request builds only the
+entries flagged `"core": true` — enough to cover every chip and every board support
+directory — while a push to `main` and a push to `staging` build all of them. The matrix
+does not fail fast, and the beta job publishes whatever succeeded, so one board failing to
+compile does not withhold every other board's build.
+
+Adding a target means an entry in `targets.json` **and** a matching
+`docs/firmware/<name>.json` manifest whose `parts[0].path` is
+`airplay2-receiver-<name>.bin`. The docs workflow silently drops a manifest whose binary is
+missing from the release, so a target added here shows up in the browser installer only
+once a release actually carries it.
 
 Tagging `vMAJOR.MINOR.PATCH` triggers a release, which validates the tag against
 `version.txt` and publishes merged firmware binaries.

--- a/docs/features/buttons.md
+++ b/docs/features/buttons.md
@@ -39,6 +39,7 @@ device.
 | Volume down | Decrease volume, roughly 3 dB per step, auto-repeats |
 | Next track | Skip to the next track |
 | Previous | Go to the previous track |
+| Rotary encoder | Clockwise raises the volume, anti-clockwise lowers it |
 
 Volume buttons auto-repeat: hold for 500 ms and the action repeats every 200 ms.
 
@@ -66,6 +67,36 @@ Input is interrupt-driven with a 50 ms software debounce, so there is no polling
 Actions are dispatched to whichever source is active: DACP for AirPlay v1, AVRCP
 passthrough for Bluetooth.
 
+### Rotary encoder
+
+A quadrature rotary encoder — an EC11 or similar — can be used for volume instead of, or
+alongside, the volume buttons. Wire its two signal pins to the channel A and channel B
+GPIOs and its common pin to GND.
+
+```mermaid
+flowchart LR
+    A["GPIO — channel A"]
+    B["GPIO — channel B"]
+    ENC["Rotary encoder"]
+    GND["GND"]
+
+    A --- ENC
+    B --- ENC
+    ENC --- GND
+```
+
+The same pull-up rules apply as for buttons, so GPIOs 34–39 need external pull-ups on both
+channels. The encoder is decoded in the GPIO interrupt handler with a quadrature state
+machine, and one detent — four quadrature transitions on a typical encoder — produces one
+volume step.
+
+!!! tip "Turning the wrong way?"
+
+    If clockwise lowers the volume, swap the channel A and channel B GPIOs.
+
+Many encoder modules also have a push switch. It is a plain button, so wire it to any of
+the button GPIOs above — the play/pause pin is the usual choice.
+
 ## Configuration
 
 All button GPIOs default to `-1`, meaning disabled.
@@ -89,6 +120,13 @@ pio run -e <env> -t menuconfig
 | Volume down button GPIO | -1 | GPIO for volume down, auto-repeats |
 | Next track button GPIO | -1 | GPIO for next track |
 | Previous track button GPIO | -1 | GPIO for previous track |
+| Rotary encoder channel A GPIO | -1 | GPIO for encoder channel A |
+| Rotary encoder channel B GPIO | -1 | GPIO for encoder channel B |
+
+!!! note
+
+    Both rotary GPIOs must be set. If either is left at `-1` the encoder is compiled out
+    entirely.
 
 !!! note
 

--- a/docs/features/sendspin.md
+++ b/docs/features/sendspin.md
@@ -1,0 +1,358 @@
+# Sendspin (experimental)
+
+[Sendspin](https://github.com/Sendspin/sendspin-cpp) is an open multi-room audio protocol: a
+server pushes timestamped audio chunks to every player over a WebSocket, and each player
+schedules them against a shared clock. This firmware can act as a Sendspin **player**,
+sharing the same output path, DSP and volume control that AirPlay uses.
+
+!!! warning "Experimental"
+
+    PCM and FLAC are decoded everywhere, and Opus on the ESP32-S3 and P4.
+    Everything else about a session is in place: the transport is
+    encrypted, and the board can be paired so that it is authenticated too.
+
+## What works
+
+- Discovery: the board advertises `_sendspin._tcp`
+- The full `client/init` → `server/init` → Noise handshake → `server/hello` →
+  `client/hello` → `server/activate` sequence
+- An **encrypted** transport: Noise `KKpsk2` over Curve25519, ChaCha20-Poly1305 and
+  SHA-256, keyed with the Sentinel PSK
+- Continuous clock sync, so playback is aligned with the server rather than free-running
+- The `player@v1` role: 16- and 24-bit PCM, mono or stereo, 8–192 kHz in, played out as
+  44.1 or 48 kHz stereo
+- **FLAC**, which is what a lossless server will reach for first and what cuts the
+  bandwidth a 44.1 kHz stereo stream needs from about 1.4 Mbit/s to roughly half that
+- **Opus** at 48 kHz, on boards whose SoC can keep up — see
+  [Opus](#opus) below
+- Stream start, clear and end, including re-anchoring when the server jumps
+- The `metadata@v1` role: title, artist, album and progress reach the
+  [OLED](oled-display.md) and [TFT](tft-display.md) displays and the LEDs on the same
+  event bus AirPlay and Bluetooth use, so a board that powers its amplifier down between
+  tracks wakes for a Sendspin stream too
+- Volume and mute: the server can set either, and the board reports its own back — so a
+  change made with the [hardware buttons](buttons.md) or the
+  [web UI](../reference/spiffs.md) shows up in the server's UI
+- The `controller@v1` role: the board's play/pause, next and previous buttons drive the
+  server's queue, the way DACP does for AirPlay
+- **Two pairing methods**: a **static PIN**, an eight-digit code the board prints at boot,
+  and the **Pairing PSK** the specification requires of every client. Either way the two
+  ends agree a long-term key and the connection becomes authenticated rather than merely
+  encrypted. See [Pairing](#pairing)
+- **In-band re-handshaking**: a server promoting a live connection onto a new key — which is
+  what it does the moment pairing finishes — re-runs the Noise handshake inside the existing
+  session rather than reconnecting
+
+## What does not
+
+- **The dynamic pairing code.** It needs a display or a spoken prompt the board does not
+  have, so only the static code is offered
+- **Opus on the original ESP32.** It is offered only where the SoC can decode it in
+  realtime; see [Opus](#opus)
+- The artwork and visualizer roles
+
+## How it works
+
+The Sendspin endpoint lives on the existing web server, at `ws://<board>/sendspin`. No
+second HTTP server is started; the endpoint costs one URI handler and two sockets.
+
+```mermaid
+flowchart LR
+    S[Sendspin server] -- WebSocket --> W[/sendspin endpoint/]
+    W -- audio chunks --> D[FLAC / Opus decoder]
+    D -- PCM --> T[Playout timeline]
+    W -- client/time --> C[Clock estimator]
+    C -- offset --> R[Render hook]
+    T --> R
+    R --> O[I2S / DAC]
+```
+
+Audio chunks carry a server timestamp. The clock estimator turns the four-timestamp
+`client/time` exchange into a local-to-server offset, filtering out samples whose round
+trip was slow and fitting a straight line through the rest so it tracks the two crystals
+drifting apart. Chunks are decoded if the stream is compressed, then re-cut into fixed
+512-frame blocks and filed in a playout timeline by their position on the server's clock.
+On every I2S refill the render hook asks where the DAC will actually be when those samples
+emerge, converts that to server time, and pulls the matching block.
+
+That is the same machinery AirPlay uses — Sendspin simply supplies a different clock and a
+different transport.
+
+## Opus
+
+Opus is advertised at **48 kHz only**, which is the one rate the reference encoder
+accepts, and it sits behind PCM and FLAC in the priority the board advertises: it is
+lossy, so it is something you opt into rather than the first thing a server reaches for.
+
+It is enabled by default on the **ESP32-S3 and ESP32-P4**, and off on the original
+ESP32. That is not caution — it genuinely does not work there. The decoder keeps about
+26 KB of state, which on an ESP32 lands in PSRAM, and a 20 ms stereo packet then takes
+around 7.7 ms to decode with peaks past realtime. That starves the task decoding it, the
+task watchdog fires and the audio breaks up. FLAC already halves the bandwidth on those
+boards, so little is lost. Set `CONFIG_SENDSPIN_OPUS` if you want to try it anyway.
+
+Opus also makes the playout timeline much more expensive, because the server meters what
+it may queue **in bytes**. The same byte budget buys roughly ten times the duration once
+Opus is on the wire, so a server will happily run several seconds further ahead than it
+would with PCM. Anything arriving past the end of the timeline window is rejected and
+comes back later as a hole to conceal, which is why an Opus build gets 1024 blocks rather
+than 192.
+
+## Encryption
+
+Sendspin has no cleartext mode. Only three message types ever travel in the open —
+`client/init`, `server/init` and `noise/handshake` — and everything after them is a Noise
+transport message in a binary WebSocket frame, whose first decrypted byte says what kind of
+Sendspin message it holds.
+
+The handshake is `Noise_KKpsk2_25519_ChaChaPoly_SHA256`. Both static keys are known in
+advance: the server learns the board's from the `client_id` in `client/init`, and the board
+learns the server's from the `server_id` in `server/init`. The prologue is the raw bytes of
+those two messages, so anything that tampers with them fails the handshake. The server is
+the Noise initiator; the board is the responder.
+
+That leaves the pre-shared key, and the pre-shared key is what decides whether the session
+is *authenticated*. Before anyone pairs the board it has no shared secret with any server,
+so it uses the **Sentinel PSK** — a fixed value published in the protocol specification and
+known to everybody:
+
+```
+psk    = SHA-256("sendspin-sentinel-psk-v1")
+psk_id = base64url(SHA-256("sendspin-psk-id-v1" ‖ psk))
+```
+
+A Sentinel session is therefore **encrypted and tamper-evident, but not authenticated**:
+nothing about it proves the server is the one you meant. That is why the specification only
+lets a Sentinel-keyed session do pairing or, if the client asks for it, playback — and why
+the board sets `unpaired_access.enabled` to say that it does. Servers are expected to make
+a human approve the device before sending it anything.
+
+If the server names a PSK the board has never held — usually a stale pairing record on the
+server side — the board logs a warning and answers with the Sentinel anyway. That is the
+specification's Sentinel Fallback, and the handshake then either succeeds unpaired or fails
+silently, depending on which key the server actually used.
+
+## Pairing
+
+Pairing replaces the Sentinel with a secret both sides hold, so the handshake starts proving
+who is on the other end. The board offers two of the specification's three methods and lets
+the server pick: a **static PIN**, which is the one a user interface will normally reach
+for, and the **Pairing PSK** every client is required to support.
+
+### Static PIN
+
+On first boot the board draws an eight-digit PIN and keeps it in NVS. Read it from the boot
+log, or from `/api/system/info` as `sendspin_pairing_pin`:
+
+```bash
+curl -s http://<board>/api/system/info | grep pairing_pin
+```
+
+Type it into the server when it asks. The two then run a **CPace** PAKE — a balanced
+password-authenticated key exchange over Curve25519 — which turns those eight digits into a
+strong shared key without ever putting them on the wire. An eavesdropper learns nothing, and
+an impostor server gets exactly one guess per attempt. The board wraps its fresh long-term
+PSK under a key derived from the PAKE result before sending it, so the PIN, not the
+Sentinel-keyed channel, is what protects the handover.
+
+### Pairing PSK
+
+The board also generates a 32-byte **pairing PSK** from the hardware RNG on first boot and
+keeps it in NVS. That key plus the board's public key make up its **pairing token**:
+
+```
+payload = client_key (32 bytes) ‖ pairing_psk (32 bytes)
+token   = "SP:0" + base32(payload), padding stripped, every '2' rewritten as '9'
+```
+
+The result is 107 characters. Read it from the boot log, or from `/api/system/info` as
+`sendspin_pairing_token`:
+
+```bash
+curl -s http://<board>/api/system/info | grep pairing_token
+```
+
+Paste it into the server. In Music Assistant that is the Sendspin provider's pairing field.
+The server then opens a connection keyed with the pairing PSK and activates the `pairing`
+activity; the board checks that this connection really is keyed with the pairing PSK,
+generates a fresh 32-byte **long-term PSK**, sends it in `client/pair-finalize`, and stores
+the record once the server acknowledges. Every later session with that server uses the
+long-term key.
+
+!!! danger "The PIN and the pairing token are credentials"
+
+    Anyone who can read either one can adopt the board. Neither is rotated automatically —
+    erasing NVS is what changes them. The board keeps records for up to four servers; a
+    fifth pairing evicts the oldest.
+
+### Forgetting servers
+
+There are only four slots, so a board that has been paired with servers that no longer exist
+will start evicting the ones that do. Clear them all:
+
+```bash
+curl -X POST http://<board>/api/sendspin/unpair
+```
+
+The board keeps its identity, its token and its PIN, so any server can pair again.
+
+!!! warning "This only forgets the board's half"
+
+    A pairing record lives at both ends, and clearing one side strands the other: the
+    server keeps offering a PSK the board can no longer resolve, the handshake aborts, and
+    neither end reports why. Music Assistant logs that abort at debug level and then
+    retries forever, so it looks like a board that has stopped answering.
+
+    Unpairing from the **server's** UI is the route that prunes both records. Prefer it
+    whenever the server is reachable.
+
+Because of that, the endpoint refuses with **409 Conflict** while a server is connected —
+which is exactly when the server-side control is available to you. With nothing connected
+the request goes through, since that is the case the endpoint exists for. To clear the
+records anyway, when you know the server is gone for good:
+
+```bash
+curl -X POST 'http://<board>/api/sendspin/unpair?force=1'
+```
+
+### Getting out of a stale pairing
+
+If a server is already stuck in that loop, the board can escape without anyone editing the
+server's store: give it a new identity.
+
+```bash
+curl -X POST http://<board>/api/sendspin/reset-identity
+curl -X POST http://<board>/api/system/restart
+```
+
+The board's `client_id` is the public half of its Noise static key, and that is what a
+server looks its records up by. A fresh key means the server finds nothing, falls back to
+the Sentinel, and the handshake succeeds — the board looks like one it has never seen. The
+restart is what re-announces over mDNS; servers generally connect on discovery rather than
+retrying a dead address.
+
+The pairing token changes too, because it carries the public key. The PIN does not, and
+neither does the pairing PSK, so the second half of the token stays the same. Existing
+pairing records are dropped with the old identity, since nothing can reach them again.
+
+!!! note "The server is left holding an orphan"
+
+    A stale record and, usually, a dead player entry. Both are harmless and both can be
+    removed from the server's own UI once the board is back.
+
+!!! tip "Music Assistant"
+
+    Add the board with an explicit port, `<ip>:80` — a bare address is assumed to be on
+    Sendspin's default port and will not connect. Then **approve** the device when Music
+    Assistant asks: until you do, it activates the connection with an empty activity set and
+    no audio will flow. Choosing to pair prompts for the eight-digit PIN.
+
+!!! note "Sendspin gets its own timeline"
+
+    It does not share AirPlay's. The two are never active at the same time, but AirPlay's
+    timeline is deliberately never torn down once created, so sharing it would mean
+    reaching into a buffer the playback task is reading from.
+
+## Coexistence
+
+Sendspin, AirPlay and [Bluetooth](bluetooth.md) are **mutually exclusive at runtime** —
+one DMA ring, and the two protocols run off different clocks — but they are not equal.
+**AirPlay outranks Sendspin**, so a phone can always take the speaker back:
+
+- Starting an AirPlay session takes the output away from a Sendspin stream. The board tells
+  the server it is **unavailable** and pauses the server's queue, so it stops sending rather
+  than being left to work it out from a stalled player
+- When the AirPlay session ends, the board reports itself available again and resumes what
+  the server was playing. **Pausing** does not release it — the session is still yours until
+  you disconnect or the phone goes away
+- The AirPlay services stay running throughout. Only the playback task changes hands, so the
+  speaker keeps answering to AirPlay even while Sendspin is streaming
+- While Bluetooth or the USB host is streaming, the board reports itself **unavailable** to
+  the Sendspin server, so it is skipped rather than dropped mid-song
+
+!!! note "Why the queue is paused rather than just dropped"
+
+    A player that only reports `available: false` leaves the server's queue *stopped*, and a
+    stopped queue does not restart itself when the player comes back. Music Assistant will
+    sit idle indefinitely. Pausing it through the `controller@v1` role leaves something to
+    resume, which is what the board sends when it hands the output back.
+
+## Turning it on
+
+Sendspin is built into every firmware that has PSRAM, but it starts **switched off**. Use
+the **Native SendSpin Client Support** control under Device Settings in the web UI to turn
+it on. The section is hidden on a firmware built without it.
+
+Like the AirPlay mode setting, it **takes effect on the next restart** — the WebSocket
+endpoint, the mDNS record and the playout timeline are all built once at startup. While it
+is off none of that is allocated, which is what makes it safe to ship on by default.
+
+Over HTTP:
+
+```bash
+curl -s http://<device>/api/sendspin/mode
+# {"enabled": false, "restart_required": false, "success": true}
+
+curl -s -X POST http://<device>/api/sendspin/mode \
+  -H 'Content-Type: application/json' -d '{"enabled": true}'
+# {"success": true, "restart_required": true}
+
+curl -s -X POST http://<device>/api/system/restart
+```
+
+`/api/system/info` reports `sendspin_supported` (compiled in), `sendspin_enabled` (the
+saved setting) and `sendspin_active` (whether it is actually running this boot). The
+pairing PIN and token are only meaningful once it is active.
+
+## Building
+
+Nothing has to be built to try Sendspin — every shipping image carries it except
+`smartamp` and `esp32wrover-dev`, which are excluded on flash grounds: both pair Bluetooth
+with a 1.92 MB app slot and have only 4–5 % of it free before Sendspin is added, which is
+too little to absorb any later growth. It also needs **PSRAM**, so it is absent from a
+board configured without any.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `CONFIG_SENDSPIN_ENABLE` | `y` where there is PSRAM | Build the player role, ~73 KB of flash |
+| `CONFIG_SENDSPIN_OPUS` | `y` on S3/P4 | Offer Opus as well as FLAC and PCM |
+| `CONFIG_SENDSPIN_TIMELINE_BLOCKS` | `1024` with Opus, else `192` | Playout depth, in 512-frame blocks |
+| `CONFIG_SENDSPIN_RX_BUFFER_SIZE` | `32768` | Largest message accepted from the server |
+| `CONFIG_SENDSPIN_TIME_SYNC_INTERVAL_MS` | `2000` | Steady-state clock sync interval |
+
+Once enabled at runtime, the defaults cost roughly **448 KB of PSRAM**: 384 KB for about
+2.2 seconds of playout timeline, and 64 KB for the receive and reassembly buffers. A
+compressed stream takes a further 64 KB of decoder scratch, allocated when the stream
+starts and released when it ends.
+
+An Opus build is much hungrier, because the timeline has to cover how far ahead the
+server will run: 1024 blocks is **2 MB** of playout timeline. Enabling Opus also adds
+8 KB to the web server task's stack, since libopus keeps its CELT scratch on the stack
+and the decode runs on the task serving the WebSocket.
+
+## Identity
+
+On first boot the board generates a Curve25519 key pair and stores the secret in NVS. The
+public key, Base64url encoded, is the `client_id` the server sees, and it is stable across
+reboots and firmware updates. The same key pair is the board's Noise static key, so
+erasing the `sendspin` NVS namespace gives the board a new identity and invalidates any
+pairing a server has recorded for it. The pairing PSK, the static PIN and the pairing
+records live in the same namespace, so erasing it also changes the pairing token and the
+PIN.
+
+## Caveats
+
+- Until the board is paired the session is encrypted but **not authenticated** — see
+  [Pairing](#pairing). Treat an unpaired board the way you
+  would treat any other device on a network you control
+- The service is advertised on **port 80**, the web server's port, with the endpoint path in
+  the TXT record. A server that ignores the SRV port and assumes Sendspin's default will not
+  find it
+- `send_ahead` on each chunk is ignored; the timestamp alone decides when audio plays
+- If a chunk arrives after its slot has already been rendered it is dropped, which is
+  audible as a gap rather than as drift
+- A FLAC chunk's timestamp is not sample-exact. The reference server bills a chunk for one
+  encoder block but sends whatever the encoder handed back, so once per stream — when the
+  encoder's pipeline fills — a chunk carries two blocks. The board tolerates 200 ms of
+  drift on a compressed stream for that reason, and only re-anchors beyond it; on PCM,
+  where the byte count does match the timestamp, the tolerance stays at 1 ms

--- a/docs/firmware/amped-esp32-bt.json
+++ b/docs/firmware/amped-esp32-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Amped-ESP32)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-amped-esp32-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/amped-esp32-s3.json
+++ b/docs/firmware/amped-esp32-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Amped-ESP32-S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-amped-esp32-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/amped-esparagus-bt.json
+++ b/docs/firmware/amped-esparagus-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Amped-Esparagus)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-amped-esparagus-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/esparagus-echo.json
+++ b/docs/firmware/esparagus-echo.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Esparagus Echo)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-esparagus-echo.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/hifi-esp32-bt.json
+++ b/docs/firmware/hifi-esp32-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (HiFi-ESP32)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-hifi-esp32-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/hifi-esp32-s3.json
+++ b/docs/firmware/hifi-esp32-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (HiFi-ESP32-S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-hifi-esp32-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/hifi-esparagus-bt.json
+++ b/docs/firmware/hifi-esparagus-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (HiFi-Esparagus)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-hifi-esparagus-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/hifi-esparagus-s3.json
+++ b/docs/firmware/hifi-esparagus-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (HiFi-Esparagus-S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-hifi-esparagus-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/loud-esp32-bt.json
+++ b/docs/firmware/loud-esp32-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Loud-ESP32)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-loud-esp32-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/loud-esp32-s3.json
+++ b/docs/firmware/loud-esp32-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Loud-ESP32-S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-loud-esp32-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/loud-esparagus-bt.json
+++ b/docs/firmware/loud-esparagus-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Loud-Esparagus)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-loud-esparagus-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/louder-esp32-bt.json
+++ b/docs/firmware/louder-esp32-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Louder-ESP32)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-louder-esp32-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/louder-esp32-plus-bt.json
+++ b/docs/firmware/louder-esp32-plus-bt.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Louder-ESP32-Plus)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        {
+          "path": "airplay2-receiver-louder-esp32-plus-bt.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/louder-esp32-s3-plus.json
+++ b/docs/firmware/louder-esp32-s3-plus.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Louder-ESP32-S3-Plus)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-louder-esp32-s3-plus.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/firmware/louder-esp32-s3.json
+++ b/docs/firmware/louder-esp32-s3.json
@@ -1,0 +1,16 @@
+{
+  "name": "ESP32 AirPlay 2 Receiver (Louder-ESP32-S3)",
+  "version": "latest",
+  "new_install_prompt_erase": true,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "parts": [
+        {
+          "path": "airplay2-receiver-louder-esp32-s3.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}

--- a/docs/getting-started/flashing.md
+++ b/docs/getting-started/flashing.md
@@ -7,7 +7,7 @@ another, use the browser installer.
 | --- | --- | --- |
 | **[A — Browser](#option-a-install-from-your-browser)** | You just want a working speaker | Chrome, Edge or Opera |
 | **[B — PlatformIO](#option-b-platformio)** | You want to change build settings, or your board has no prebuilt binary | Python, a clone of the repo |
-| **[C — ESP-IDF](#option-c-esp-idf)** | You already work with ESP-IDF | ESP-IDF v5.5+ |
+| **[C — ESP-IDF](#option-c-esp-idf)** | You already work with ESP-IDF | ESP-IDF v5.5.5+ |
 
 ## Option A — Install from your browser
 
@@ -213,6 +213,254 @@ Ethernet. Bluetooth A2DP only exists on the original ESP32.
 
 </div>
 
+### HiFi boards
+
+[HiFi-ESP32 and HiFi-Esparagus](../boards/hifi-esp32.md) carry a **PCM5100** line-level
+DAC and no amplifier — they feed an amp or active speakers. The `-ESP32` boards have
+W5500 Ethernet and an OLED; the Esparagus ones do not.
+
+<div class="grid cards" markdown>
+
+-   __HiFi-ESP32__
+
+    ESP32 + PCM5100, Ethernet and OLED. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/hifi-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/hifi-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __HiFi-Esparagus__
+
+    ESP32 + PCM5100, WiFi only. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/hifi-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/hifi-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __HiFi-ESP32-S3__
+
+    ESP32-S3 + PCM5100, Ethernet and OLED.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/hifi-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/hifi-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __HiFi-Esparagus-S3__
+
+    ESP32-S3 + PCM5100, WiFi only.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/hifi-esparagus-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/hifi-esparagus-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+</div>
+
+### Loud and Echo boards
+
+[Loud-ESP32, Loud-Esparagus and Esparagus Echo](../boards/loud-esp32.md) drive
+**MAX98357A** amplifiers directly — connect speakers to the board.
+
+<div class="grid cards" markdown>
+
+-   __Loud-ESP32__
+
+    ESP32 + MAX98357A, Ethernet and OLED. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/loud-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/loud-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Loud-Esparagus__
+
+    ESP32 + dual MAX98357A, WiFi only. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/loud-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/loud-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Loud-ESP32-S3__
+
+    ESP32-S3 + dual MAX98357A, Ethernet and OLED.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/loud-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/loud-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Esparagus Echo__
+
+    ESP32-S3 + dual MAX98357A, Ethernet, no display.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/esparagus-echo.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/esparagus-echo.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+</div>
+
+### Amped boards
+
+[Amped-ESP32 and Amped-Esparagus](../boards/amped-esp32.md) put a **PCM5100** DAC in front
+of a **TPA3110/TPA3128** amplifier. Connect speakers to the board.
+
+<div class="grid cards" markdown>
+
+-   __Amped-ESP32__
+
+    ESP32 + PCM5100 + TPA31xx, Ethernet and OLED. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/amped-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/amped-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Amped-Esparagus__
+
+    ESP32 rev M, Ethernet and a rotary encoder. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/amped-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/amped-esparagus-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Amped-ESP32-S3__
+
+    ESP32-S3 + PCM5100 + TPA31xx, Ethernet and OLED.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/amped-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/amped-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+</div>
+
+### Louder boards
+
+[Louder-ESP32](../boards/louder-esp32.md) carries a **TAS58xx** DAC and amplifier. The
+**Plus** boards have a TAS5825M, the plain ones a TAS5805M — pick the card that matches
+the board, the pinouts differ.
+
+<div class="grid cards" markdown>
+
+-   __Louder-ESP32__
+
+    ESP32 + TAS5805M, Ethernet and OLED. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/louder-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/louder-esp32-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Louder-ESP32-Plus__
+
+    ESP32 + TAS5825M, Ethernet and OLED. Includes Bluetooth A2DP.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/louder-esp32-plus-bt.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/louder-esp32-plus-bt.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Louder-ESP32-S3__
+
+    ESP32-S3 + TAS5805M, Ethernet and OLED.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/louder-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/louder-esp32-s3.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+-   __Louder-ESP32-S3-Plus__
+
+    ESP32-S3 + TAS5825M, Ethernet and OLED.
+
+    <esp-web-install-button manifest="/airplay-esp32/firmware/louder-esp32-s3-plus.json">
+      <button slot="activate" class="md-button md-button--primary">Install</button>
+      <span slot="unsupported">Your browser cannot flash over USB. Use Chrome, Edge or Opera on desktop.</span>
+      <span slot="not-allowed">Flashing needs a secure (HTTPS) connection.</span>
+    </esp-web-install-button><esp-web-install-button class="install-beta" manifest="/airplay-esp32/firmware/beta/louder-esp32-s3-plus.json">
+      <button slot="activate" class="md-button md-button--beta">Install beta</button>
+      <span slot="unsupported"></span>
+      <span slot="not-allowed"></span>
+    </esp-web-install-button>
+
+</div>
+
 Once the install finishes, unplug and re-plug the board. It boots into setup mode — carry
 on to [First boot](first-boot.md).
 
@@ -277,7 +525,7 @@ Replace `esp32s3` with whichever environment matches your hardware — see
 ## Option C — ESP-IDF
 
 ```bash
-# 1. Install ESP-IDF v5.5 or newer:
+# 1. Install ESP-IDF v5.5.5 or newer:
 #    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/
 
 # 2. Clone the project, including submodules

--- a/docs/reference/build-environments.md
+++ b/docs/reference/build-environments.md
@@ -38,6 +38,40 @@ with two amplifiers: stereo at I2C address 0x4C and a second at 0x4D, wired eith
 bridged (PBTL) mono output or as a second stereo pair. `-dual-uac` adds USB audio to the
 same board.
 
+## Sonocotta audio dock boards
+
+The [HiFi](../boards/hifi-esp32.md), [Loud](../boards/loud-esp32.md),
+[Amped](../boards/amped-esp32.md) and [Louder](../boards/louder-esp32.md) families all
+come in an `-esp32` form with an Ethernet jack and an OLED header, and an `-esparagus`
+form without either. Bluetooth Classic exists only on the original ESP32, so no S3
+environment has a `-bt` variant.
+
+| Environment | Chip | DAC / amp | Flash | Bluetooth |
+| --- | --- | --- | --- | :-: |
+| `hifi-esp32` | ESP32 | PCM5100 | 8 MB | — |
+| `hifi-esp32-bt` | ESP32 | PCM5100 | 8 MB | yes |
+| `hifi-esparagus` | ESP32 | PCM5100 | 8 MB | — |
+| `hifi-esparagus-bt` | ESP32 | PCM5100 | 8 MB | yes |
+| `hifi-esp32-s3` | ESP32-S3 | PCM5100 | 8 MB | — |
+| `hifi-esparagus-s3` | ESP32-S3 | PCM5100 | 8 MB | — |
+| `loud-esp32` | ESP32 | MAX98357A | 8 MB | — |
+| `loud-esp32-bt` | ESP32 | MAX98357A | 8 MB | yes |
+| `loud-esparagus` | ESP32 | 2× MAX98357A | 8 MB | — |
+| `loud-esparagus-bt` | ESP32 | 2× MAX98357A | 8 MB | yes |
+| `loud-esp32-s3` | ESP32-S3 | 2× MAX98357A | 8 MB | — |
+| `esparagus-echo` | ESP32-S3 | 2× MAX98357A | 8 MB | — |
+| `amped-esp32` | ESP32 | PCM5100 + TPA31xx | 8 MB | — |
+| `amped-esp32-bt` | ESP32 | PCM5100 + TPA31xx | 8 MB | yes |
+| `amped-esparagus` | ESP32 | PCM5100 + TPA31xx | 8 MB | — |
+| `amped-esparagus-bt` | ESP32 | PCM5100 + TPA31xx | 8 MB | yes |
+| `amped-esp32-s3` | ESP32-S3 | PCM5100 + TPA31xx | 8 MB | — |
+| `louder-esp32` | ESP32 | TAS5805M | 8 MB | — |
+| `louder-esp32-bt` | ESP32 | TAS5805M | 8 MB | yes |
+| `louder-esp32-plus` | ESP32 | TAS5825M | 8 MB | — |
+| `louder-esp32-plus-bt` | ESP32 | TAS5825M | 8 MB | yes |
+| `louder-esp32-s3` | ESP32-S3 | TAS5805M | 8 MB | — |
+| `louder-esp32-s3-plus` | ESP32-S3 | TAS5825M | 8 MB | — |
+
 ## Targets without a PlatformIO environment
 
 These have sdkconfig defaults and are built through ESP-IDF directly.
@@ -54,20 +88,31 @@ idf.py -DSDKCONFIG_DEFAULTS="config/sdkconfig.defaults;config/sdkconfig.defaults
 
 ## Which builds get a prebuilt binary
 
-CI builds a subset of environments on every push and attaches them to each release. These
-are the ones available in the [browser installer](../getting-started/flashing.md):
+CI builds a subset of environments and attaches them to each release. These are the ones
+available in the [browser installer](../getting-started/flashing.md):
 
 `esp32s3`, `waveshare-esp32s3`, `esp32s2`, `squeezeamp-bt`, `squeezeamp-4m`, `smartamp`,
 `esparagus-audio-brick-bt`, `esparagus-audio-brick-s3`, `esparagus-audio-brick-dual-dac`,
-`esparagus-audio-brick-dual-uac`, `esparagus-louder-bt`, `esparagus-louder-s3`.
+`esparagus-audio-brick-dual-uac`, `esparagus-louder-bt`, `esparagus-louder-s3`,
+`esparagus-echo`, `hifi-esp32-bt`, `hifi-esparagus-bt`, `hifi-esp32-s3`,
+`hifi-esparagus-s3`, `loud-esp32-bt`, `loud-esparagus-bt`, `loud-esp32-s3`,
+`amped-esp32-bt`, `amped-esparagus-bt`, `amped-esp32-s3`, `louder-esp32-bt`,
+`louder-esp32-plus-bt`, `louder-esp32-s3`, `louder-esp32-s3-plus`.
+
+The list lives in `.github/workflows/targets.json`, and each entry needs a matching
+`docs/firmware/<name>.json` manifest for the installer to offer it.
 
 Everything else you build yourself. On an ESP32 board that can do Bluetooth the published
-binary always includes it, so there is no prebuilt `squeezeamp`, `esparagus-audio-brick` or
-`esparagus-louder` — build one of those yourself if you want the RAM and flash back.
+binary always includes it, so there is no prebuilt `squeezeamp`, `esparagus-audio-brick`,
+`esparagus-louder`, `hifi-esp32`, `loud-esp32`, `amped-esp32` or `louder-esp32` — build
+one of those yourself if you want the RAM and flash back.
 
-The same matrix also runs on every push to `staging` and publishes a rolling
+The same list runs on every push to `staging` and publishes a rolling
 [beta](../getting-started/flashing.md#beta-builds) pre-release, so each of these boards
-has an untested build of the current development tip available too.
+has an untested build of the current development tip available too. A pull request builds
+only the entries flagged `"core": true`, which cover every chip and every board support
+directory without a job per variant, and the matrix does not fail fast, so one board
+failing to compile no longer stops the others being published.
 
 ## How sdkconfig layering works
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -174,8 +174,10 @@ git submodule update --init --recursive
 
 Clone with `--recursive` to avoid this in the first place.
 
-**Wrong ESP-IDF version.** The project requires **v5.5 or newer** and is tested against
-v5.5.2. Older versions need workarounds.
+**Wrong ESP-IDF version.** The project requires **v5.5.5 or newer**. Sendspin needs the
+WebSocket post-handshake callback added in that release; an older 5.5.x builds only with
+`CONFIG_SENDSPIN_ENABLE=n`. PlatformIO gets 5.5.5 from the pioarduino platform pinned in
+`platformio.ini`; the official `platformio/espressif32` platform is still on 5.5.3.
 
 ### Changes to sdkconfig defaults have no effect
 
@@ -189,9 +191,9 @@ pio run -e <env> -t build
 
 ### PlatformIO cannot find a platform for my chip
 
-The official `platformio/espressif32` platform does not support the ESP32-C5. The
-`esp32c5-xiao` environment pins the community pioarduino platform instead — see
-[Seeed XIAO ESP32-C5](boards/xiao-esp32c5.md).
+The official `platformio/espressif32` platform does not support the ESP32-C5, and is stuck
+on ESP-IDF 5.5.3. `platformio.ini` pins the community pioarduino platform for every
+environment instead — see [Seeed XIAO ESP32-C5](boards/xiao-esp32c5.md).
 
 ## Still stuck?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,11 +111,16 @@ nav:
       - SqueezeAMP: boards/squeezeamp.md
       - Esparagus Audio Brick: boards/esparagus-audio-brick.md
       - Esparagus Audio Brick Dual: boards/esparagus-audio-brick-dual-dac.md
+      - HiFi-ESP32: boards/hifi-esp32.md
+      - Loud-ESP32 and Esparagus Echo: boards/loud-esp32.md
+      - Amped-ESP32: boards/amped-esp32.md
+      - Louder-ESP32: boards/louder-esp32.md
       - Seeed XIAO ESP32-C5: boards/xiao-esp32c5.md
       - Custom board: boards/custom.md
   - Features:
       - Bluetooth A2DP: features/bluetooth.md
       - USB audio (UAC): features/usb-audio.md
+      - Sendspin (experimental): features/sendspin.md
       - Ethernet (W5500): features/ethernet.md
       - OLED display: features/oled-display.md
       - ST7789 TFT display: features/tft-display.md


### PR DESCRIPTION
Brings `main`'s docs up to date with `staging` so the site republishes, the same way #143 did. **Docs only** — no firmware, workflow or config changes. `docs/` and `mkdocs.yml` here are byte-identical to `staging`.

Most of this is the docs half of #148, which has just landed on `staging`.

## What lands

**Four new board pages**, one per Sonocotta family, each covering its Esparagus and ESP32-S3 variants:

- `boards/hifi-esp32.md` — HiFi-ESP32 / HiFi-Esparagus / -S3 (PCM5100)
- `boards/loud-esp32.md` — Loud-ESP32 / Loud-Esparagus / -S3 and Esparagus Echo (MAX98357A)
- `boards/amped-esp32.md` — Amped-ESP32 / Amped-Esparagus / -S3 (PCM5100 + TPA3110/TPA3128)
- `boards/louder-esp32.md` — Louder-ESP32 / -Plus / -S3 and Esparagus Louder (TAS5805M/TAS5825M)

**15 new ESP Web Tools manifests**, so every board in the release matrix now has one. Each `parts[0].path` matches its published binary name.

**27 install cards** on the flashing page, stable + beta, covering the whole matrix.

**Also swept up from staging:** the Sendspin feature page (already labelled experimental), the rotary encoder section on the buttons page, the expanded build-environments reference, and the boards index grown from 8 rows to 17.

## The install buttons during the gap

`main` is still at v0.2.0 and these boards' binaries first appear in a release at 0.3.0. That is handled, not broken:

- **Stable** — `docs.yml` bundles from the latest release, drops any manifest whose binary is missing, and emits a `::warning::` for each. `install-buttons.js` then hides the card. Expect a run of those warnings; the cards light up on the next release.
- **Beta** — the rolling pre-release tag is already at the `staging` tip (`aa9a0e9`), so `beta.yml` has rebuilt it since #148 merged and the beta buttons work immediately.

So the pages are live and useful now, with only the stable half of each new card hidden until 0.3.0 ships.

## Checks

- `zensical build --strict --clean` on top of `main` → **No issues found**. Every internal link and every `nav:` entry resolves without the firmware changes present.
- `docs.yml` is identical on `main` and `staging`, and reads `docs/firmware/*.json` directly rather than `targets.json`, so nothing here depends on the new build matrix having reached `main`.
- Excludes `README.md` and `CONTRIBUTING.md`, which also differ between the branches but are not part of the published site — same scope as #143.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and installer manifest changes only; no firmware or runtime behavior is modified in this PR.
> 
> **Overview**
> Publishes the documentation site updates that were already on `staging`: **four Sonocotta audio-dock board guides** (HiFi, Loud, Amped, Louder), an expanded **boards index** and **build-environments** table, plus a new **Sendspin (experimental)** feature page and **rotary encoder** wiring on the buttons page.
> 
> The **browser flashing page** gains grouped install cards for HiFi, Loud/Echo, Amped, and Louder variants (stable and beta), backed by **15 new** `docs/firmware/*.json` manifests aligned with published binary names. **Contributing**, **troubleshooting**, and **XIAO C5** pages now document ESP-IDF **v5.5.5+** (Sendspin WebSocket requirement) and the **`targets.json` / core-only PR build** CI model.
> 
> **`mkdocs.yml`** adds the new board and Sendspin nav entries. Until the next release ships those binaries on `main`, stable install buttons for the new boards are expected to be hidden when manifests are dropped; beta buttons can work from the rolling pre-release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a5ee2443f7815726f35512568db3392f61a68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->