### PR TITLE
fix(plist): emit non-ASCII device name as UTF-16 unicode string in binary /info

### DIFF
--- a/main/plist/bplist_builder.c
+++ b/main/plist/bplist_builder.c
@@ -48,6 +48,86 @@ static bool bplist_write_ascii_string(uint8_t *out, size_t capacity,
   return true;
 }
 
+// Decode one UTF-8 sequence. Invalid bytes decode to U+FFFD and advance by 1.
+static uint32_t bplist_utf8_decode(const uint8_t **cursor) {
+  const uint8_t *p = *cursor;
+  uint32_t cp;
+  size_t extra;
+  if (p[0] < 0x80) {
+    cp = p[0];
+    extra = 0;
+  } else if ((p[0] & 0xE0) == 0xC0) {
+    cp = p[0] & 0x1F;
+    extra = 1;
+  } else if ((p[0] & 0xF0) == 0xE0) {
+    cp = p[0] & 0x0F;
+    extra = 2;
+  } else if ((p[0] & 0xF8) == 0xF0) {
+    cp = p[0] & 0x07;
+    extra = 3;
+  } else {
+    *cursor = p + 1;
+    return 0xFFFD;
+  }
+  for (size_t i = 1; i <= extra; i++) {
+    if ((p[i] & 0xC0) != 0x80) {
+      *cursor = p + 1;
+      return 0xFFFD;
+    }
+    cp = (cp << 6) | (p[i] & 0x3F);
+  }
+  *cursor = p + extra + 1;
+  if (cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)) {
+    return 0xFFFD;
+  }
+  return cp;
+}
+
+// Unicode string object (marker 0x6X): UTF-16BE, length in code units.
+static bool bplist_write_unicode_string(uint8_t *out, size_t capacity,
+                                        size_t *pos, const char *value) {
+  const uint8_t *p = (const uint8_t *)value;
+  size_t units = 0;
+  while (*p) {
+    units += (bplist_utf8_decode(&p) >= 0x10000) ? 2 : 1;
+  }
+  if (!bplist_write_length(out, capacity, pos, 0x60, units) ||
+      !bplist_has_room(*pos, units * 2, capacity)) {
+    return false;
+  }
+  p = (const uint8_t *)value;
+  while (*p) {
+    uint32_t cp = bplist_utf8_decode(&p);
+    uint16_t u[2];
+    size_t n = 1;
+    if (cp >= 0x10000) {
+      cp -= 0x10000;
+      u[0] = (uint16_t)(0xD800 | (cp >> 10));
+      u[1] = (uint16_t)(0xDC00 | (cp & 0x3FF));
+      n = 2;
+    } else {
+      u[0] = (uint16_t)cp;
+    }
+    for (size_t i = 0; i < n; i++) {
+      out[(*pos)++] = (uint8_t)(u[i] >> 8);
+      out[(*pos)++] = (uint8_t)u[i];
+    }
+  }
+  return true;
+}
+
+// User-supplied UTF-8 string: ASCII object when possible, else UTF-16BE.
+// Writing non-ASCII bytes as an ASCII object makes iOS show mojibake.
+static bool bplist_write_string(uint8_t *out, size_t capacity, size_t *pos,
+                                const char *value) {
+  for (const uint8_t *p = (const uint8_t *)value; *p; p++) {
+    if (*p >= 0x80) {
+      return bplist_write_unicode_string(out, capacity, pos, value);
+    }
+  }
+  return bplist_write_ascii_string(out, capacity, pos, value);
+}
+
 static bool bplist_write_data(uint8_t *out, size_t capacity, size_t *pos,
                               const uint8_t *data, size_t len) {
   if (!bplist_write_length(out, capacity, pos, 0x40, len) ||
@@ -549,7 +629,7 @@ size_t bplist_build_info_response(uint8_t *out, size_t capacity,
     return 0;
   }
   ADD_OFFSET(); // 19: device name
-  if (!bplist_write_ascii_string(out, capacity, &pos, device_name)) {
+  if (!bplist_write_string(out, capacity, &pos, device_name)) {
     return 0;
   }
   ADD_OFFSET(); // 20: "audioFormats"

--- a/main/plist/plist.h
+++ b/main/plist/plist.h
@@ -289,7 +289,8 @@ size_t bplist_build_feedback_response(uint8_t *out, size_t capacity,
  * @param out Output buffer
  * @param capacity Buffer capacity
  * @param device_id Device MAC string
- * @param device_name User-visible AirPlay device name
+ * @param device_name User-visible AirPlay device name (UTF-8; non-ASCII
+ *                    is emitted as a UTF-16BE unicode string object)
  * @param public_key HAP Ed25519 public key
  * @param public_key_len Public key length
  * @param features AirPlay feature bitmask


### PR DESCRIPTION
## Summary

Fixes #151.

Non-ASCII device names (e.g. Chinese) were written into the binary `/info` plist as an ASCII string object (`0x5X`) containing raw UTF-8 bytes, so iOS showed mojibake in Control Center once connected, even though the mDNS name in the AirPlay picker looked fine.

## Change

- `main/plist/bplist_builder.c`: add `bplist_write_string()`, which scans the value and emits a Unicode string object (`0x6X`, UTF-16BE, length in UTF-16 code units, surrogate pairs for code points above U+FFFF) when any byte is `>= 0x80`, otherwise falls through to the existing ASCII writer. Only the user-controlled `device_name` call site switches to it; every other string in the builders is a literal key or an ASCII-by-construction value (`device_id`), so the wire format for those is unchanged. Object count and offset table are unaffected.
- `main/plist/plist.h`: document the encoding contract for `device_name`.

Invalid UTF-8 bytes decode to U+FFFD rather than failing the whole response.

## Testing

- Built with the `esp32s3` PlatformIO environment and flashed via OTA to an ESP32-S3.
- Issued `GET /info RTSP/1.0` to port 7000 and parsed the body with Python `plistlib`:
  - `廚房` → `廚房` (marker byte `0x62`)
  - `客廳 🎵 Speaker` → identical (emoji surrogate pair)
  - `Kitchen` → identical (ASCII path, unchanged)
- Confirmed on an iPhone that the connected-device name is now rendered correctly.
- `clang-format --dry-run --Werror` (22.1.4) passes on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized encoding change for one string field in the /info bplist builder; ASCII names behave as before and invalid UTF-8 degrades to replacement characters instead of failing the response.
> 
> **Overview**
> Fixes incorrect display of non-ASCII AirPlay device names on iOS after connect by changing how the binary `/info` plist encodes the **`name`** value.
> 
> **`bplist_builder.c`** adds UTF-8 decoding (invalid sequences become U+FFFD), a **`0x6X`** Unicode string writer (UTF-16BE, surrogate pairs for supplementary characters), and **`bplist_write_string`**, which keeps the existing ASCII **`0x5X`** path for all-ASCII input and switches to Unicode when any byte is `>= 0x80`. Only the user-supplied **`device_name`** in **`bplist_build_info_response`** uses this helper; literal keys and other fixed strings still use **`bplist_write_ascii_string`**.
> 
> **`plist.h`** documents that **`device_name`** is UTF-8 and may be emitted as a Unicode plist object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ee43c5ababee5e50bdf70b18e04ac065bb8134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->